### PR TITLE
Node palette, drag & drop, colour scheme, and context-menu deletion

### DIFF
--- a/src/ui/node_editor_page.py
+++ b/src/ui/node_editor_page.py
@@ -317,13 +317,10 @@ class NodeEditorPage(Page):
                 dpg.configure_item(self._node_ctx_tag, show=True)
                 return
 
-        # If the canvas is hovered and links are selected, offer link deletion
-        if not dpg.get_item_state(self._canvas_tag).get("hovered", False):
-            return
-        if dpg.get_selected_links(self._node_editor_tag):
-            self._hide_ctx_menus()
-            dpg.set_item_pos(self._link_ctx_tag, dpg.get_mouse_pos())
-            dpg.configure_item(self._link_ctx_tag, show=True)
+        # No node hovered — offer link deletion (select a link first, then right-click)
+        self._hide_ctx_menus()
+        dpg.set_item_pos(self._link_ctx_tag, dpg.get_mouse_pos())
+        dpg.configure_item(self._link_ctx_tag, show=True)
 
     def _on_left_click(self) -> None:
         """Dismiss context menus when clicking outside them."""

--- a/src/ui/node_editor_page.py
+++ b/src/ui/node_editor_page.py
@@ -64,6 +64,14 @@ class NodeEditorPage(Page):
         self._theme_sink:        int | str | None = None
         self._theme_pin_input:   int | str | None = None
         self._theme_pin_output:  int | str | None = None
+        # Node tracking for delete / context-menu support
+        self._node_map:        dict[int | str, NodeBase]         = {}
+        self._node_dialog_map: dict[int | str, int | str | None] = {}
+        self._ctx_target:      tuple[int | str, NodeBase] | None = None
+        # Context-menu window tags (created in _build_ui)
+        self._node_ctx_tag:    int | str = dpg.generate_uuid()
+        self._link_ctx_tag:    int | str = dpg.generate_uuid()
+        self._handler_reg_tag: int | str = dpg.generate_uuid()
         super().__init__(parent=parent, menu_bar=menu_bar, page_manager=page_manager)
 
     def set_flow(self, flow: Flow) -> None:
@@ -76,6 +84,44 @@ class NodeEditorPage(Page):
         self._theme_sink       = _make_node_theme(*_COL_SINK)
         self._theme_pin_input  = _make_pin_theme(*_COL_PIN_INPUT)
         self._theme_pin_output = _make_pin_theme(*_COL_PIN_OUTPUT)
+
+        # ── Context menus (floating windows, shown/hidden on demand) ───────────
+        with dpg.window(
+            tag=self._node_ctx_tag,
+            show=False,
+            no_title_bar=True,
+            autosize=True,
+            no_scrollbar=True,
+            no_move=True,
+            no_resize=True,
+            no_collapse=True,
+            min_size=(10, 10),
+        ):
+            dpg.add_menu_item(label="Delete Node", callback=self._on_ctx_delete_node)
+
+        with dpg.window(
+            tag=self._link_ctx_tag,
+            show=False,
+            no_title_bar=True,
+            autosize=True,
+            no_scrollbar=True,
+            no_move=True,
+            no_resize=True,
+            no_collapse=True,
+            min_size=(10, 10),
+        ):
+            dpg.add_menu_item(label="Delete Connection(s)", callback=self._delete_selected_links)
+
+        # ── Global mouse handlers ──────────────────────────────────────────────
+        with dpg.handler_registry(tag=self._handler_reg_tag):
+            dpg.add_mouse_click_handler(
+                button=dpg.mvMouseButton_Right,
+                callback=self._on_right_click,
+            )
+            dpg.add_mouse_click_handler(
+                button=dpg.mvMouseButton_Left,
+                callback=self._on_left_click,
+            )
 
         dpg.add_spacer(height=20)
         with dpg.group(horizontal=True):
@@ -249,7 +295,94 @@ class NodeEditorPage(Page):
                         dpg.add_spacer(height=6)
                     dpg.add_text(", ".join(t.value for t in port.emits))
 
+        # Register node for context-menu / delete tracking
+        self._node_map[node_tag] = node
+        self._node_dialog_map[node_tag] = dialog_tag
+
         return node_tag
+
+    # ── Right-click / context menus ────────────────────────────────────────────
+
+    def _on_right_click(self) -> None:
+        """Show the appropriate context menu on right-click inside the editor."""
+        if not self._active:
+            return
+
+        # If a node is hovered, offer node deletion
+        for tag in self._node_map:
+            if dpg.does_item_exist(tag) and dpg.get_item_state(tag).get("hovered", False):
+                self._ctx_target = (tag, self._node_map[tag])
+                self._hide_ctx_menus()
+                dpg.set_item_pos(self._node_ctx_tag, dpg.get_mouse_pos())
+                dpg.configure_item(self._node_ctx_tag, show=True)
+                return
+
+        # If the canvas is hovered and links are selected, offer link deletion
+        if not dpg.get_item_state(self._canvas_tag).get("hovered", False):
+            return
+        if dpg.get_selected_links(self._node_editor_tag):
+            self._hide_ctx_menus()
+            dpg.set_item_pos(self._link_ctx_tag, dpg.get_mouse_pos())
+            dpg.configure_item(self._link_ctx_tag, show=True)
+
+    def _on_left_click(self) -> None:
+        """Dismiss context menus when clicking outside them."""
+        if not self._active:
+            return
+        for tag in (self._node_ctx_tag, self._link_ctx_tag):
+            if dpg.does_item_exist(tag) and not dpg.get_item_state(tag).get("hovered", False):
+                dpg.configure_item(tag, show=False)
+
+    def _hide_ctx_menus(self) -> None:
+        dpg.configure_item(self._node_ctx_tag, show=False)
+        dpg.configure_item(self._link_ctx_tag, show=False)
+
+    def _on_ctx_delete_node(self) -> None:
+        dpg.configure_item(self._node_ctx_tag, show=False)
+        if self._ctx_target is not None:
+            self._delete_node(*self._ctx_target)
+            self._ctx_target = None
+
+    def _delete_node(self, node_tag: int | str, node: NodeBase) -> None:
+        """Remove a node and all its connected links from the canvas and flow."""
+        # Collect attribute tags so we can find connected links
+        attr_tags = set(dpg.get_item_children(node_tag, 1) or [])
+
+        # Delete any links that reference this node's attributes
+        for child in list(dpg.get_item_children(self._node_editor_tag, 1) or []):
+            if child in self._node_map:
+                continue  # it's a node, not a link
+            try:
+                conf = dpg.get_item_configuration(child)
+                if conf.get("attr_1") in attr_tags or conf.get("attr_2") in attr_tags:
+                    dpg.delete_item(child)
+            except Exception:
+                pass
+
+        # Clean up file dialog owned by this node (if any)
+        dialog_tag = self._node_dialog_map.pop(node_tag, None)
+        if dialog_tag is not None and dpg.does_item_exist(dialog_tag):
+            dpg.delete_item(dialog_tag)
+            try:
+                self._file_dialogs.remove(dialog_tag)
+            except ValueError:
+                pass
+
+        # Delete the visual node
+        self._node_map.pop(node_tag, None)
+        if dpg.does_item_exist(node_tag):
+            dpg.delete_item(node_tag)
+
+        # Remove from flow model
+        if self._flow is not None:
+            self._flow.remove_node(node)
+
+    def _delete_selected_links(self) -> None:
+        """Delete all currently selected links."""
+        dpg.configure_item(self._link_ctx_tag, show=False)
+        for link in dpg.get_selected_links(self._node_editor_tag):
+            if dpg.does_item_exist(link):
+                dpg.delete_item(link)
 
     # ── Link callbacks ─────────────────────────────────────────────────────────
 
@@ -272,6 +405,10 @@ class NodeEditorPage(Page):
                 dpg.delete_item(dialog_tag)
 
         self._file_dialogs.clear()
+        self._node_map.clear()
+        self._node_dialog_map.clear()
+        self._ctx_target = None
+
         if self._flow is not None:
             for node in list(self._flow.nodes):
                 self._flow.remove_node(node)

--- a/src/ui/node_editor_page.py
+++ b/src/ui/node_editor_page.py
@@ -24,6 +24,11 @@ _COL_SINK   = ((180, 100,  20, 255), (200, 120,  30, 255), (210, 130,  40, 255))
 _COL_PIN_INPUT  = ((210, 210, 210, 255), (255, 255, 255, 255))
 _COL_PIN_OUTPUT = ((220, 180,   0, 255), (240, 200,  30, 255))
 
+# ── Link colours (normal, hovered, selected) ──────────────────────────────────
+_COL_LINK          = (180, 180, 180, 255)   # neutral grey
+_COL_LINK_HOVERED  = (255, 255, 255, 255)   # bright white  – hover feedback
+_COL_LINK_SELECTED = (220, 160,   0, 255)   # gold/orange   – matches output pins
+
 
 def _make_node_theme(title, hovered, selected) -> int | str:
     with dpg.theme() as theme:
@@ -39,6 +44,15 @@ def _make_pin_theme(normal, hovered) -> int | str:
         with dpg.theme_component(dpg.mvAll):
             dpg.add_theme_color(dpg.mvNodeCol_Pin,        normal,  category=dpg.mvThemeCat_Nodes)
             dpg.add_theme_color(dpg.mvNodeCol_PinHovered, hovered, category=dpg.mvThemeCat_Nodes)
+    return theme
+
+
+def _make_editor_theme(link, hovered, selected) -> int | str:
+    with dpg.theme() as theme:
+        with dpg.theme_component(dpg.mvAll):
+            dpg.add_theme_color(dpg.mvNodeCol_Link,         link,     category=dpg.mvThemeCat_Nodes)
+            dpg.add_theme_color(dpg.mvNodeCol_LinkHovered,  hovered,  category=dpg.mvThemeCat_Nodes)
+            dpg.add_theme_color(dpg.mvNodeCol_LinkSelected, selected, category=dpg.mvThemeCat_Nodes)
     return theme
 
 
@@ -85,6 +99,7 @@ class NodeEditorPage(Page):
         self._theme_sink       = _make_node_theme(*_COL_SINK)
         self._theme_pin_input  = _make_pin_theme(*_COL_PIN_INPUT)
         self._theme_pin_output = _make_pin_theme(*_COL_PIN_OUTPUT)
+        editor_theme           = _make_editor_theme(_COL_LINK, _COL_LINK_HOVERED, _COL_LINK_SELECTED)
 
         # ── Context menus (floating windows, shown/hidden on demand) ───────────
         with dpg.window(
@@ -149,6 +164,7 @@ class NodeEditorPage(Page):
                         width=-1,
                         height=-1,
                     )
+                    dpg.bind_item_theme(self._node_editor_tag, editor_theme)
 
     # ── Palette ────────────────────────────────────────────────────────────────
 

--- a/src/ui/node_editor_page.py
+++ b/src/ui/node_editor_page.py
@@ -68,6 +68,7 @@ class NodeEditorPage(Page):
         self._node_map:        dict[int | str, NodeBase]         = {}
         self._node_dialog_map: dict[int | str, int | str | None] = {}
         self._ctx_target:      tuple[int | str, NodeBase] | None = None
+        self._ctx_links:       list[int | str]                   = []
         # Context-menu window tags (created in _build_ui)
         self._node_ctx_tag:    int | str = dpg.generate_uuid()
         self._link_ctx_tag:    int | str = dpg.generate_uuid()
@@ -317,7 +318,10 @@ class NodeEditorPage(Page):
                 dpg.configure_item(self._node_ctx_tag, show=True)
                 return
 
-        # No node hovered — offer link deletion (select a link first, then right-click)
+        # No node hovered — snapshot selected links now (selection may clear later)
+        self._ctx_links = dpg.get_selected_links(self._node_editor_tag)
+        if not self._ctx_links:
+            return
         self._hide_ctx_menus()
         dpg.set_item_pos(self._link_ctx_tag, dpg.get_mouse_pos())
         dpg.configure_item(self._link_ctx_tag, show=True)
@@ -375,11 +379,12 @@ class NodeEditorPage(Page):
             self._flow.remove_node(node)
 
     def _delete_selected_links(self) -> None:
-        """Delete all currently selected links."""
+        """Delete the links that were selected when the context menu was opened."""
         dpg.configure_item(self._link_ctx_tag, show=False)
-        for link in dpg.get_selected_links(self._node_editor_tag):
+        for link in self._ctx_links:
             if dpg.does_item_exist(link):
                 dpg.delete_item(link)
+        self._ctx_links = []
 
     # ── Link callbacks ─────────────────────────────────────────────────────────
 
@@ -405,6 +410,7 @@ class NodeEditorPage(Page):
         self._node_map.clear()
         self._node_dialog_map.clear()
         self._ctx_target = None
+        self._ctx_links = []
 
         if self._flow is not None:
             for node in list(self._flow.nodes):

--- a/src/ui/node_editor_page.py
+++ b/src/ui/node_editor_page.py
@@ -47,10 +47,10 @@ def _make_pin_theme(normal, hovered) -> int | str:
     return theme
 
 
-def _make_editor_theme(link, hovered, selected) -> int | str:
+def _make_link_theme(normal, hovered, selected) -> int | str:
     with dpg.theme() as theme:
-        with dpg.theme_component(dpg.mvAll):
-            dpg.add_theme_color(dpg.mvNodeCol_Link,         link,     category=dpg.mvThemeCat_Nodes)
+        with dpg.theme_component(dpg.mvNodeLink):
+            dpg.add_theme_color(dpg.mvNodeCol_Link,         normal,   category=dpg.mvThemeCat_Nodes)
             dpg.add_theme_color(dpg.mvNodeCol_LinkHovered,  hovered,  category=dpg.mvThemeCat_Nodes)
             dpg.add_theme_color(dpg.mvNodeCol_LinkSelected, selected, category=dpg.mvThemeCat_Nodes)
     return theme
@@ -78,6 +78,7 @@ class NodeEditorPage(Page):
         self._theme_sink:        int | str | None = None
         self._theme_pin_input:   int | str | None = None
         self._theme_pin_output:  int | str | None = None
+        self._theme_link:        int | str | None = None
         # Node tracking for delete / context-menu support
         self._node_map:        dict[int | str, NodeBase]         = {}
         self._node_dialog_map: dict[int | str, int | str | None] = {}
@@ -99,7 +100,7 @@ class NodeEditorPage(Page):
         self._theme_sink       = _make_node_theme(*_COL_SINK)
         self._theme_pin_input  = _make_pin_theme(*_COL_PIN_INPUT)
         self._theme_pin_output = _make_pin_theme(*_COL_PIN_OUTPUT)
-        editor_theme           = _make_editor_theme(_COL_LINK, _COL_LINK_HOVERED, _COL_LINK_SELECTED)
+        self._theme_link       = _make_link_theme(_COL_LINK, _COL_LINK_HOVERED, _COL_LINK_SELECTED)
 
         # ── Context menus (floating windows, shown/hidden on demand) ───────────
         with dpg.window(
@@ -164,7 +165,6 @@ class NodeEditorPage(Page):
                         width=-1,
                         height=-1,
                     )
-                    dpg.bind_item_theme(self._node_editor_tag, editor_theme)
 
     # ── Palette ────────────────────────────────────────────────────────────────
 
@@ -405,7 +405,9 @@ class NodeEditorPage(Page):
     # ── Link callbacks ─────────────────────────────────────────────────────────
 
     def _link(self, sender, app_data) -> None:
-        dpg.add_node_link(app_data[0], app_data[1], parent=sender)
+        link_tag = dpg.add_node_link(app_data[0], app_data[1], parent=sender)
+        if self._theme_link is not None:
+            dpg.bind_item_theme(link_tag, self._theme_link)
 
     def _delink(self, sender, app_data) -> None:
         dpg.delete_item(app_data)


### PR DESCRIPTION
## Summary

- **Node palette** with Search box and collapsible Sources / Filters / Sinks sections, populated automatically from `NodeRegistry` AST scan
- **Drag & drop** from palette onto the canvas; nodes are placed under the cursor (canvas offset corrected)
- **Colour scheme** — Sources: blue, Filters: green, Sinks: orange; input pins: light grey, output pins: gold; links: grey / white on hover / gold when selected
- **Right-click context menus** — right-click a node → "Delete Node" (removes node, connected links, and its file dialog); right-click canvas with a link selected → "Delete Connection(s)"
- **Grayscale filter node** added for testing
- **Version number** (0.1.0) shown in window title and start page

## Test plan

- [ ] Drag each category (Source, Filter, Sink) onto the canvas and verify correct header colour
- [ ] Connect nodes and confirm links are grey at rest, white on hover, gold when selected
- [ ] Right-click a node → Delete Node removes it and its connected links
- [ ] Click a link to select it (turns gold), right-click canvas → Delete Connection(s) removes it
- [ ] Palette search box filters buttons by name
- [ ] Clear All and Exit (via Node Editor menu) both clean up correctly

https://claude.ai/code/session_01FAWFxdtdWgssTs1VdZmGQq