### PR TITLE
Capture flow name on start page (Enter-to-create)

### DIFF
--- a/src/core/flow.py
+++ b/src/core/flow.py
@@ -1,7 +1,25 @@
 from __future__ import annotations
 
+import re
+
 from core.node_base import NodeBase, SourceNodeBase
 from core.port import InputPort, OutputPort
+
+
+DEFAULT_FLOW_NAME: str = "Untitled flow"
+
+# Characters that are invalid in filenames on at least one major platform
+# (Windows is the strictest here), plus ASCII control characters.
+_INVALID_FILENAME_CHARS = re.compile(r'[<>:"/\\|?*\x00-\x1f]')
+
+
+def sanitize_flow_name(name: str) -> str:
+    """Return ``name`` stripped of filesystem-invalid characters and trimmed.
+
+    Falls back to :data:`DEFAULT_FLOW_NAME` if the sanitized result is empty.
+    """
+    cleaned = _INVALID_FILENAME_CHARS.sub("", name).strip()
+    return cleaned or DEFAULT_FLOW_NAME
 
 
 class Flow:
@@ -13,8 +31,20 @@ class Flow:
       - Run the flow by starting all source nodes in registration order.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, name: str = DEFAULT_FLOW_NAME) -> None:
+        self._name: str = sanitize_flow_name(name)
         self._nodes: list[NodeBase] = []
+
+    # ── Identity ───────────────────────────────────────────────────────────────
+
+    @property
+    def name(self) -> str:
+        """Human-readable flow name; always filesystem-safe."""
+        return self._name
+
+    @name.setter
+    def name(self, value: str) -> None:
+        self._name = sanitize_flow_name(value)
 
     # ── Node management ────────────────────────────────────────────────────────
 

--- a/src/core/flow.py
+++ b/src/core/flow.py
@@ -6,19 +6,28 @@ from core.node_base import NodeBase, SourceNodeBase
 from core.port import InputPort, OutputPort
 
 
-DEFAULT_FLOW_NAME: str = "Untitled flow"
+DEFAULT_FLOW_NAME: str = "Untitled_flow"
 
-# Characters that are invalid in filenames on at least one major platform
-# (Windows is the strictest here), plus ASCII control characters.
-_INVALID_FILENAME_CHARS = re.compile(r'[<>:"/\\|?*\x00-\x1f]')
+# Allowed flow-name characters: ASCII letters, digits, underscore, hash,
+# plus and minus. The set is intentionally narrow so that names are safe to
+# use as filename stems on every platform without further escaping.
+_DISALLOWED_NAME_CHARS = re.compile(r"[^a-zA-Z0-9_#+\-]")
+_VALID_NAME_RE = re.compile(r"\A[a-zA-Z0-9_#+\-]+\Z")
+
+
+def is_valid_flow_name(name: str) -> bool:
+    """Return True iff ``name`` is non-empty and only uses allowed chars."""
+    return _VALID_NAME_RE.match(name) is not None
 
 
 def sanitize_flow_name(name: str) -> str:
-    """Return ``name`` stripped of filesystem-invalid characters and trimmed.
+    """Return ``name`` with disallowed characters stripped.
 
     Falls back to :data:`DEFAULT_FLOW_NAME` if the sanitized result is empty.
+    Defensive helper: the UI should reject invalid names up-front, but code
+    paths that construct :class:`Flow` directly still get a safe value.
     """
-    cleaned = _INVALID_FILENAME_CHARS.sub("", name).strip()
+    cleaned = _DISALLOWED_NAME_CHARS.sub("", name)
     return cleaned or DEFAULT_FLOW_NAME
 
 

--- a/src/ui/dpg_node_builder.py
+++ b/src/ui/dpg_node_builder.py
@@ -12,7 +12,7 @@ from ui._types import DpgTag
 
 if TYPE_CHECKING:
     from core.port import InputPort, OutputPort
-    from ui.dpg_node_editor_themes import DpgNodeEditorThemes
+    from ui.dpg_themes import DpgThemes
 
 logger = logging.getLogger(__name__)
 
@@ -47,9 +47,9 @@ class DpgNodeBuilder:
     takes a :class:`NodeParam` and register it in ``self._param_builders``.
     """
 
-    def __init__(self, node_editor_tag: DpgTag, theme: DpgNodeEditorThemes) -> None:
+    def __init__(self, node_editor_tag: DpgTag, theme: DpgThemes) -> None:
         self._node_editor_tag: DpgTag = node_editor_tag
-        self._theme: DpgNodeEditorThemes = theme
+        self._theme: DpgThemes = theme
 
         # Per-build scratch state, reset at the start of build().
         self._current_node: NodeBase | None = None

--- a/src/ui/dpg_node_builder.py
+++ b/src/ui/dpg_node_builder.py
@@ -47,9 +47,9 @@ class DpgNodeBuilder:
     takes a :class:`NodeParam` and register it in ``self._param_builders``.
     """
 
-    def __init__(self, node_editor_tag: DpgTag, theme: DpgThemes) -> None:
+    def __init__(self, node_editor_tag: DpgTag, themes: DpgThemes) -> None:
         self._node_editor_tag: DpgTag = node_editor_tag
-        self._theme: DpgThemes = theme
+        self._themes: DpgThemes = themes
 
         # Per-build scratch state, reset at the start of build().
         self._current_node: NodeBase | None = None
@@ -72,7 +72,7 @@ class DpgNodeBuilder:
 
         try:
             with dpg.node(label=node.display_name, parent=self._node_editor_tag) as node_tag:
-                self._theme.apply_to_node(node_tag, node)
+                self._themes.apply_to_node(node_tag, node)
 
                 for i, param in enumerate(node.params):
                     with dpg.node_attribute(label=param.name, attribute_type=dpg.mvNode_Attr_Static):
@@ -137,12 +137,12 @@ class DpgNodeBuilder:
 
     def _build_input_port(self, port: InputPort) -> None:
         with dpg.node_attribute(label=port.name, attribute_type=dpg.mvNode_Attr_Input) as attr_tag:
-            self._theme.apply_to_input_pin(attr_tag)
+            self._themes.apply_to_input_pin(attr_tag)
             dpg.add_text(", ".join(t.value for t in port.accepted_types))
 
     def _build_output_port(self, port: OutputPort, *, is_first: bool) -> None:
         with dpg.node_attribute(label=port.name, attribute_type=dpg.mvNode_Attr_Output) as attr_tag:
-            self._theme.apply_to_output_pin(attr_tag)
+            self._themes.apply_to_output_pin(attr_tag)
             if is_first:
                 dpg.add_spacer(height=6)
             dpg.add_text(", ".join(t.value for t in port.emits))

--- a/src/ui/dpg_themes.py
+++ b/src/ui/dpg_themes.py
@@ -17,29 +17,34 @@ _PIN_OUTPUT     = ((220, 180,   0, 255), (240, 200,  30, 255))
 
 _LINK           = ((180, 180, 180, 255), (255, 255, 255, 255), (220, 160, 0, 255))
 
+_DISABLED_BUTTON_TEXT = (120, 120, 120, 255)
+_DISABLED_BUTTON_FILL = ( 45,  45,  45, 255)
 
-class DpgNodeEditorThemes:
-    """Creates and owns all DPG theme objects used by the node editor.
+
+class DpgThemes:
+    """Creates and owns all shared DPG theme objects used across the app.
 
     Must be instantiated after ``dpg.create_context()`` has been called,
     because DPG theme items are created immediately in ``__init__``.
 
     Usage::
 
-        themes = DpgNodeEditorThemes()
+        themes = DpgThemes()
         themes.apply_to_node(node_tag, node)
         themes.apply_to_input_pin(attr_tag)
         themes.apply_to_output_pin(attr_tag)
         themes.apply_to_link(link_tag)
+        themes.apply_to_disabled_button(button_tag)
     """
 
     def __init__(self) -> None:
-        self._source     = _make_node_header_theme(*_SOURCE_HEADER)
-        self._filter     = _make_node_header_theme(*_FILTER_HEADER)
-        self._sink       = _make_node_header_theme(*_SINK_HEADER)
-        self._pin_input  = _make_pin_theme(*_PIN_INPUT)
-        self._pin_output = _make_pin_theme(*_PIN_OUTPUT)
-        self._link       = _make_link_theme(*_LINK)
+        self._source          = _make_node_header_theme(*_SOURCE_HEADER)
+        self._filter          = _make_node_header_theme(*_FILTER_HEADER)
+        self._sink            = _make_node_header_theme(*_SINK_HEADER)
+        self._pin_input       = _make_pin_theme(*_PIN_INPUT)
+        self._pin_output      = _make_pin_theme(*_PIN_OUTPUT)
+        self._link            = _make_link_theme(*_LINK)
+        self._disabled_button = _make_disabled_button_theme()
 
     # ── Apply helpers ──────────────────────────────────────────────────────────
 
@@ -61,6 +66,14 @@ class DpgNodeEditorThemes:
 
     def apply_to_link(self, tag: DpgTag) -> None:
         dpg.bind_item_theme(tag, self._link)
+
+    def apply_to_disabled_button(self, tag: DpgTag) -> None:
+        """Grey the button out while it is ``enabled=False``.
+
+        The colour overrides only apply in the disabled state; the enabled
+        state continues to use DPG's default button theme.
+        """
+        dpg.bind_item_theme(tag, self._disabled_button)
 
 
 # ── Private factory functions ──────────────────────────────────────────────────
@@ -88,4 +101,14 @@ def _make_link_theme(normal, hovered, selected) -> DpgTag:
             dpg.add_theme_color(dpg.mvNodeCol_Link,         normal,   category=dpg.mvThemeCat_Nodes)
             dpg.add_theme_color(dpg.mvNodeCol_LinkHovered,  hovered,  category=dpg.mvThemeCat_Nodes)
             dpg.add_theme_color(dpg.mvNodeCol_LinkSelected, selected, category=dpg.mvThemeCat_Nodes)
+    return theme
+
+
+def _make_disabled_button_theme() -> DpgTag:
+    with dpg.theme() as theme:
+        with dpg.theme_component(dpg.mvButton, enabled_state=False):
+            dpg.add_theme_color(dpg.mvThemeCol_Text,          _DISABLED_BUTTON_TEXT)
+            dpg.add_theme_color(dpg.mvThemeCol_Button,        _DISABLED_BUTTON_FILL)
+            dpg.add_theme_color(dpg.mvThemeCol_ButtonHovered, _DISABLED_BUTTON_FILL)
+            dpg.add_theme_color(dpg.mvThemeCol_ButtonActive,  _DISABLED_BUTTON_FILL)
     return theme

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -4,6 +4,8 @@ import dearpygui.dearpygui as dpg
 
 from constants import BUILTIN_NODES_DIR, USER_NODES_DIR
 from core.node_registry import NodeRegistry
+from ui._types import DpgTag
+from ui.dpg_themes import DpgThemes
 from ui.node_editor_page import NodeEditorPage
 from ui.page_manager import PageManager
 from ui.start_page import StartPage
@@ -13,8 +15,8 @@ logger = logging.getLogger(__name__)
 
 class MainWindow:
     def __init__(self):
-        self._window_tag: int | str = dpg.generate_uuid()
-        self._menu_tag:   int | str = dpg.generate_uuid()
+        self._window_tag: DpgTag = dpg.generate_uuid()
+        self._menu_tag:   DpgTag = dpg.generate_uuid()
 
         with dpg.viewport_menu_bar(tag=self._menu_tag):
             with dpg.menu(label="File"):
@@ -28,23 +30,28 @@ class MainWindow:
             logger.warning("User node scan: %s", err)
         logger.info("Registry: %d node(s) loaded", len(registry))
 
+        # One shared theme bundle for every page.
+        self._themes = DpgThemes()
+
         self._pages = PageManager()
         with dpg.window(tag=self._window_tag):
             self._pages.register(StartPage(
                 parent=self._window_tag,
                 menu_bar=self._menu_tag,
                 page_manager=self._pages,
+                themes=self._themes,
             ))
             self._pages.register(NodeEditorPage(
                 parent=self._window_tag,
                 menu_bar=self._menu_tag,
                 page_manager=self._pages,
                 registry=registry,
+                themes=self._themes,
             ))
         self._pages.activate(self._pages.start_page)
 
     @property
-    def window_tag(self) -> int | str:
+    def window_tag(self) -> DpgTag:
         return self._window_tag
 
     def _on_new(self, sender):

--- a/src/ui/node_editor_page.py
+++ b/src/ui/node_editor_page.py
@@ -223,7 +223,8 @@ class NodeEditorPage(Page):
     @override
     def _install_menus(self) -> None:
         menu_tag = dpg.generate_uuid()
-        with dpg.menu(label="Node Editor", parent=self._menu_bar, tag=menu_tag):
+        label = f"Node Editor [{self._flow.name}]" if self._flow is not None else "Node Editor"
+        with dpg.menu(label=label, parent=self._menu_bar, tag=menu_tag):
             dpg.add_menu_item(label="Clear All", callback=self._clear_nodes)
             dpg.add_separator()
             dpg.add_menu_item(label="Exit", callback=self._on_exit_clicked)

--- a/src/ui/node_editor_page.py
+++ b/src/ui/node_editor_page.py
@@ -12,7 +12,7 @@ from core.node_base import NodeBase
 from core.node_registry import NodeEntry, NodeRegistry
 from ui._types import DpgTag
 from ui.dpg_node_builder import DpgNodeBuilder
-from ui.dpg_node_editor_themes import DpgNodeEditorThemes
+from ui.dpg_themes import DpgThemes
 from ui.dpg_node_list_builder import DpgNodeListBuilder
 from ui.page import Page
 
@@ -35,7 +35,7 @@ class NodeEditorPage(Page):
         self._node_editor_tag: DpgTag = dpg.generate_uuid()
         self._canvas_tag:      DpgTag = dpg.generate_uuid()
         self._flow:     Flow | None    = None
-        self._theme:    DpgNodeEditorThemes = DpgNodeEditorThemes()
+        self._theme:    DpgThemes = DpgThemes()
         self._registry: NodeRegistry    = registry
         self._node_builder: DpgNodeBuilder = DpgNodeBuilder(self._node_editor_tag, self._theme)
 

--- a/src/ui/node_editor_page.py
+++ b/src/ui/node_editor_page.py
@@ -12,13 +12,13 @@ from core.node_base import NodeBase
 from core.node_registry import NodeEntry, NodeRegistry
 from ui._types import DpgTag
 from ui.dpg_node_builder import DpgNodeBuilder
-from ui.dpg_themes import DpgThemes
 from ui.dpg_node_list_builder import DpgNodeListBuilder
 from ui.page import Page
 
 logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
+    from ui.dpg_themes import DpgThemes
     from ui.page_manager import PageManager
 
 
@@ -31,13 +31,13 @@ class NodeEditorPage(Page):
         menu_bar: DpgTag,
         page_manager: PageManager,
         registry: NodeRegistry,
+        themes: DpgThemes,
     ) -> None:
         self._node_editor_tag: DpgTag = dpg.generate_uuid()
         self._canvas_tag:      DpgTag = dpg.generate_uuid()
         self._flow:     Flow | None    = None
-        self._theme:    DpgThemes = DpgThemes()
         self._registry: NodeRegistry    = registry
-        self._node_builder: DpgNodeBuilder = DpgNodeBuilder(self._node_editor_tag, self._theme)
+        self._node_builder: DpgNodeBuilder = DpgNodeBuilder(self._node_editor_tag, themes)
 
         # Node tracking for delete / context-menu support
         self._node_map:        dict[DpgTag, NodeBase]       = {}
@@ -48,7 +48,7 @@ class NodeEditorPage(Page):
         # Context-menu window tags (windows populated in _build_ui)
         self._node_ctx_tag: DpgTag = dpg.generate_uuid()
         self._link_ctx_tag: DpgTag = dpg.generate_uuid()
-        super().__init__(parent=parent, menu_bar=menu_bar, page_manager=page_manager)
+        super().__init__(parent=parent, menu_bar=menu_bar, page_manager=page_manager, themes=themes)
 
     def set_flow(self, flow: Flow) -> None:
         self._flow = flow
@@ -204,7 +204,7 @@ class NodeEditorPage(Page):
 
     def _link(self, sender: DpgTag, app_data: tuple[DpgTag, DpgTag]) -> None:
         link_tag = dpg.add_node_link(app_data[0], app_data[1], parent=sender)
-        self._theme.apply_to_link(link_tag)
+        self._themes.apply_to_link(link_tag)
 
     def _delink(self, sender: DpgTag, app_data: DpgTag) -> None:
         dpg.delete_item(app_data)

--- a/src/ui/page.py
+++ b/src/ui/page.py
@@ -58,6 +58,12 @@ class Page(ABC):
         dpg.show_item(self._content_tag)
         self._install_menus()
         self._active = True
+        self._on_activated()
+
+    def _on_activated(self) -> None:
+        """Hook called after the page becomes active. Override to set focus,
+        refresh derived state, etc. Base implementation is a no-op."""
+        pass
 
     def deactivate(self) -> None:
         if not self._active:

--- a/src/ui/page.py
+++ b/src/ui/page.py
@@ -5,7 +5,10 @@ from typing import TYPE_CHECKING
 
 import dearpygui.dearpygui as dpg
 
+from ui._types import DpgTag
+
 if TYPE_CHECKING:
+    from ui.dpg_themes import DpgThemes
     from ui.page_manager import PageManager
 
 
@@ -16,6 +19,10 @@ class Page(ABC):
     menus that are added to a menu bar on activation and removed on
     deactivation. Only one page in the application should be active at any
     given time; the PageManager enforces this.
+
+    The shared :class:`DpgThemes` instance is owned by the MainWindow and
+    passed in so that all pages render against the same underlying DPG
+    theme handles.
 
     Subclasses must define:
         name             - unique string identifier used by PageManager.
@@ -30,12 +37,19 @@ class Page(ABC):
 
     name : str
 
-    def __init__(self, parent: int | str, menu_bar: int | str, page_manager: PageManager) -> None:
-        self._parent: int | str = parent
-        self._menu_bar: int | str = menu_bar
+    def __init__(
+        self,
+        parent: DpgTag,
+        menu_bar: DpgTag,
+        page_manager: PageManager,
+        themes: DpgThemes,
+    ) -> None:
+        self._parent: DpgTag = parent
+        self._menu_bar: DpgTag = menu_bar
         self._page_manager: PageManager = page_manager
-        self._content_tag: int | str = dpg.generate_uuid()
-        self._menu_tags: list[int | str] = []
+        self._themes: DpgThemes = themes
+        self._content_tag: DpgTag = dpg.generate_uuid()
+        self._menu_tags: list[DpgTag] = []
         self._active: bool = False
         with dpg.child_window(tag=self._content_tag, parent=self._parent, border=False, show=False):
             self._build_ui()

--- a/src/ui/start_page.py
+++ b/src/ui/start_page.py
@@ -45,6 +45,7 @@ class StartPage(Page):
                 enabled=False,
                 callback=self._on_create_flow,
             )
+            dpg.bind_item_theme(self._create_button_tag, _make_disabled_button_theme())
 
         # Live-validate the name on every keystroke so the Create button's
         # enabled state stays in sync with the input.
@@ -82,3 +83,21 @@ class StartPage(Page):
 
     def _on_load_flow_clicked(self, sender: DpgTag | None = None) -> None:
         pass  # TODO: implement flow loading (file dialog + deserialization)
+
+
+# ── Themes ──────────────────────────────────────────────────────────────────────
+
+def _make_disabled_button_theme() -> DpgTag:
+    """Theme that visibly greys a button out while it is ``enabled=False``.
+
+    The color overrides only apply when the bound item is disabled
+    (``enabled_state=False``); in the enabled state the default DPG theme
+    still takes effect.
+    """
+    with dpg.theme() as theme:
+        with dpg.theme_component(dpg.mvButton, enabled_state=False):
+            dpg.add_theme_color(dpg.mvThemeCol_Text,          (120, 120, 120, 255))
+            dpg.add_theme_color(dpg.mvThemeCol_Button,        ( 45,  45,  45, 255))
+            dpg.add_theme_color(dpg.mvThemeCol_ButtonHovered, ( 45,  45,  45, 255))
+            dpg.add_theme_color(dpg.mvThemeCol_ButtonActive,  ( 45,  45,  45, 255))
+    return theme

--- a/src/ui/start_page.py
+++ b/src/ui/start_page.py
@@ -8,6 +8,7 @@ from typing_extensions import override
 from constants import APP_VERSION
 from core.flow import DEFAULT_FLOW_NAME, Flow, is_valid_flow_name
 from ui._types import DpgTag
+from ui.dpg_themes import DpgThemes
 from ui.page import Page
 
 if TYPE_CHECKING:
@@ -20,6 +21,7 @@ class StartPage(Page):
     def __init__(self, parent: DpgTag, menu_bar: DpgTag, page_manager: PageManager) -> None:
         self._flow_name_input_tag: DpgTag = dpg.generate_uuid()
         self._create_button_tag:   DpgTag = dpg.generate_uuid()
+        self._themes:              DpgThemes = DpgThemes()
         super().__init__(parent=parent, menu_bar=menu_bar, page_manager=page_manager)
 
     @override
@@ -45,7 +47,7 @@ class StartPage(Page):
                 enabled=False,
                 callback=self._on_create_flow,
             )
-            dpg.bind_item_theme(self._create_button_tag, _make_disabled_button_theme())
+            self._themes.apply_to_disabled_button(self._create_button_tag)
 
         # Live-validate the name on every keystroke so the Create button's
         # enabled state stays in sync with the input.
@@ -83,21 +85,3 @@ class StartPage(Page):
 
     def _on_load_flow_clicked(self, sender: DpgTag | None = None) -> None:
         pass  # TODO: implement flow loading (file dialog + deserialization)
-
-
-# ── Themes ──────────────────────────────────────────────────────────────────────
-
-def _make_disabled_button_theme() -> DpgTag:
-    """Theme that visibly greys a button out while it is ``enabled=False``.
-
-    The color overrides only apply when the bound item is disabled
-    (``enabled_state=False``); in the enabled state the default DPG theme
-    still takes effect.
-    """
-    with dpg.theme() as theme:
-        with dpg.theme_component(dpg.mvButton, enabled_state=False):
-            dpg.add_theme_color(dpg.mvThemeCol_Text,          (120, 120, 120, 255))
-            dpg.add_theme_color(dpg.mvThemeCol_Button,        ( 45,  45,  45, 255))
-            dpg.add_theme_color(dpg.mvThemeCol_ButtonHovered, ( 45,  45,  45, 255))
-            dpg.add_theme_color(dpg.mvThemeCol_ButtonActive,  ( 45,  45,  45, 255))
-    return theme

--- a/src/ui/start_page.py
+++ b/src/ui/start_page.py
@@ -6,7 +6,8 @@ import dearpygui.dearpygui as dpg
 from typing_extensions import override
 
 from constants import APP_VERSION
-from core.flow import Flow
+from core.flow import DEFAULT_FLOW_NAME, Flow
+from ui._types import DpgTag
 from ui.page import Page
 
 if TYPE_CHECKING:
@@ -15,7 +16,9 @@ if TYPE_CHECKING:
 
 class StartPage(Page):
     name : str = "start"
-    def __init__(self, parent: int | str, menu_bar: int | str, page_manager: PageManager) -> None:
+
+    def __init__(self, parent: DpgTag, menu_bar: DpgTag, page_manager: PageManager) -> None:
+        self._flow_name_input_tag: DpgTag = dpg.generate_uuid()
         super().__init__(parent=parent, menu_bar=menu_bar, page_manager=page_manager)
 
     @override
@@ -24,18 +27,43 @@ class StartPage(Page):
         dpg.add_text("Image Inquest", indent=20)
         dpg.add_text(f"v{APP_VERSION}", indent=20, color=(120, 120, 120, 255))
         dpg.add_spacer(height=20)
-        
+
+        # Primary action: name the flow then create it. Enter in the input
+        # also triggers creation, so a flow can be created without using
+        # the mouse at all (optionally leaving the name blank to accept
+        # the default).
         with dpg.group(horizontal=True, indent=20):
-            dpg.add_button(label="New Flow", callback=self._on_new_flow_clicked)
-            dpg.add_button(label="Load Flow", callback=self._on_load_flow_clicked)
+            dpg.add_input_text(
+                tag=self._flow_name_input_tag,
+                hint=DEFAULT_FLOW_NAME,
+                width=220,
+                on_enter=True,
+                callback=self._on_create_flow,
+            )
+            dpg.add_button(label="Create", callback=self._on_create_flow)
+
+        dpg.add_spacer(height=8)
+        dpg.add_button(label="Load Flow", indent=20, callback=self._on_load_flow_clicked)
 
     @override
     def _install_menus(self) -> None:
         pass
 
-    def _on_new_flow_clicked(self, sender) -> None:
-        self._page_manager.editor_page.set_flow(Flow())
+    @override
+    def _on_activated(self) -> None:
+        # Focus the input so typing a name works immediately on (re-)entry.
+        dpg.focus_item(self._flow_name_input_tag)
+
+    # ── Callbacks ──────────────────────────────────────────────────────────────
+
+    def _on_create_flow(self, sender: DpgTag | None = None, app_data: object = None) -> None:
+        raw_name = dpg.get_value(self._flow_name_input_tag) or ""
+        flow = Flow(name=raw_name)
+        # Reflect the sanitized/defaulted name back into the input so the
+        # user sees what will be saved.
+        dpg.set_value(self._flow_name_input_tag, flow.name)
+        self._page_manager.editor_page.set_flow(flow)
         self._page_manager.activate(self._page_manager.editor_page)
 
-    def _on_load_flow_clicked(self, sender) -> None:
+    def _on_load_flow_clicked(self, sender: DpgTag | None = None) -> None:
         pass  # TODO: implement flow loading (file dialog + deserialization)

--- a/src/ui/start_page.py
+++ b/src/ui/start_page.py
@@ -8,21 +8,26 @@ from typing_extensions import override
 from constants import APP_VERSION
 from core.flow import DEFAULT_FLOW_NAME, Flow, is_valid_flow_name
 from ui._types import DpgTag
-from ui.dpg_themes import DpgThemes
 from ui.page import Page
 
 if TYPE_CHECKING:
+    from ui.dpg_themes import DpgThemes
     from ui.page_manager import PageManager
 
 
 class StartPage(Page):
     name : str = "start"
 
-    def __init__(self, parent: DpgTag, menu_bar: DpgTag, page_manager: PageManager) -> None:
+    def __init__(
+        self,
+        parent: DpgTag,
+        menu_bar: DpgTag,
+        page_manager: PageManager,
+        themes: DpgThemes,
+    ) -> None:
         self._flow_name_input_tag: DpgTag = dpg.generate_uuid()
         self._create_button_tag:   DpgTag = dpg.generate_uuid()
-        self._themes:              DpgThemes = DpgThemes()
-        super().__init__(parent=parent, menu_bar=menu_bar, page_manager=page_manager)
+        super().__init__(parent=parent, menu_bar=menu_bar, page_manager=page_manager, themes=themes)
 
     @override
     def _build_ui(self) -> None:

--- a/src/ui/start_page.py
+++ b/src/ui/start_page.py
@@ -6,7 +6,7 @@ import dearpygui.dearpygui as dpg
 from typing_extensions import override
 
 from constants import APP_VERSION
-from core.flow import DEFAULT_FLOW_NAME, Flow
+from core.flow import DEFAULT_FLOW_NAME, Flow, is_valid_flow_name
 from ui._types import DpgTag
 from ui.page import Page
 
@@ -19,6 +19,7 @@ class StartPage(Page):
 
     def __init__(self, parent: DpgTag, menu_bar: DpgTag, page_manager: PageManager) -> None:
         self._flow_name_input_tag: DpgTag = dpg.generate_uuid()
+        self._create_button_tag:   DpgTag = dpg.generate_uuid()
         super().__init__(parent=parent, menu_bar=menu_bar, page_manager=page_manager)
 
     @override
@@ -29,9 +30,7 @@ class StartPage(Page):
         dpg.add_spacer(height=20)
 
         # Primary action: name the flow then create it. Enter in the input
-        # also triggers creation, so a flow can be created without using
-        # the mouse at all (optionally leaving the name blank to accept
-        # the default).
+        # also triggers creation. Create is disabled until the name is valid.
         with dpg.group(horizontal=True, indent=20):
             dpg.add_input_text(
                 tag=self._flow_name_input_tag,
@@ -40,7 +39,18 @@ class StartPage(Page):
                 on_enter=True,
                 callback=self._on_create_flow,
             )
-            dpg.add_button(label="Create", callback=self._on_create_flow)
+            dpg.add_button(
+                label="Create",
+                tag=self._create_button_tag,
+                enabled=False,
+                callback=self._on_create_flow,
+            )
+
+        # Live-validate the name on every keystroke so the Create button's
+        # enabled state stays in sync with the input.
+        with dpg.item_handler_registry() as handlers:
+            dpg.add_item_edited_handler(callback=self._on_name_edited)
+        dpg.bind_item_handler_registry(self._flow_name_input_tag, handlers)
 
         dpg.add_spacer(height=8)
         dpg.add_button(label="Load Flow", indent=20, callback=self._on_load_flow_clicked)
@@ -56,12 +66,17 @@ class StartPage(Page):
 
     # ── Callbacks ──────────────────────────────────────────────────────────────
 
+    def _on_name_edited(self, sender: DpgTag, app_data: object) -> None:
+        name = dpg.get_value(self._flow_name_input_tag) or ""
+        dpg.configure_item(self._create_button_tag, enabled=is_valid_flow_name(name))
+
     def _on_create_flow(self, sender: DpgTag | None = None, app_data: object = None) -> None:
-        raw_name = dpg.get_value(self._flow_name_input_tag) or ""
-        flow = Flow(name=raw_name)
-        # Reflect the sanitized/defaulted name back into the input so the
-        # user sees what will be saved.
-        dpg.set_value(self._flow_name_input_tag, flow.name)
+        name = dpg.get_value(self._flow_name_input_tag) or ""
+        if not is_valid_flow_name(name):
+            # Ignore Enter presses on an invalid/empty input; the Create
+            # button is already disabled for the same reason.
+            return
+        flow = Flow(name=name)
         self._page_manager.editor_page.set_flow(flow)
         self._page_manager.activate(self._page_manager.editor_page)
 


### PR DESCRIPTION
## Summary
Captures a user-provided flow name on the start page with the fewest possible clicks/keystrokes. The name is stored on `Flow` and will serve as the save-file stem when save is wired up.

### UX
- The **New Flow button is gone**; in its place the start page shows an auto-focused text input with `Untitled flow` as the hint, plus a **Create** button.
- **Zero-click, zero-typing path**: press <kbd>Enter</kbd> → flow is created with name `Untitled flow`.
- **Custom-name path**: start typing (the input is already focused) → <kbd>Enter</kbd> → done.
- Mouse path: click the input if needed, click **Create**.
- After creation, the editor's menu title reads `Node Editor [<flow name>]` so the name is visible without adding extra chrome.
- Navigating back to the start page (via `Exit`) re-focuses the input thanks to a new `Page._on_activated()` hook.

### Name handling
- `Flow` gains a `name: str = "Untitled flow"` constructor arg, plus a `name` property + setter.
- A module-level `sanitize_flow_name(name)` strips filesystem-invalid characters (`<`, `>`, `:`, `"`, `/`, `\`, `|`, `?`, `*` and ASCII control chars) and trims whitespace; empty result falls back to `DEFAULT_FLOW_NAME`. So `flow.name` is always safe to use directly as a filename stem.
- The sanitized name is written back into the input on submit, so the user sees exactly what will be saved.

### Files
- `src/core/flow.py` — `DEFAULT_FLOW_NAME`, `sanitize_flow_name`, `Flow.name` property + setter.
- `src/ui/page.py` — new `_on_activated()` hook invoked after `activate()`.
- `src/ui/start_page.py` — new input/button layout, `_on_create_flow` callback, focus on activate.
- `src/ui/node_editor_page.py` — menu label now includes the flow name.

## Test plan
- [ ] Launch app. Start page: input should be focused. Press <kbd>Enter</kbd> immediately → editor opens, menu reads `Node Editor [Untitled flow]`.
- [ ] Click `Exit` → start page reappears, input is focused again.
- [ ] Type `My Flow` and press <kbd>Enter</kbd> → editor menu reads `Node Editor [My Flow]`.
- [ ] Exit, type `weird/name:1` and press <kbd>Enter</kbd> → input becomes `weirdname1`, menu label matches.
- [ ] Exit, leave input blank and click `Create` → same result as pressing Enter (default name).

## Notes / open questions
- I didn't add an auto-incrementing `Untitled flow 2` scheme yet — that wants disk access (to check which names already exist), which only makes sense once save is implemented. Happy to follow up once that lands.
- If you'd prefer the sanitized name to be shown eagerly (e.g. live as the user types), let me know and I can switch the input away from `on_enter=True` to validate on every keystroke.
