### PR TITLE
Rename Page hooks: _build_ui and is_active

### DIFF
--- a/src/ui/node_editor_page.py
+++ b/src/ui/node_editor_page.py
@@ -10,7 +10,7 @@ class NodeEditorPage(Page):
         self._node_count: int = 0
         super().__init__(parent=parent, menu_bar=menu_bar)
 
-    def _build(self) -> None:
+    def _build_ui(self) -> None:
         with dpg.child_window(tag=self._content_tag, parent=self._parent, border=False, show=False):
             dpg.add_node_editor(
                 tag=self._node_editor_tag,

--- a/src/ui/page.py
+++ b/src/ui/page.py
@@ -12,7 +12,7 @@ class Page(ABC):
     given time; the PageManager enforces this.
 
     Subclasses implement:
-        _build()         - create the page content (use self._content_tag
+        _build_ui()      - create the page content (use self._content_tag
                            as the root container tag, self._parent as the
                            parent, and pass show=False so the page starts
                            hidden).
@@ -28,10 +28,10 @@ class Page(ABC):
         self._content_tag: int = dpg.generate_uuid()
         self._menu_tags: list[int | str] = []
         self._active: bool = False
-        self._build()
+        self._build_ui()
 
     @abstractmethod
-    def _build(self) -> None:
+    def _build_ui(self) -> None:
         ...
 
     @abstractmethod

--- a/src/ui/page.py
+++ b/src/ui/page.py
@@ -39,7 +39,7 @@ class Page(ABC):
         ...
 
     @property
-    def active(self) -> bool:
+    def is_active(self) -> bool:
         return self._active
 
     def activate(self) -> None:

--- a/src/ui/start_page.py
+++ b/src/ui/start_page.py
@@ -8,7 +8,7 @@ class StartPage(Page):
         self._on_create_flow = on_create_flow
         super().__init__(parent=parent, menu_bar=menu_bar)
 
-    def _build(self) -> None:
+    def _build_ui(self) -> None:
         with dpg.child_window(tag=self._content_tag, parent=self._parent, border=False, show=False):
             dpg.add_spacer(height=60)
             dpg.add_text("Image Inquest", indent=20)


### PR DESCRIPTION
## Summary
Two small naming improvements on the `Page` base class:

- `Page._build()` → `Page._build_ui()` — pairs naturally with `_install_menus()` and makes the intent obvious (this hook builds the page's UI widgets)
- `Page.active` → `Page.is_active` — conventional boolean property naming

Subclass implementations in `StartPage` and `NodeEditorPage` updated to match. No call sites of `active` existed outside the definition, so nothing else needed changing.

## Test plan
- [ ] App still launches on the start page
- [ ] New Flow → node editor transition works
- [ ] Exit → start page transition works

https://claude.ai/code/session_01DBhntZKSRtjkUAQ8DmY5MM