### PR TITLE
Rename node_editor_theme -> dpg_node_editor_themes

### DIFF
--- a/src/ui/dpg_node_builder.py
+++ b/src/ui/dpg_node_builder.py
@@ -12,7 +12,7 @@ from ui._types import DpgTag
 
 if TYPE_CHECKING:
     from core.port import InputPort, OutputPort
-    from ui.node_editor_theme import NodeEditorTheme
+    from ui.dpg_node_editor_themes import DpgNodeEditorThemes
 
 logger = logging.getLogger(__name__)
 
@@ -47,9 +47,9 @@ class DpgNodeBuilder:
     takes a :class:`NodeParam` and register it in ``self._param_builders``.
     """
 
-    def __init__(self, node_editor_tag: DpgTag, theme: NodeEditorTheme) -> None:
+    def __init__(self, node_editor_tag: DpgTag, theme: DpgNodeEditorThemes) -> None:
         self._node_editor_tag: DpgTag = node_editor_tag
-        self._theme: NodeEditorTheme = theme
+        self._theme: DpgNodeEditorThemes = theme
 
         # Per-build scratch state, reset at the start of build().
         self._current_node: NodeBase | None = None

--- a/src/ui/dpg_node_editor_themes.py
+++ b/src/ui/dpg_node_editor_themes.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import dearpygui.dearpygui as dpg
 
 from core.node_base import NodeBase, SourceNodeBase, SinkNodeBase
+from ui._types import DpgTag
 
 # ── Colour palette ─────────────────────────────────────────────────────────────
 # Each tuple is (normal, hovered, selected) unless noted.
@@ -17,7 +18,7 @@ _PIN_OUTPUT     = ((220, 180,   0, 255), (240, 200,  30, 255))
 _LINK           = ((180, 180, 180, 255), (255, 255, 255, 255), (220, 160, 0, 255))
 
 
-class NodeEditorTheme:
+class DpgNodeEditorThemes:
     """Creates and owns all DPG theme objects used by the node editor.
 
     Must be instantiated after ``dpg.create_context()`` has been called,
@@ -25,11 +26,11 @@ class NodeEditorTheme:
 
     Usage::
 
-        theme = NodeEditorTheme()
-        theme.apply_to_node(node_tag, node)
-        theme.apply_to_input_pin(attr_tag)
-        theme.apply_to_output_pin(attr_tag)
-        theme.apply_to_link(link_tag)
+        themes = DpgNodeEditorThemes()
+        themes.apply_to_node(node_tag, node)
+        themes.apply_to_input_pin(attr_tag)
+        themes.apply_to_output_pin(attr_tag)
+        themes.apply_to_link(link_tag)
     """
 
     def __init__(self) -> None:
@@ -42,7 +43,7 @@ class NodeEditorTheme:
 
     # ── Apply helpers ──────────────────────────────────────────────────────────
 
-    def apply_to_node(self, tag: int | str, node: NodeBase) -> None:
+    def apply_to_node(self, tag: DpgTag, node: NodeBase) -> None:
         """Bind the correct header theme based on the node's category."""
         if isinstance(node, SourceNodeBase):
             theme = self._source
@@ -52,19 +53,19 @@ class NodeEditorTheme:
             theme = self._filter
         dpg.bind_item_theme(tag, theme)
 
-    def apply_to_input_pin(self, tag: int | str) -> None:
+    def apply_to_input_pin(self, tag: DpgTag) -> None:
         dpg.bind_item_theme(tag, self._pin_input)
 
-    def apply_to_output_pin(self, tag: int | str) -> None:
+    def apply_to_output_pin(self, tag: DpgTag) -> None:
         dpg.bind_item_theme(tag, self._pin_output)
 
-    def apply_to_link(self, tag: int | str) -> None:
+    def apply_to_link(self, tag: DpgTag) -> None:
         dpg.bind_item_theme(tag, self._link)
 
 
 # ── Private factory functions ──────────────────────────────────────────────────
 
-def _make_node_header_theme(title, hovered, selected) -> int | str:
+def _make_node_header_theme(title, hovered, selected) -> DpgTag:
     with dpg.theme() as theme:
         with dpg.theme_component(dpg.mvAll):
             dpg.add_theme_color(dpg.mvNodeCol_TitleBar,         title,    category=dpg.mvThemeCat_Nodes)
@@ -73,7 +74,7 @@ def _make_node_header_theme(title, hovered, selected) -> int | str:
     return theme
 
 
-def _make_pin_theme(normal, hovered) -> int | str:
+def _make_pin_theme(normal, hovered) -> DpgTag:
     with dpg.theme() as theme:
         with dpg.theme_component(dpg.mvAll):
             dpg.add_theme_color(dpg.mvNodeCol_Pin,        normal,  category=dpg.mvThemeCat_Nodes)
@@ -81,7 +82,7 @@ def _make_pin_theme(normal, hovered) -> int | str:
     return theme
 
 
-def _make_link_theme(normal, hovered, selected) -> int | str:
+def _make_link_theme(normal, hovered, selected) -> DpgTag:
     with dpg.theme() as theme:
         with dpg.theme_component(dpg.mvNodeLink):
             dpg.add_theme_color(dpg.mvNodeCol_Link,         normal,   category=dpg.mvThemeCat_Nodes)

--- a/src/ui/node_editor_page.py
+++ b/src/ui/node_editor_page.py
@@ -12,8 +12,8 @@ from core.node_base import NodeBase
 from core.node_registry import NodeEntry, NodeRegistry
 from ui._types import DpgTag
 from ui.dpg_node_builder import DpgNodeBuilder
+from ui.dpg_node_editor_themes import DpgNodeEditorThemes
 from ui.dpg_node_list_builder import DpgNodeListBuilder
-from ui.node_editor_theme import NodeEditorTheme
 from ui.page import Page
 
 logger = logging.getLogger(__name__)
@@ -35,7 +35,7 @@ class NodeEditorPage(Page):
         self._node_editor_tag: DpgTag = dpg.generate_uuid()
         self._canvas_tag:      DpgTag = dpg.generate_uuid()
         self._flow:     Flow | None    = None
-        self._theme:    NodeEditorTheme = NodeEditorTheme()
+        self._theme:    DpgNodeEditorThemes = DpgNodeEditorThemes()
         self._registry: NodeRegistry    = registry
         self._node_builder: DpgNodeBuilder = DpgNodeBuilder(self._node_editor_tag, self._theme)
 


### PR DESCRIPTION
## Summary
- Rename `src/ui/node_editor_theme.py` → `src/ui/dpg_node_editor_themes.py`, matching the `dpg_node_builder` / `dpg_node_list_builder` naming convention established in #21.
- Rename class `NodeEditorTheme` → `DpgNodeEditorThemes` (plural, since the class owns multiple theme objects: source/filter/sink headers, input/output pins, links).
- Sweep `int | str` → `DpgTag` in the renamed module for consistency with its siblings.
- Update the two import sites (`NodeEditorPage`, `DpgNodeBuilder`).

Purely a rename / type-alias refresh — no behaviour changes.

## Test plan
- [ ] `python -m py_compile src/ui/dpg_node_editor_themes.py src/ui/dpg_node_builder.py src/ui/node_editor_page.py` succeeds (done locally).
- [ ] Launch the app: start page renders, open the node editor, drop one source / one filter / one sink, connect them, and confirm headers, pins and links all show the expected colours.

Note on scope: I kept the instance attribute name `_theme` (singular) on the consumers. The class is plural because it owns several themes, but each consumer holds a single bundle — renaming the attribute felt like unrelated churn. Happy to change it if you'd prefer `_themes`.
