### PR TITLE
Replace magic string tags with dpg.generate_uuid()

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -7,14 +7,14 @@ from constants import *
 class App:
     def __init__(self):
         dpg.create_context()
-        MainWindow()
+        self._main_window = MainWindow()
 
         dpg.create_viewport(title=APP_NAME, width=APP_WIDTH, height=APP_HEIGHT)
 
     def run(self):
         dpg.setup_dearpygui()
         dpg.show_viewport()
-        dpg.set_primary_window("main_window", True)
+        dpg.set_primary_window(self._main_window.window_tag, True)
         dpg.start_dearpygui()
         dpg.destroy_context()
 

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -31,14 +31,14 @@ class MainWindow:
             on_exit=self._close_flow,
         )
 
-    @property
-    def window_tag(self) -> int:
-        return self._window_tag
-
         self._pages = PageManager()
         self._pages.register(self._start_page)
         self._pages.register(self._node_editor_page)
         self._pages.activate(self._start_page)
+
+    @property
+    def window_tag(self) -> int:
+        return self._window_tag
 
     def _open_flow(self, flow: Flow) -> None:
         self._node_editor_page.set_flow(flow)

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -8,8 +8,8 @@ from ui.start_page import StartPage
 
 class MainWindow:
     def __init__(self):
-        self._window_tag: int = dpg.generate_uuid()
-        self._menu_tag: int = dpg.generate_uuid()
+        self._window_tag: int | str = dpg.generate_uuid()
+        self._menu_tag: int | str = dpg.generate_uuid()
 
         with dpg.window(tag=self._window_tag):
             pass
@@ -37,7 +37,7 @@ class MainWindow:
         self._pages.activate(self._start_page)
 
     @property
-    def window_tag(self) -> int:
+    def window_tag(self) -> int | str:
         return self._window_tag
 
     def _open_flow(self, flow: Flow) -> None:

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -8,25 +8,32 @@ from ui.start_page import StartPage
 
 class MainWindow:
     def __init__(self):
-        with dpg.window(label="App", tag="main_window"):
+        self._window_tag: int = dpg.generate_uuid()
+        self._menu_tag: int = dpg.generate_uuid()
+
+        with dpg.window(tag=self._window_tag):
             pass
 
-        with dpg.viewport_menu_bar(tag="main_menu"):
+        with dpg.viewport_menu_bar(tag=self._menu_tag):
             with dpg.menu(label="File"):
                 dpg.add_menu_item(label="New", callback=self._on_new)
                 dpg.add_menu_item(label="Save As", callback=self._on_save)
 
         self._start_page = StartPage(
-            parent="main_window",
-            menu_bar="main_menu",
+            parent=self._window_tag,
+            menu_bar=self._menu_tag,
             on_create_flow=self._open_flow,
             on_load_flow=self._on_load_flow,
         )
         self._node_editor_page = NodeEditorPage(
-            parent="main_window",
-            menu_bar="main_menu",
+            parent=self._window_tag,
+            menu_bar=self._menu_tag,
             on_exit=self._close_flow,
         )
+
+    @property
+    def window_tag(self) -> int:
+        return self._window_tag
 
         self._pages = PageManager()
         self._pages.register(self._start_page)

--- a/src/ui/node_editor_page.py
+++ b/src/ui/node_editor_page.py
@@ -7,9 +7,9 @@ from ui.page import Page
 class NodeEditorPage(Page):
     name = "editor"
 
-    def __init__(self, parent: int, menu_bar: int, on_exit) -> None:
+    def __init__(self, parent: int | str, menu_bar: int | str, on_exit) -> None:
         self._on_exit = on_exit
-        self._node_editor_tag: int = dpg.generate_uuid()
+        self._node_editor_tag: int | str = dpg.generate_uuid()
         self._node_count: int = 0
         self._flow: Flow | None = None
         super().__init__(parent=parent, menu_bar=menu_bar)

--- a/src/ui/node_editor_page.py
+++ b/src/ui/node_editor_page.py
@@ -7,7 +7,7 @@ from ui.page import Page
 class NodeEditorPage(Page):
     name = "editor"
 
-    def __init__(self, parent: str, menu_bar: str, on_exit) -> None:
+    def __init__(self, parent: int, menu_bar: int, on_exit) -> None:
         self._on_exit = on_exit
         self._node_editor_tag: int = dpg.generate_uuid()
         self._node_count: int = 0

--- a/src/ui/page.py
+++ b/src/ui/page.py
@@ -25,9 +25,9 @@ class Page(ABC):
 
     name: str
 
-    def __init__(self, parent: str, menu_bar: str) -> None:
-        self._parent: str = parent
-        self._menu_bar: str = menu_bar
+    def __init__(self, parent: int, menu_bar: int) -> None:
+        self._parent: int = parent
+        self._menu_bar: int = menu_bar
         self._content_tag: int = dpg.generate_uuid()
         self._menu_tags: list[int | str] = []
         self._active: bool = False

--- a/src/ui/page.py
+++ b/src/ui/page.py
@@ -25,10 +25,10 @@ class Page(ABC):
 
     name: str
 
-    def __init__(self, parent: int, menu_bar: int) -> None:
-        self._parent: int = parent
-        self._menu_bar: int = menu_bar
-        self._content_tag: int = dpg.generate_uuid()
+    def __init__(self, parent: int | str, menu_bar: int | str) -> None:
+        self._parent: int | str = parent
+        self._menu_bar: int | str = menu_bar
+        self._content_tag: int | str = dpg.generate_uuid()
         self._menu_tags: list[int | str] = []
         self._active: bool = False
         self._build_ui()

--- a/src/ui/start_page.py
+++ b/src/ui/start_page.py
@@ -7,7 +7,7 @@ from ui.page import Page
 class StartPage(Page):
     name = "start"
 
-    def __init__(self, parent: str, menu_bar: str, on_create_flow, on_load_flow) -> None:
+    def __init__(self, parent: int, menu_bar: int, on_create_flow, on_load_flow) -> None:
         self._on_create_flow = on_create_flow
         self._on_load_flow = on_load_flow
         super().__init__(parent=parent, menu_bar=menu_bar)

--- a/src/ui/start_page.py
+++ b/src/ui/start_page.py
@@ -7,7 +7,7 @@ from ui.page import Page
 class StartPage(Page):
     name = "start"
 
-    def __init__(self, parent: int, menu_bar: int, on_create_flow, on_load_flow) -> None:
+    def __init__(self, parent: int | str, menu_bar: int | str, on_create_flow, on_load_flow) -> None:
         self._on_create_flow = on_create_flow
         self._on_load_flow = on_load_flow
         super().__init__(parent=parent, menu_bar=menu_bar)


### PR DESCRIPTION
## Summary

Eliminates the last two magic string tags (`"main_window"`, `"main_menu"`) by switching to `dpg.generate_uuid()` throughout, consistent with how `Page._content_tag` and `NodeEditorPage._node_editor_tag` already work.

## Changes

- **`MainWindow`** generates `_window_tag` and `_menu_tag` as integer UUIDs and passes them to page constructors. Exposes `window_tag` as a property.
- **`App`** stores the `MainWindow` instance and reads `window_tag` to call `dpg.set_primary_window()` — no string needed.
- **`Page`, `StartPage`, `NodeEditorPage`** — `parent` and `menu_bar` type hints updated from `str` to `int`.

## Test plan
- [ ] App launches and the start page is shown full-screen (primary window still set correctly)
- [ ] New Flow → node editor transition works
- [ ] Node Editor Exit → start page transition works

https://claude.ai/code/session_01DBhntZKSRtjkUAQ8DmY5MM