### PR TITLE
Pages own their navigation via PageManager

### DIFF
--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -1,6 +1,5 @@
 import dearpygui.dearpygui as dpg
 
-from core.flow import Flow
 from ui.node_editor_page import NodeEditorPage
 from ui.page_manager import PageManager
 from ui.start_page import StartPage
@@ -19,37 +18,22 @@ class MainWindow:
                 dpg.add_menu_item(label="New", callback=self._on_new)
                 dpg.add_menu_item(label="Save As", callback=self._on_save)
 
-        self._start_page = StartPage(
-            parent=self._window_tag,
-            menu_bar=self._menu_tag,
-            on_create_flow=self._open_flow,
-            on_load_flow=self._on_load_flow,
-        )
-        self._node_editor_page = NodeEditorPage(
-            parent=self._window_tag,
-            menu_bar=self._menu_tag,
-            on_exit=self._close_flow,
-        )
-
         self._pages = PageManager()
-        self._pages.register(self._start_page)
-        self._pages.register(self._node_editor_page)
-        self._pages.activate(self._start_page)
+        self._pages.register(StartPage(
+            parent=self._window_tag,
+            menu_bar=self._menu_tag,
+            page_manager=self._pages,
+        ))
+        self._pages.register(NodeEditorPage(
+            parent=self._window_tag,
+            menu_bar=self._menu_tag,
+            page_manager=self._pages,
+        ))
+        self._pages.activate(self._pages.start_page)
 
     @property
     def window_tag(self) -> int | str:
         return self._window_tag
-
-    def _open_flow(self, flow: Flow) -> None:
-        self._node_editor_page.set_flow(flow)
-        self._pages.activate(self._node_editor_page)
-
-    def _close_flow(self) -> None:
-        self._pages.activate(self._start_page)
-
-    def _on_load_flow(self) -> None:
-        # TODO: implement flow loading (file dialog + deserialization).
-        print("Load Flow: not implemented yet")
 
     def _on_new(self, sender):
         print(f"New: {sender}")

--- a/src/ui/node_editor_page.py
+++ b/src/ui/node_editor_page.py
@@ -1,18 +1,24 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import dearpygui.dearpygui as dpg
 
 from core.flow import Flow
 from ui.page import Page
 
+if TYPE_CHECKING:
+    from ui.page_manager import PageManager
+
 
 class NodeEditorPage(Page):
     name = "editor"
 
-    def __init__(self, parent: int | str, menu_bar: int | str, on_exit) -> None:
-        self._on_exit = on_exit
+    def __init__(self, parent: int | str, menu_bar: int | str, page_manager: PageManager) -> None:
         self._node_editor_tag: int | str = dpg.generate_uuid()
         self._node_count: int = 0
         self._flow: Flow | None = None
-        super().__init__(parent=parent, menu_bar=menu_bar)
+        super().__init__(parent=parent, menu_bar=menu_bar, page_manager=page_manager)
 
     def set_flow(self, flow: Flow) -> None:
         self._flow = flow
@@ -51,7 +57,6 @@ class NodeEditorPage(Page):
         children = dpg.get_item_children(self._node_editor_tag, 1)
         if children is None:
             return
-
         for child in children:
             dpg.delete_item(child)
         self._node_count = 0
@@ -71,4 +76,4 @@ class NodeEditorPage(Page):
 
     def _on_exit_clicked(self, sender) -> None:
         self._clear_nodes()
-        self._on_exit()
+        self._page_manager.activate(self._page_manager.start_page)

--- a/src/ui/page.py
+++ b/src/ui/page.py
@@ -1,6 +1,12 @@
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING
 
 import dearpygui.dearpygui as dpg
+
+if TYPE_CHECKING:
+    from ui.page_manager import PageManager
 
 
 class Page(ABC):
@@ -25,9 +31,10 @@ class Page(ABC):
 
     name: str
 
-    def __init__(self, parent: int | str, menu_bar: int | str) -> None:
+    def __init__(self, parent: int | str, menu_bar: int | str, page_manager: PageManager) -> None:
         self._parent: int | str = parent
         self._menu_bar: int | str = menu_bar
+        self._page_manager: PageManager = page_manager
         self._content_tag: int | str = dpg.generate_uuid()
         self._menu_tags: list[int | str] = []
         self._active: bool = False

--- a/src/ui/page_manager.py
+++ b/src/ui/page_manager.py
@@ -1,8 +1,16 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, cast
+
 from ui.page import Page
+
+if TYPE_CHECKING:
+    from ui.node_editor_page import NodeEditorPage
+    from ui.start_page import StartPage
 
 
 class PageManager:
-    """Owns a set of named pages and guarantees that only one is active."""
+    """Owns all pages and guarantees that only one is active at a time."""
 
     def __init__(self) -> None:
         self._pages: dict[str, Page] = {}
@@ -16,12 +24,19 @@ class PageManager:
     def activate(self, page: Page) -> None:
         if page.name not in self._pages:
             raise KeyError(f"Page '{page.name}' is not registered")
-
         if self._active is page:
             return
-
         if self._active is not None:
             self._active.deactivate()
-
         page.activate()
         self._active = page
+
+    @property
+    def start_page(self) -> StartPage:
+        from ui.start_page import StartPage
+        return cast("StartPage", self._pages[StartPage.name])
+
+    @property
+    def editor_page(self) -> NodeEditorPage:
+        from ui.node_editor_page import NodeEditorPage
+        return cast("NodeEditorPage", self._pages[NodeEditorPage.name])

--- a/src/ui/start_page.py
+++ b/src/ui/start_page.py
@@ -1,16 +1,21 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import dearpygui.dearpygui as dpg
 
 from core.flow import Flow
 from ui.page import Page
 
+if TYPE_CHECKING:
+    from ui.page_manager import PageManager
+
 
 class StartPage(Page):
     name = "start"
 
-    def __init__(self, parent: int | str, menu_bar: int | str, on_create_flow, on_load_flow) -> None:
-        self._on_create_flow = on_create_flow
-        self._on_load_flow = on_load_flow
-        super().__init__(parent=parent, menu_bar=menu_bar)
+    def __init__(self, parent: int | str, menu_bar: int | str, page_manager: PageManager) -> None:
+        super().__init__(parent=parent, menu_bar=menu_bar, page_manager=page_manager)
 
     def _build_ui(self) -> None:
         with dpg.child_window(tag=self._content_tag, parent=self._parent, border=False, show=False):
@@ -22,11 +27,12 @@ class StartPage(Page):
                 dpg.add_button(label="Load Flow", callback=self._on_load_flow_clicked)
 
     def _install_menus(self) -> None:
-        # Start page contributes no menus of its own.
         pass
 
     def _on_new_flow_clicked(self, sender) -> None:
-        self._on_create_flow(Flow())
+        self._page_manager.editor_page.set_flow(Flow())
+        self._page_manager.activate(self._page_manager.editor_page)
 
     def _on_load_flow_clicked(self, sender) -> None:
-        self._on_load_flow()
+        # TODO: implement flow loading (file dialog + deserialization).
+        print("Load Flow: not implemented yet")


### PR DESCRIPTION
## Summary

Removes all navigation callbacks from page constructors and from `MainWindow`. Pages navigate themselves directly through a `PageManager` reference, which now exposes typed `start_page` and `editor_page` properties.

## Changes

**`PageManager`**
- Gains `start_page` and `editor_page` typed properties for direct, IDE-friendly access to pages
- Lazy runtime imports inside the properties + `TYPE_CHECKING` guard avoids circular imports; `cast()` narrows the return type

**`Page`**
- `__init__` now accepts a `page_manager` reference stored as `self._page_manager`
- Subclasses can navigate without any callbacks

**`StartPage`**
- `on_create_flow` / `on_load_flow` constructor params removed
- `_on_new_flow_clicked` calls `self._page_manager.editor_page.set_flow(flow)` then `activate`
- Load flow stub stays local to the page

**`NodeEditorPage`**
- `on_exit` constructor param removed
- `_on_exit_clicked` calls `self._page_manager.activate(self._page_manager.start_page)`

**`MainWindow`**
- `_open_flow`, `_close_flow`, `_on_load_flow` all removed
- Per-page member variables removed
- Reduced to a thin bootstrap: create tags, build `PageManager`, register pages, activate start

## Test plan
- [ ] App launches on the start page
- [ ] **New Flow** creates a fresh `Flow`, sets it on the editor, and transitions to the node editor
- [ ] **Load Flow** prints the TODO stub and stays on the start page
- [ ] Node editor Add Node / Clear All work correctly
- [ ] **Exit** clears the canvas and returns to the start page

https://claude.ai/code/session_01DBhntZKSRtjkUAQ8DmY5MM