### PR TITLE
Fix FileSink: typo, dead code, missing params, correct imports

### DIFF
--- a/src/nodes/sinks/file_sink.py
+++ b/src/nodes/sinks/file_sink.py
@@ -1,66 +1,63 @@
 from __future__ import annotations
 
+import os
+from enum import Enum
+
 import cv2
 
-from enum import Enum
 from core.io_data import IoDataType
-from core.node_base import SinkNodeBase, InputPort
-
-import os
+from core.node_base import SinkNodeBase, NodeParam, NodeParamType
+from core.port import InputPort
 
 
 class OutputFormat(Enum):
     SAME_AS_INPUT = 0
-    GIF = 1
-    PNG = 2
+    PNG = 1
 
 
 class FileSink(SinkNodeBase):
     def __init__(self):
-        super().__init__("File Sinke")
-        
-        self.__output_path = "out.png"
-        self.__output_format = OutputFormat.SAME_AS_INPUT
+        super().__init__("File Sink")
+
+        self._output_path: str = "output/out.png"
+        self._output_format: OutputFormat = OutputFormat.SAME_AS_INPUT
 
         self._add_input(InputPort("image", {IoDataType.IMAGE}))
 
+    # ── Parameters ─────────────────────────────────────────────────────────────
 
     @property
-    def output_format(self):
-        return self.__output_format
+    def params(self) -> list[NodeParam]:
+        return [NodeParam("output_path", NodeParamType.FILE_PATH, {"default": "output/out.png"})]
 
+    # ── Properties ─────────────────────────────────────────────────────────────
+
+    @property
+    def output_format(self) -> OutputFormat:
+        return self._output_format
 
     @output_format.setter
-    def output_format(self, output_format):
-        self.__output_format = output_format
-
+    def output_format(self, output_format: OutputFormat) -> None:
+        self._output_format = output_format
 
     @property
-    def output_path(self):
-        return self.__output_path
-
+    def output_path(self) -> str:
+        return self._output_path
 
     @output_path.setter
-    def output_path(self, output_path):
-        self.__output_path = output_path
+    def output_path(self, output_path: str) -> None:
+        self._output_path = output_path
 
+    # ── SinkNodeBase interface ──────────────────────────────────────────────────
 
-    def process(self):
-        file_name, file_ext = os.path.splitext(self.output_path)
-        
-        if self.__output_format==OutputFormat.SAME_AS_INPUT:
+    def process(self) -> None:
+        file_name, file_ext = os.path.splitext(self._output_path)
+
+        if self._output_format == OutputFormat.SAME_AS_INPUT:
             output = file_name + file_ext
-        elif self.__output_format==OutputFormat.PNG:
+        elif self._output_format == OutputFormat.PNG:
             output = file_name + ".png"
         else:
-            raise(Exception("Invalid output format"))
-        
+            raise ValueError(f"Unsupported output format: {self._output_format}")
+
         cv2.imwrite(output, self.inputs[0].data.image)
-        cv2.imshow(output, self.inputs[0].data.image)
-        cv2.waitKey(0)
-        cv2.destroyAllWindows()
-
-
-    def end_of_series(self):
-        pass
-


### PR DESCRIPTION
## Summary

- Fix typo `"File Sinke"` → `"File Sink"` in display name
- Add missing `params` property (required by the `@abstractmethod` on `NodeBase`)
- Remove dead `end_of_series()` method (wrong name — the correct hook `_on_end_of_stream()` is already a no-op in `SinkNodeBase`)
- Remove `cv2.imshow` / `waitKey` / `destroyAllWindows` from `process()` — a sink node should not pop up a display window as a side effect
- Import `InputPort` from `core.port` (where it is defined) instead of `core.node_base`
- Remove `GIF` from `OutputFormat` (no write logic existed for it)
- Switch name-mangled `__fields` to single-underscore `_fields`, consistent with the rest of the codebase

## Test plan

- [ ] `FileSink()` instantiates without `TypeError` (previously would fail due to missing `params`)
- [ ] `params` returns a `FILE_PATH` param with default `"output/out.png"`
- [ ] `process()` writes the image to disk without opening a display window

https://claude.ai/code/session_01FAWFxdtdWgssTs1VdZmGQq