### PR TITLE
Wire Flow to editor, add Load Flow button, write README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,76 @@
-# image-inquest
- 
+# Image Inquest
+
+A Python desktop application for building image processing workflows using a node-based visual editor.
+
+## Status
+
+Early-stage development. The application provides a two-page UI — a start page and a node editor — with dynamic node creation and linking. Actual image processing, flow persistence, and flow loading are not yet implemented.
+
+## Requirements
+
+- Python 3.10+
+- [DearPyGUI](https://github.com/hoffstadt/DearPyGui)
+
+```bash
+pip install dearpygui
+```
+
+## Running
+
+```bash
+python src/main.py
+```
+
+Optional arguments:
+
+| Argument | Default | Description |
+|---|---|---|
+| `--width N` | 1024 | Viewport width in pixels |
+| `--height N` | 768 | Viewport height in pixels |
+
+## Usage
+
+1. The app opens on the **start page**.
+2. Click **New Flow** to create a new empty flow and open the node editor.
+3. In the node editor use **Node Editor → Add Node** to add nodes to the canvas.
+4. Drag between node attributes to create links; drag an existing link to remove it.
+5. Use **Node Editor → Clear All** to remove all nodes, or **Node Editor → Exit** to return to the start page.
+
+## Project Structure
+
+```
+src/
+├── main.py                 # Entry point and viewport setup
+├── constants.py            # Global constants (app name, default size)
+├── core/
+│   └── flow.py             # Flow domain model (framework-agnostic)
+└── ui/
+    ├── page.py             # Page abstract base class
+    ├── page_manager.py     # Enforces single-active-page invariant
+    ├── main_window.py      # Top-level window, menu bar, page wiring
+    ├── start_page.py       # Start page (New Flow / Load Flow)
+    └── node_editor_page.py # Node editor page
+```
+
+## Architecture
+
+The UI is built around a `Page` abstraction. Each page owns a hidden content container and a list of menus it contributes to the viewport menu bar. `PageManager` ensures only one page is active at any time, deactivating the current page before activating the next.
+
+Adding a new page requires only subclassing `Page` and implementing two methods:
+
+```python
+class MyPage(Page):
+    def _build_ui(self) -> None:
+        # create widgets under self._parent, tag the root with self._content_tag, show=False
+        ...
+
+    def _install_menus(self) -> None:
+        # create menus under self._menu_bar, append their tags to self._menu_tags
+        ...
+```
+
+The domain layer lives under `src/core/` and has no UI framework dependencies.
+
+## License
+
+MIT — see [LICENSE](LICENSE).

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -29,8 +29,8 @@ class MainWindow:
         )
 
         self._pages = PageManager()
-        self._pages.register("start", self._start_page)
-        self._pages.register("editor", self._node_editor_page)
+        self._pages.register(self._start_page)
+        self._pages.register(self._node_editor_page)
         self._pages.activate("start")
 
     def _open_flow(self, flow: Flow) -> None:

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -1,5 +1,6 @@
 import dearpygui.dearpygui as dpg
 
+from core.flow import Flow
 from ui.node_editor_page import NodeEditorPage
 from ui.page_manager import PageManager
 from ui.start_page import StartPage
@@ -15,24 +16,32 @@ class MainWindow:
                 dpg.add_menu_item(label="New", callback=self._on_new)
                 dpg.add_menu_item(label="Save As", callback=self._on_save)
 
+        self._node_editor_page = NodeEditorPage(
+            parent="main_window",
+            menu_bar="main_menu",
+            on_exit=self._close_flow,
+        )
+
         self._pages = PageManager()
         self._pages.register("start", StartPage(
             parent="main_window",
             menu_bar="main_menu",
-            on_create_flow=self._goto_editor,
+            on_create_flow=self._open_flow,
+            on_load_flow=self._on_load_flow,
         ))
-        self._pages.register("editor", NodeEditorPage(
-            parent="main_window",
-            menu_bar="main_menu",
-            on_exit=self._goto_start,
-        ))
+        self._pages.register("editor", self._node_editor_page)
         self._pages.activate("start")
 
-    def _goto_editor(self) -> None:
+    def _open_flow(self, flow: Flow) -> None:
+        self._node_editor_page.set_flow(flow)
         self._pages.activate("editor")
 
-    def _goto_start(self) -> None:
+    def _close_flow(self) -> None:
         self._pages.activate("start")
+
+    def _on_load_flow(self) -> None:
+        # TODO: implement flow loading (file dialog + deserialization).
+        print("Load Flow: not implemented yet")
 
     def _on_new(self, sender):
         print(f"New: {sender}")

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -16,6 +16,12 @@ class MainWindow:
                 dpg.add_menu_item(label="New", callback=self._on_new)
                 dpg.add_menu_item(label="Save As", callback=self._on_save)
 
+        self._start_page = StartPage(
+            parent="main_window",
+            menu_bar="main_menu",
+            on_create_flow=self._open_flow,
+            on_load_flow=self._on_load_flow,
+        )
         self._node_editor_page = NodeEditorPage(
             parent="main_window",
             menu_bar="main_menu",
@@ -23,12 +29,7 @@ class MainWindow:
         )
 
         self._pages = PageManager()
-        self._pages.register("start", StartPage(
-            parent="main_window",
-            menu_bar="main_menu",
-            on_create_flow=self._open_flow,
-            on_load_flow=self._on_load_flow,
-        ))
+        self._pages.register("start", self._start_page)
         self._pages.register("editor", self._node_editor_page)
         self._pages.activate("start")
 

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -31,14 +31,14 @@ class MainWindow:
         self._pages = PageManager()
         self._pages.register(self._start_page)
         self._pages.register(self._node_editor_page)
-        self._pages.activate("start")
+        self._pages.activate(self._start_page)
 
     def _open_flow(self, flow: Flow) -> None:
         self._node_editor_page.set_flow(flow)
-        self._pages.activate("editor")
+        self._pages.activate(self._node_editor_page)
 
     def _close_flow(self) -> None:
-        self._pages.activate("start")
+        self._pages.activate(self._start_page)
 
     def _on_load_flow(self) -> None:
         # TODO: implement flow loading (file dialog + deserialization).

--- a/src/ui/node_editor_page.py
+++ b/src/ui/node_editor_page.py
@@ -5,6 +5,8 @@ from ui.page import Page
 
 
 class NodeEditorPage(Page):
+    name = "editor"
+
     def __init__(self, parent: str, menu_bar: str, on_exit) -> None:
         self._on_exit = on_exit
         self._node_editor_tag: int = dpg.generate_uuid()

--- a/src/ui/node_editor_page.py
+++ b/src/ui/node_editor_page.py
@@ -1,5 +1,6 @@
 import dearpygui.dearpygui as dpg
 
+from core.flow import Flow
 from ui.page import Page
 
 
@@ -8,7 +9,11 @@ class NodeEditorPage(Page):
         self._on_exit = on_exit
         self._node_editor_tag: int = dpg.generate_uuid()
         self._node_count: int = 0
+        self._flow: Flow | None = None
         super().__init__(parent=parent, menu_bar=menu_bar)
+
+    def set_flow(self, flow: Flow) -> None:
+        self._flow = flow
 
     def _build_ui(self) -> None:
         with dpg.child_window(tag=self._content_tag, parent=self._parent, border=False, show=False):

--- a/src/ui/page.py
+++ b/src/ui/page.py
@@ -11,7 +11,8 @@ class Page(ABC):
     deactivation. Only one page in the application should be active at any
     given time; the PageManager enforces this.
 
-    Subclasses implement:
+    Subclasses must define:
+        name             - unique string identifier used by PageManager.
         _build_ui()      - create the page content (use self._content_tag
                            as the root container tag, self._parent as the
                            parent, and pass show=False so the page starts
@@ -21,6 +22,8 @@ class Page(ABC):
                            self._menu_tags so the base class can remove
                            them automatically on deactivation.
     """
+
+    name: str
 
     def __init__(self, parent: str, menu_bar: str) -> None:
         self._parent: str = parent

--- a/src/ui/page_manager.py
+++ b/src/ui/page_manager.py
@@ -8,10 +8,10 @@ class PageManager:
         self._pages: dict[str, Page] = {}
         self._active: Page | None = None
 
-    def register(self, name: str, page: Page) -> None:
-        if name in self._pages:
-            raise ValueError(f"Page '{name}' is already registered")
-        self._pages[name] = page
+    def register(self, page: Page) -> None:
+        if page.name in self._pages:
+            raise ValueError(f"Page '{page.name}' is already registered")
+        self._pages[page.name] = page
 
     def activate(self, name: str) -> None:
         if name not in self._pages:

--- a/src/ui/page_manager.py
+++ b/src/ui/page_manager.py
@@ -13,16 +13,15 @@ class PageManager:
             raise ValueError(f"Page '{page.name}' is already registered")
         self._pages[page.name] = page
 
-    def activate(self, name: str) -> None:
-        if name not in self._pages:
-            raise KeyError(f"Unknown page: '{name}'")
+    def activate(self, page: Page) -> None:
+        if page.name not in self._pages:
+            raise KeyError(f"Page '{page.name}' is not registered")
 
-        target = self._pages[name]
-        if self._active is target:
+        if self._active is page:
             return
 
         if self._active is not None:
             self._active.deactivate()
 
-        target.activate()
-        self._active = target
+        page.activate()
+        self._active = page

--- a/src/ui/start_page.py
+++ b/src/ui/start_page.py
@@ -5,6 +5,8 @@ from ui.page import Page
 
 
 class StartPage(Page):
+    name = "start"
+
     def __init__(self, parent: str, menu_bar: str, on_create_flow, on_load_flow) -> None:
         self._on_create_flow = on_create_flow
         self._on_load_flow = on_load_flow

--- a/src/ui/start_page.py
+++ b/src/ui/start_page.py
@@ -1,11 +1,13 @@
 import dearpygui.dearpygui as dpg
 
+from core.flow import Flow
 from ui.page import Page
 
 
 class StartPage(Page):
-    def __init__(self, parent: str, menu_bar: str, on_create_flow) -> None:
+    def __init__(self, parent: str, menu_bar: str, on_create_flow, on_load_flow) -> None:
         self._on_create_flow = on_create_flow
+        self._on_load_flow = on_load_flow
         super().__init__(parent=parent, menu_bar=menu_bar)
 
     def _build_ui(self) -> None:
@@ -13,11 +15,16 @@ class StartPage(Page):
             dpg.add_spacer(height=60)
             dpg.add_text("Image Inquest", indent=20)
             dpg.add_spacer(height=20)
-            dpg.add_button(label="New Flow", callback=self._on_new_flow, indent=20)
+            with dpg.group(horizontal=True, indent=20):
+                dpg.add_button(label="New Flow", callback=self._on_new_flow_clicked)
+                dpg.add_button(label="Load Flow", callback=self._on_load_flow_clicked)
 
     def _install_menus(self) -> None:
         # Start page contributes no menus of its own.
         pass
 
-    def _on_new_flow(self, sender) -> None:
-        self._on_create_flow()
+    def _on_new_flow_clicked(self, sender) -> None:
+        self._on_create_flow(Flow())
+
+    def _on_load_flow_clicked(self, sender) -> None:
+        self._on_load_flow()


### PR DESCRIPTION
## Summary
- **New Flow** button now creates a `Flow()` instance and passes it through to the node editor via `MainWindow._open_flow(flow)` → `NodeEditorPage.set_flow(flow)`
- **Load Flow** button added to the start page; wired to a stub handler (`_on_load_flow`) that prints a TODO message until loading is implemented
- `MainWindow` now holds a direct reference to `NodeEditorPage` so it can call `set_flow` before activating the editor page
- `_goto_editor` / `_goto_start` renamed to `_open_flow(flow)` / `_close_flow()` for clearer semantics
- **README** written from scratch: requirements, usage walkthrough, project structure, architecture overview, and the `Page` extension recipe

## Test plan
- [ ] App launches on the start page with both **New Flow** and **Load Flow** buttons visible
- [ ] **New Flow** transitions to the node editor (a fresh `Flow` instance is created and held by `NodeEditorPage`)
- [ ] **Load Flow** prints a TODO message and stays on the start page
- [ ] Node editor Add Node / Clear All / Exit still work correctly
- [ ] **Exit** returns to the start page

https://claude.ai/code/session_01DBhntZKSRtjkUAQ8DmY5MM