### PR TITLE
Add node palette with drag & drop, colour scheme, and Grayscale filter

### DIFF
--- a/src/ui/node_editor_page.py
+++ b/src/ui/node_editor_page.py
@@ -144,11 +144,14 @@ class NodeEditorPage(Page):
         if self._flow is not None:
             self._flow.add_node(node)
         node_tag = self._add_visual_node(node)
-        # Position the node at the drop location.
-        # local=True gives coordinates relative to the canvas child_window,
-        # which matches the node editor's own coordinate space.
-        mouse_pos = dpg.get_mouse_pos(local=True)
-        dpg.set_item_pos(node_tag, [mouse_pos[0], mouse_pos[1]])
+        # get_mouse_pos(local=True) is relative to the main window origin.
+        # Subtract the canvas child_window's offset to get node editor coordinates.
+        mouse_pos  = dpg.get_mouse_pos(local=True)
+        canvas_pos = dpg.get_item_pos(self._canvas_tag)
+        dpg.set_item_pos(node_tag, [
+            mouse_pos[0] - canvas_pos[0],
+            mouse_pos[1] - canvas_pos[1],
+        ])
 
     # ── Node creation ──────────────────────────────────────────────────────────
 

--- a/src/ui/node_editor_page.py
+++ b/src/ui/node_editor_page.py
@@ -90,6 +90,8 @@ class NodeEditorPage(Page):
                     tag=self._node_editor_tag,
                     callback=self._link,
                     delink_callback=self._delink,
+                    drop_callback=self._on_node_dropped,
+                    payload_type="NODE_PALETTE",
                     width=-1,
                     height=-1,
                 )
@@ -113,13 +115,13 @@ class NodeEditorPage(Page):
                     dpg.add_text("(none)", color=(120, 120, 120, 255))
                 for entry in entries:
                     tag = dpg.generate_uuid()
-                    dpg.add_button(
-                        label=entry.display_name,
-                        tag=tag,
-                        width=-1,
-                        callback=self._on_palette_add,
-                        user_data=entry,
-                    )
+                    dpg.add_button(label=entry.display_name, tag=tag, width=-1)
+                    with dpg.drag_payload(
+                        parent=tag,
+                        drag_data=entry,
+                        payload_type="NODE_PALETTE",
+                    ):
+                        dpg.add_text(f"+ {entry.display_name}")
                     self._palette_items.append((tag, entry.display_name.lower()))
 
     def _on_palette_search(self, sender: int | str, value: str) -> None:
@@ -127,17 +129,25 @@ class NodeEditorPage(Page):
         for tag, text in self._palette_items:
             dpg.configure_item(tag, show=(not query or query in text))
 
-    def _on_palette_add(self, sender: int | str, app_data, entry: NodeEntry) -> None:
+    def _on_node_dropped(self, sender: int | str, app_data) -> None:
+        entry: NodeEntry = app_data
         module = importlib.import_module(entry.module)
         cls = getattr(module, entry.class_name)
         node: NodeBase = cls()
         if self._flow is not None:
             self._flow.add_node(node)
-        self._add_visual_node(node)
+        node_tag = self._add_visual_node(node)
+        # Position the new node at the drop location
+        mouse_pos  = dpg.get_mouse_pos(local=False)
+        editor_min = dpg.get_item_rect_min(self._node_editor_tag)
+        dpg.set_item_pos(node_tag, [
+            mouse_pos[0] - editor_min[0],
+            mouse_pos[1] - editor_min[1],
+        ])
 
     # ── Node creation ──────────────────────────────────────────────────────────
 
-    def _add_visual_node(self, node: NodeBase) -> None:
+    def _add_visual_node(self, node: NodeBase) -> int | str:
         """Create a visual node driven by node.params, node.inputs, and node.outputs."""
         assert node is not None
 
@@ -230,6 +240,8 @@ class NodeEditorPage(Page):
                     if i == 0:
                         dpg.add_spacer(height=6)
                     dpg.add_text(", ".join(t.value for t in port.emits))
+
+        return node_tag
 
     # ── Link callbacks ─────────────────────────────────────────────────────────
 

--- a/src/ui/node_editor_page.py
+++ b/src/ui/node_editor_page.py
@@ -144,13 +144,11 @@ class NodeEditorPage(Page):
         if self._flow is not None:
             self._flow.add_node(node)
         node_tag = self._add_visual_node(node)
-        # Position the new node at the drop location
-        mouse_pos  = dpg.get_mouse_pos(local=False)
-        canvas_min = dpg.get_item_rect_min(self._canvas_tag)
-        dpg.set_item_pos(node_tag, [
-            mouse_pos[0] - canvas_min[0],
-            mouse_pos[1] - canvas_min[1],
-        ])
+        # Position the node at the drop location.
+        # local=True gives coordinates relative to the canvas child_window,
+        # which matches the node editor's own coordinate space.
+        mouse_pos = dpg.get_mouse_pos(local=True)
+        dpg.set_item_pos(node_tag, [mouse_pos[0], mouse_pos[1]])
 
     # ── Node creation ──────────────────────────────────────────────────────────
 

--- a/src/ui/node_editor_page.py
+++ b/src/ui/node_editor_page.py
@@ -53,6 +53,7 @@ class NodeEditorPage(Page):
         registry: NodeRegistry,
     ) -> None:
         self._node_editor_tag: int | str = dpg.generate_uuid()
+        self._canvas_tag:      int | str = dpg.generate_uuid()
         self._flow: Flow | None = None
         self._file_dialogs: list[int | str] = []
         self._registry: NodeRegistry = registry
@@ -86,15 +87,21 @@ class NodeEditorPage(Page):
             with dpg.group():
                 with dpg.group(horizontal=True):
                     dpg.add_button(label="Clear All", callback=self._on_clear_nodes)
-                dpg.add_node_editor(
-                    tag=self._node_editor_tag,
-                    callback=self._link,
-                    delink_callback=self._delink,
+                with dpg.child_window(
+                    tag=self._canvas_tag,
                     drop_callback=self._on_node_dropped,
                     payload_type="NODE_PALETTE",
                     width=-1,
                     height=-1,
-                )
+                    border=False,
+                ):
+                    dpg.add_node_editor(
+                        tag=self._node_editor_tag,
+                        callback=self._link,
+                        delink_callback=self._delink,
+                        width=-1,
+                        height=-1,
+                    )
 
     # ── Palette ────────────────────────────────────────────────────────────────
 
@@ -139,10 +146,10 @@ class NodeEditorPage(Page):
         node_tag = self._add_visual_node(node)
         # Position the new node at the drop location
         mouse_pos  = dpg.get_mouse_pos(local=False)
-        editor_min = dpg.get_item_rect_min(self._node_editor_tag)
+        canvas_min = dpg.get_item_rect_min(self._canvas_tag)
         dpg.set_item_pos(node_tag, [
-            mouse_pos[0] - editor_min[0],
-            mouse_pos[1] - editor_min[1],
+            mouse_pos[0] - canvas_min[0],
+            mouse_pos[1] - canvas_min[1],
         ])
 
     # ── Node creation ──────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Replace "Add Node" button with a persistent left-side palette panel
- Nodes are added by dragging from the palette and dropping onto the canvas
- Consistent colour scheme for node headers and connection pins
- Add `Grayscale` filter node (first filter in the codebase)
- Add version number `0.1.0`

## Changes

**`src/core/node_registry.py`**
- New `NodeEntry` dataclass: `class_name`, `display_name`, `category`, `module`
- AST scanner detects category from base class name (`SourceNodeBase` → Sources, `NodeBase` → Filters, `SinkNodeBase` → Sinks) — all three categories now explicit in `_CATEGORY_MAP`
- Module path computed relative to `src/` for builtin nodes; `scan_user()` adds the user nodes folder to `sys.path`
- New `nodes_by_category()` returning entries sorted by display name per category

**`src/ui/node_editor_page.py`**
- Accepts `NodeRegistry`; layout split into fixed-width palette (left) + canvas (right)
- Palette: search input (filters by display name), collapsing header per category with item count
- Each palette button is a **drag source** (`drag_payload`, type `"NODE_PALETTE"`) — dragging shows a floating `+ Name` label
- Node editor is the **drop target** — node is instantiated and positioned at the release point
- File dialog only created for nodes that actually have a `FILE_PATH` param
- Input ports now rendered (`mvNode_Attr_Input`)
- Colour scheme:

| Element | Colour |
|---|---|
| Source header | Blue |
| Filter header | Green |
| Sink header | Orange |
| Input pin | Light grey |
| Output pin | Yellow / gold |

**`src/ui/main_window.py`**
- Creates `NodeRegistry`, scans builtin + user nodes, passes to `NodeEditorPage`

**`src/nodes/filters/grayscale.py`** *(new)*
- Converts BGR → grayscale → 3-channel BGR for downstream compatibility
- Adapted from ocvl `GreyscaleProcessor`

**`src/constants.py`** — `APP_VERSION = "0.1.0"`

**`src/main.py`** — window title shows `Image-Inquest v0.1.0`

**`src/ui/start_page.py`** — version shown in muted grey below the title

## Test plan

- [ ] Palette shows Sources (1), Filters (1), Sinks (1)
- [ ] Search filters items; clearing restores all
- [ ] Dragging a palette item shows `+ Name` label while dragging
- [ ] Releasing over the canvas creates the node at that position
- [ ] Source = blue header, Filter = green header, Sink = orange header
- [ ] Input pins = light grey, output pins = yellow
- [ ] File Source → Grayscale → File Sink pipeline produces a greyscale image
- [ ] Window title and start page both show `v0.1.0`

https://claude.ai/code/session_01FAWFxdtdWgssTs1VdZmGQq