### PR TITLE
Add Save button: persist flow as JSON to /flow/&lt;name&gt;.json

### DIFF
--- a/src/constants.py
+++ b/src/constants.py
@@ -13,6 +13,9 @@ BUILTIN_NODES_DIR: Path = Path(__file__).parent / "nodes"
 INPUT_DIR:  Path = Path(__file__).parent.parent / "input"
 OUTPUT_DIR: Path = Path(__file__).parent.parent / "output"
 
+# Folder where saved flows are written (one JSON file per flow).
+FLOW_DIR:   Path = Path(__file__).parent.parent / "flow"
+
 # User-defined nodes (~/.image-inquest/user_nodes/)
 USER_CONFIG_DIR: Path = Path.home() / ".image-inquest"
 USER_NODES_DIR:  Path = USER_CONFIG_DIR / "user_nodes"

--- a/src/ui/flow_file_dialog.py
+++ b/src/ui/flow_file_dialog.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from typing import Callable
+
+import dearpygui.dearpygui as dpg
+
+from ui._types import DpgTag
+
+#: Extension used for saved flow files. Centralised so Save, the Open
+#: dialog filter, and any future importers stay in sync.
+FLOW_FILE_EXTENSION: str = ".flowjs"
+
+
+def make_open_flow_dialog(tag: DpgTag, callback: Callable[..., None]) -> None:
+    """Create a persistent, initially-hidden DPG file dialog for picking a flow.
+
+    The dialog is filtered to :data:`FLOW_FILE_EXTENSION`. The caller is
+    responsible for showing it (``dpg.show_item(tag)``) and for setting
+    ``default_path`` to the desired starting directory before doing so.
+    """
+    with dpg.file_dialog(
+        label="Open Flow",
+        tag=tag,
+        callback=callback,
+        show=False,
+        modal=True,
+        width=700,
+        height=400,
+    ):
+        dpg.add_file_extension(FLOW_FILE_EXTENSION, color=(0, 200, 255, 255), custom_text="Flow")

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -18,10 +18,8 @@ class MainWindow:
         self._window_tag: DpgTag = dpg.generate_uuid()
         self._menu_tag:   DpgTag = dpg.generate_uuid()
 
-        with dpg.viewport_menu_bar(tag=self._menu_tag):
-            with dpg.menu(label="File"):
-                dpg.add_menu_item(label="New",     callback=self._on_new)
-                dpg.add_menu_item(label="Save As", callback=self._on_save)
+        # Empty viewport menu bar; pages populate it on activation.
+        dpg.add_viewport_menu_bar(tag=self._menu_tag)
 
         registry = NodeRegistry()
         for err in registry.scan_builtin(BUILTIN_NODES_DIR):
@@ -53,9 +51,3 @@ class MainWindow:
     @property
     def window_tag(self) -> DpgTag:
         return self._window_tag
-
-    def _on_new(self, sender):
-        logger.debug("File > New")
-
-    def _on_save(self, sender):
-        logger.debug("File > Save As")

--- a/src/ui/node_editor_page.py
+++ b/src/ui/node_editor_page.py
@@ -278,7 +278,7 @@ class NodeEditorPage(Page):
             dpg.add_menu_item(label="Open",      callback=self._on_open_flow)
             dpg.add_menu_item(label="Clear All", callback=self._clear_nodes)
             dpg.add_separator()
-            dpg.add_menu_item(label="Exit", callback=self._on_exit_clicked)
+            dpg.add_menu_item(label="Back",      callback=self._on_back_clicked)
         self._menu_tags.append(self._editor_menu_tag)
 
     def _menu_label(self) -> str:
@@ -520,8 +520,8 @@ class NodeEditorPage(Page):
 
     # ── Button / menu callbacks ────────────────────────────────────────────────
 
-    def _on_exit_clicked(self, sender: DpgTag | None = None) -> None:
-        logger.info("Exiting node editor")
+    def _on_back_clicked(self, sender: DpgTag | None = None) -> None:
+        logger.info("Returning to start page")
         self._clear_nodes()
         self._page_manager.activate(self._page_manager.start_page)
 

--- a/src/ui/node_editor_page.py
+++ b/src/ui/node_editor_page.py
@@ -58,8 +58,13 @@ class NodeEditorPage(Page):
         self._ctx_links:       list[DpgTag]                 = []
 
         # Context-menu window tags (windows populated in _build_ui)
-        self._node_ctx_tag: DpgTag = dpg.generate_uuid()
-        self._link_ctx_tag: DpgTag = dpg.generate_uuid()
+        self._node_ctx_tag:    DpgTag = dpg.generate_uuid()
+        self._link_ctx_tag:    DpgTag = dpg.generate_uuid()
+        # The Node Editor menu is re-created on every activation, but we
+        # keep a stable tag so the label can be refreshed in-place when
+        # the flow is swapped out (e.g. after an Open).
+        self._editor_menu_tag: DpgTag = dpg.generate_uuid()
+        self._open_dialog_tag: DpgTag = dpg.generate_uuid()
         super().__init__(parent=parent, menu_bar=menu_bar, page_manager=page_manager, themes=themes)
 
     def set_flow(self, flow: Flow) -> None:
@@ -82,10 +87,11 @@ class NodeEditorPage(Page):
             with dpg.group():
                 with dpg.group(horizontal=True):
                     dpg.add_button(label="Save",      callback=self._save_flow)
+                    dpg.add_button(label="Open",      callback=self._on_open_flow)
                     dpg.add_button(label="Clear All", callback=self._clear_nodes)
                     dpg.add_spacer(width=16)
-                    # Status readout updated by _save_flow. Empty until the
-                    # first save attempt.
+                    # Status readout updated by _save_flow / _load_flow.
+                    # Empty until the first save or open attempt.
                     dpg.add_text("", tag=self._save_status_tag)
 
                 with dpg.child_window(
@@ -101,6 +107,18 @@ class NodeEditorPage(Page):
                         delink_callback=self._delink,
                         width=-1,
                         height=-1)
+
+        # Persistent file dialog used by the Open button.
+        with dpg.file_dialog(
+            label="Open Flow",
+            tag=self._open_dialog_tag,
+            callback=self._on_flow_file_selected,
+            show=False,
+            modal=True,
+            width=700,
+            height=400,
+        ):
+            dpg.add_file_extension(".json", color=(0, 200, 255, 255), custom_text="Flow JSON")
 
     @staticmethod
     def _build_ctx_menu(tag: DpgTag, item_label: str, callback: Callable[..., None]) -> None:
@@ -255,19 +273,28 @@ class NodeEditorPage(Page):
 
         self._ctx_target = None
         self._ctx_links = []
+        # Wipe any stale save-status message so the readout matches the canvas.
+        self._set_save_status("", _SAVE_OK_COLOR)
 
     # ── Menu ───────────────────────────────────────────────────────────────────
 
     @override
     def _install_menus(self) -> None:
-        menu_tag = dpg.generate_uuid()
-        label = f"Node Editor [{self._flow.name}]" if self._flow is not None else "Node Editor"
-        with dpg.menu(label=label, parent=self._menu_bar, tag=menu_tag):
+        with dpg.menu(label=self._menu_label(), parent=self._menu_bar, tag=self._editor_menu_tag):
             dpg.add_menu_item(label="Save",      callback=self._save_flow)
+            dpg.add_menu_item(label="Open",      callback=self._on_open_flow)
             dpg.add_menu_item(label="Clear All", callback=self._clear_nodes)
             dpg.add_separator()
             dpg.add_menu_item(label="Exit", callback=self._on_exit_clicked)
-        self._menu_tags.append(menu_tag)
+        self._menu_tags.append(self._editor_menu_tag)
+
+    def _menu_label(self) -> str:
+        return f"Node Editor [{self._flow.name}]" if self._flow is not None else "Node Editor"
+
+    def _refresh_menu_label(self) -> None:
+        """Re-apply the menu label after self._flow has changed."""
+        if dpg.does_item_exist(self._editor_menu_tag):
+            dpg.configure_item(self._editor_menu_tag, label=self._menu_label())
 
     # ── Save ───────────────────────────────────────────────────────────────────
 
@@ -368,6 +395,135 @@ class NodeEditorPage(Page):
                 "dst_input":  dst[2],
             })
         return result
+
+    # ── Open ───────────────────────────────────────────────────────────────────
+
+    def _on_open_flow(self, *_: object) -> None:
+        """Show the Open-Flow file dialog, seeded at FLOW_DIR."""
+        FLOW_DIR.mkdir(parents=True, exist_ok=True)
+        dpg.configure_item(self._open_dialog_tag, default_path=str(FLOW_DIR))
+        dpg.show_item(self._open_dialog_tag)
+
+    def _on_flow_file_selected(self, sender: DpgTag, app_data: dict) -> None:
+        path_str = app_data.get("file_path_name", "")
+        if not path_str:
+            return
+        self._load_flow(Path(path_str))
+
+    def _load_flow(self, path: Path) -> None:
+        """Parse ``path`` as flow JSON and rebuild the editor to match."""
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as err:
+            logger.exception("Failed to read flow %s", path)
+            self._set_save_status(f"Open failed ({err.__class__.__name__})", _SAVE_FAIL_COLOR)
+            return
+
+        version = data.get("version")
+        if version != _FLOW_FORMAT_VERSION:
+            logger.warning("Flow %s has unsupported version %r", path, version)
+            self._set_save_status(f"Open failed (unsupported version {version!r})",
+                                  _SAVE_FAIL_COLOR)
+            return
+
+        # Replace the current canvas and flow.
+        self._clear_nodes()
+        flow = Flow(name=data.get("name", path.stem))
+        self.set_flow(flow)
+        self._refresh_menu_label()
+
+        # Materialise each node, remembering the JSON-id → (node_tag, NodeBase)
+        # mapping so connections can be resolved below.
+        id_to_node: dict[int, tuple[DpgTag, NodeBase]] = {}
+        for entry in data.get("nodes", []):
+            built = self._instantiate_node(entry)
+            if built is None:
+                continue
+            node, position = built
+            flow.add_node(node)
+            node_tag = self._add_visual_node(node)
+            dpg.set_item_pos(node_tag, list(position))
+            id_to_node[entry["id"]] = (node_tag, node)
+
+        # Restore connections as DPG links. Flow.connect is not yet wired
+        # from the UI, so we intentionally mirror the save-side behaviour
+        # and keep link state in DPG alone.
+        for conn in data.get("connections", []):
+            self._restore_connection(conn, id_to_node)
+
+        logger.info("Loaded flow from %s", path)
+        self._set_save_status(
+            f"Loaded {self._display_path(path)} at {datetime.now().strftime('%H:%M:%S')}",
+            _SAVE_OK_COLOR,
+        )
+
+    def _instantiate_node(self, entry: dict) -> tuple[NodeBase, tuple[float, float]] | None:
+        """Construct a NodeBase from a serialized node entry.
+
+        Returns None (and logs) if the module/class is unknown, so loading
+        can proceed with the remaining nodes instead of failing the whole
+        flow.
+        """
+        module_name = entry.get("module", "")
+        class_name  = entry.get("class", "")
+        try:
+            module = importlib.import_module(module_name)
+            cls    = getattr(module, class_name)
+        except (ImportError, AttributeError):
+            logger.exception("Cannot resolve node %s.%s", module_name, class_name)
+            return None
+
+        try:
+            node: NodeBase = cls()
+        except Exception:
+            logger.exception("Failed to instantiate %s.%s", module_name, class_name)
+            return None
+
+        for name, value in (entry.get("params") or {}).items():
+            try:
+                setattr(node, name, value)
+            except Exception:
+                logger.warning("Ignoring param %s on %s.%s (%r)",
+                               name, module_name, class_name, value)
+
+        pos = entry.get("position") or [0.0, 0.0]
+        return node, (float(pos[0]), float(pos[1]))
+
+    def _restore_connection(
+        self,
+        conn: dict,
+        id_to_node: dict[int, tuple[DpgTag, NodeBase]],
+    ) -> None:
+        src = id_to_node.get(conn.get("src_node"))
+        dst = id_to_node.get(conn.get("dst_node"))
+        if src is None or dst is None:
+            logger.debug("Skipping connection with unknown endpoint: %s", conn)
+            return
+        src_tag, src_node = src
+        dst_tag, dst_node = dst
+        src_attrs = self._port_attrs(src_tag, src_node, "output")
+        dst_attrs = self._port_attrs(dst_tag, dst_node, "input")
+        try:
+            src_attr = src_attrs[conn["src_output"]]
+            dst_attr = dst_attrs[conn["dst_input"]]
+        except (IndexError, KeyError):
+            logger.warning("Skipping connection with out-of-range port index: %s", conn)
+            return
+        link_tag = dpg.add_node_link(src_attr, dst_attr, parent=self._node_editor_tag)
+        self._themes.apply_to_link(link_tag)
+
+    def _port_attrs(self, node_tag: DpgTag, node: NodeBase, kind: _PortKind) -> list[DpgTag]:
+        """Return the ordered DPG attr tags for a node's input or output ports.
+
+        Mirrors the ordering in _index_node_attrs: params, then inputs,
+        then outputs.
+        """
+        children = dpg.get_item_children(node_tag, 1) or []
+        params_len = len(node.params)
+        inputs_len = len(node.inputs)
+        if kind == "input":
+            return list(children[params_len : params_len + inputs_len])
+        return list(children[params_len + inputs_len : params_len + inputs_len + len(node.outputs)])
 
     # ── Button / menu callbacks ────────────────────────────────────────────────
 

--- a/src/ui/node_editor_page.py
+++ b/src/ui/node_editor_page.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import importlib
 import json
 import logging
+from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Callable, Literal
 
@@ -20,6 +21,9 @@ from ui.page import Page
 
 _FLOW_FORMAT_VERSION = 1
 _PortKind = Literal["input", "output"]
+
+_SAVE_OK_COLOR   = ( 90, 200, 100, 255)
+_SAVE_FAIL_COLOR = (220,  80,  80, 255)
 
 logger = logging.getLogger(__name__)
 
@@ -41,6 +45,7 @@ class NodeEditorPage(Page):
     ) -> None:
         self._node_editor_tag: DpgTag = dpg.generate_uuid()
         self._canvas_tag:      DpgTag = dpg.generate_uuid()
+        self._save_status_tag: DpgTag = dpg.generate_uuid()
         self._flow:     Flow | None    = None
         self._registry: NodeRegistry    = registry
         self._node_builder: DpgNodeBuilder = DpgNodeBuilder(self._node_editor_tag, themes)
@@ -78,6 +83,10 @@ class NodeEditorPage(Page):
                 with dpg.group(horizontal=True):
                     dpg.add_button(label="Save",      callback=self._save_flow)
                     dpg.add_button(label="Clear All", callback=self._clear_nodes)
+                    dpg.add_spacer(width=16)
+                    # Status readout updated by _save_flow. Empty until the
+                    # first save attempt.
+                    dpg.add_text("", tag=self._save_status_tag)
 
                 with dpg.child_window(
                     tag=self._canvas_tag,
@@ -265,16 +274,39 @@ class NodeEditorPage(Page):
     def _save_flow(self, *_: object) -> None:
         if self._flow is None:
             logger.warning("Save requested but no flow is active")
+            self._set_save_status("No flow to save", _SAVE_FAIL_COLOR)
             return
         data = self._serialize_flow(self._flow)
         try:
             FLOW_DIR.mkdir(parents=True, exist_ok=True)
             path = FLOW_DIR / f"{self._flow.name}.json"
             path.write_text(json.dumps(data, indent=2), encoding="utf-8")
-        except OSError:
+        except OSError as err:
             logger.exception("Failed to save flow '%s'", self._flow.name)
+            self._set_save_status(f"Save failed ({err.strerror or err.__class__.__name__})",
+                                  _SAVE_FAIL_COLOR)
             return
         logger.info("Saved flow to %s", path)
+        self._set_save_status(
+            f"Saved to {self._display_path(path)} at {datetime.now().strftime('%H:%M:%S')}",
+            _SAVE_OK_COLOR,
+        )
+
+    def _set_save_status(self, message: str, color: tuple[int, int, int, int]) -> None:
+        """Update the Save-status readout below the button row."""
+        if not dpg.does_item_exist(self._save_status_tag):
+            return
+        dpg.set_value(self._save_status_tag, message)
+        dpg.configure_item(self._save_status_tag, color=color)
+
+    @staticmethod
+    def _display_path(path: Path) -> str:
+        """Return ``path`` relative to the current working directory when
+        possible, otherwise the absolute path. Keeps the status line short."""
+        try:
+            return str(path.relative_to(Path.cwd()))
+        except ValueError:
+            return str(path)
 
     def _serialize_flow(self, flow: Flow) -> dict:
         """Return a JSON-compatible dict snapshot of the current editor state."""

--- a/src/ui/node_editor_page.py
+++ b/src/ui/node_editor_page.py
@@ -17,6 +17,7 @@ from core.node_registry import NodeEntry, NodeRegistry
 from ui._types import DpgTag
 from ui.dpg_node_builder import DpgNodeBuilder
 from ui.dpg_node_list_builder import DpgNodeListBuilder
+from ui.flow_file_dialog import FLOW_FILE_EXTENSION, make_open_flow_dialog
 from ui.page import Page
 
 _FLOW_FORMAT_VERSION = 1
@@ -108,17 +109,9 @@ class NodeEditorPage(Page):
                         width=-1,
                         height=-1)
 
-        # Persistent file dialog used by the Open button.
-        with dpg.file_dialog(
-            label="Open Flow",
-            tag=self._open_dialog_tag,
-            callback=self._on_flow_file_selected,
-            show=False,
-            modal=True,
-            width=700,
-            height=400,
-        ):
-            dpg.add_file_extension(".json", color=(0, 200, 255, 255), custom_text="Flow JSON")
+        # Persistent file dialog used by the Open button. Shared factory
+        # so StartPage and NodeEditorPage stay in sync on filter / layout.
+        make_open_flow_dialog(self._open_dialog_tag, self._on_flow_file_selected)
 
     @staticmethod
     def _build_ctx_menu(tag: DpgTag, item_label: str, callback: Callable[..., None]) -> None:
@@ -306,7 +299,7 @@ class NodeEditorPage(Page):
         data = self._serialize_flow(self._flow)
         try:
             FLOW_DIR.mkdir(parents=True, exist_ok=True)
-            path = FLOW_DIR / f"{self._flow.name}.json"
+            path = FLOW_DIR / f"{self._flow.name}{FLOW_FILE_EXTENSION}"
             path.write_text(json.dumps(data, indent=2), encoding="utf-8")
         except OSError as err:
             logger.exception("Failed to save flow '%s'", self._flow.name)
@@ -408,9 +401,9 @@ class NodeEditorPage(Page):
         path_str = app_data.get("file_path_name", "")
         if not path_str:
             return
-        self._load_flow(Path(path_str))
+        self.load_flow(Path(path_str))
 
-    def _load_flow(self, path: Path) -> None:
+    def load_flow(self, path: Path) -> None:
         """Parse ``path`` as flow JSON and rebuild the editor to match."""
         try:
             data = json.loads(path.read_text(encoding="utf-8"))

--- a/src/ui/node_editor_page.py
+++ b/src/ui/node_editor_page.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
 import importlib
+import json
 import logging
-from typing import TYPE_CHECKING, Callable
+from pathlib import Path
+from typing import TYPE_CHECKING, Callable, Literal
 
 import dearpygui.dearpygui as dpg
 from typing_extensions import override
 
+from constants import FLOW_DIR
 from core.flow import Flow
 from core.node_base import NodeBase
 from core.node_registry import NodeEntry, NodeRegistry
@@ -14,6 +17,9 @@ from ui._types import DpgTag
 from ui.dpg_node_builder import DpgNodeBuilder
 from ui.dpg_node_list_builder import DpgNodeListBuilder
 from ui.page import Page
+
+_FLOW_FORMAT_VERSION = 1
+_PortKind = Literal["input", "output"]
 
 logger = logging.getLogger(__name__)
 
@@ -39,9 +45,10 @@ class NodeEditorPage(Page):
         self._registry: NodeRegistry    = registry
         self._node_builder: DpgNodeBuilder = DpgNodeBuilder(self._node_editor_tag, themes)
 
-        # Node tracking for delete / context-menu support
+        # Node tracking for delete / context-menu / save support
         self._node_map:        dict[DpgTag, NodeBase]       = {}
         self._node_dialog_map: dict[DpgTag, DpgTag | None]  = {}
+        self._attr_to_port:    dict[DpgTag, tuple[NodeBase, _PortKind, int]] = {}
         self._ctx_target:      tuple[DpgTag, NodeBase] | None = None
         self._ctx_links:       list[DpgTag]                 = []
 
@@ -69,6 +76,7 @@ class NodeEditorPage(Page):
             DpgNodeListBuilder(self._registry)
             with dpg.group():
                 with dpg.group(horizontal=True):
+                    dpg.add_button(label="Save",      callback=self._save_flow)
                     dpg.add_button(label="Clear All", callback=self._clear_nodes)
 
                 with dpg.child_window(
@@ -123,7 +131,25 @@ class NodeEditorPage(Page):
         node_tag, dialog_tag = self._node_builder.build(node)
         self._node_map[node_tag] = node
         self._node_dialog_map[node_tag] = dialog_tag
+        self._index_node_attrs(node_tag, node)
         return node_tag
+
+    def _index_node_attrs(self, node_tag: DpgTag, node: NodeBase) -> None:
+        """Record the mapping from each port's DPG attribute tag to
+        ``(node, 'input'|'output', port_index)``.
+
+        DpgNodeBuilder creates node_attribute children in this order:
+        one per NodeParam (static), then one per input port, then one
+        per output port. We rely on that order to resolve attribute
+        tags back to ports at save time.
+        """
+        children = dpg.get_item_children(node_tag, 1) or []
+        offset = len(node.params)
+        for i in range(len(node.inputs)):
+            self._attr_to_port[children[offset + i]] = (node, "input", i)
+        offset += len(node.inputs)
+        for i in range(len(node.outputs)):
+            self._attr_to_port[children[offset + i]] = (node, "output", i)
 
     # ── Right-click / context menus ────────────────────────────────────────────
 
@@ -180,6 +206,9 @@ class NodeEditorPage(Page):
             if conf.get("attr_1") in attr_tags or conf.get("attr_2") in attr_tags:
                 dpg.delete_item(link_tag)
 
+        for attr_tag in attr_tags:
+            self._attr_to_port.pop(attr_tag, None)
+
         dialog_tag = self._node_dialog_map.pop(node_tag, None)
         if dialog_tag is not None and dpg.does_item_exist(dialog_tag):
             dpg.delete_item(dialog_tag)
@@ -225,10 +254,88 @@ class NodeEditorPage(Page):
         menu_tag = dpg.generate_uuid()
         label = f"Node Editor [{self._flow.name}]" if self._flow is not None else "Node Editor"
         with dpg.menu(label=label, parent=self._menu_bar, tag=menu_tag):
+            dpg.add_menu_item(label="Save",      callback=self._save_flow)
             dpg.add_menu_item(label="Clear All", callback=self._clear_nodes)
             dpg.add_separator()
             dpg.add_menu_item(label="Exit", callback=self._on_exit_clicked)
         self._menu_tags.append(menu_tag)
+
+    # ── Save ───────────────────────────────────────────────────────────────────
+
+    def _save_flow(self, *_: object) -> None:
+        if self._flow is None:
+            logger.warning("Save requested but no flow is active")
+            return
+        data = self._serialize_flow(self._flow)
+        try:
+            FLOW_DIR.mkdir(parents=True, exist_ok=True)
+            path = FLOW_DIR / f"{self._flow.name}.json"
+            path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+        except OSError:
+            logger.exception("Failed to save flow '%s'", self._flow.name)
+            return
+        logger.info("Saved flow to %s", path)
+
+    def _serialize_flow(self, flow: Flow) -> dict:
+        """Return a JSON-compatible dict snapshot of the current editor state."""
+        nodes_in_order = list(self._node_map.items())  # insertion order == creation order
+        node_ids: dict[int, int] = {id(node): idx for idx, (_, node) in enumerate(nodes_in_order)}
+
+        nodes_out = [self._node_to_dict(i, tag, node) for i, (tag, node) in enumerate(nodes_in_order)]
+        connections_out = self._connections_to_list(node_ids)
+
+        return {
+            "version":     _FLOW_FORMAT_VERSION,
+            "name":        flow.name,
+            "nodes":       nodes_out,
+            "connections": connections_out,
+        }
+
+    def _node_to_dict(self, node_id: int, node_tag: DpgTag, node: NodeBase) -> dict:
+        pos = dpg.get_item_pos(node_tag)
+        params = {p.name: _jsonable(getattr(node, p.name, None)) for p in node.params}
+        return {
+            "id":       node_id,
+            "module":   type(node).__module__,
+            "class":    type(node).__name__,
+            "position": [float(pos[0]), float(pos[1])],
+            "params":   params,
+        }
+
+    def _connections_to_list(self, node_ids: dict[int, int]) -> list[dict]:
+        """Derive connections from the DPG node_editor's visible links.
+
+        The editor authoritatively owns link state today (Flow.connect is
+        not yet wired to the UI), so we walk slot 0 of the editor to
+        recover them.
+        """
+        result: list[dict] = []
+        for link_tag in dpg.get_item_children(self._node_editor_tag, 0) or []:
+            try:
+                conf = dpg.get_item_configuration(link_tag)
+            except SystemError:
+                logger.debug("Skipped link %s during save", link_tag, exc_info=True)
+                continue
+            endpoint_a = self._attr_to_port.get(conf.get("attr_1"))
+            endpoint_b = self._attr_to_port.get(conf.get("attr_2"))
+            if endpoint_a is None or endpoint_b is None:
+                continue
+            # Normalise to (output, input) order. DPG doesn't guarantee
+            # which of attr_1 / attr_2 is the source.
+            if endpoint_a[1] == "output" and endpoint_b[1] == "input":
+                src, dst = endpoint_a, endpoint_b
+            elif endpoint_a[1] == "input" and endpoint_b[1] == "output":
+                src, dst = endpoint_b, endpoint_a
+            else:
+                logger.debug("Skipping link with same-kind endpoints: %s", link_tag)
+                continue
+            result.append({
+                "src_node":   node_ids[id(src[0])],
+                "src_output": src[2],
+                "dst_node":   node_ids[id(dst[0])],
+                "dst_input":  dst[2],
+            })
+        return result
 
     # ── Button / menu callbacks ────────────────────────────────────────────────
 
@@ -236,3 +343,16 @@ class NodeEditorPage(Page):
         logger.info("Exiting node editor")
         self._clear_nodes()
         self._page_manager.activate(self._page_manager.start_page)
+
+
+# ── Helpers ────────────────────────────────────────────────────────────────────
+
+def _jsonable(value: object) -> object:
+    """Coerce ``value`` to a JSON-serialisable form (recursive for containers)."""
+    if isinstance(value, Path):
+        return str(value)
+    if isinstance(value, (list, tuple)):
+        return [_jsonable(v) for v in value]
+    if isinstance(value, dict):
+        return {str(k): _jsonable(v) for k, v in value.items()}
+    return value

--- a/src/ui/start_page.py
+++ b/src/ui/start_page.py
@@ -1,13 +1,15 @@
 from __future__ import annotations
 
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 import dearpygui.dearpygui as dpg
 from typing_extensions import override
 
-from constants import APP_VERSION
+from constants import APP_VERSION, FLOW_DIR
 from core.flow import DEFAULT_FLOW_NAME, Flow, is_valid_flow_name
 from ui._types import DpgTag
+from ui.flow_file_dialog import make_open_flow_dialog
 from ui.page import Page
 
 if TYPE_CHECKING:
@@ -27,6 +29,7 @@ class StartPage(Page):
     ) -> None:
         self._flow_name_input_tag: DpgTag = dpg.generate_uuid()
         self._create_button_tag:   DpgTag = dpg.generate_uuid()
+        self._open_dialog_tag:     DpgTag = dpg.generate_uuid()
         super().__init__(parent=parent, menu_bar=menu_bar, page_manager=page_manager, themes=themes)
 
     @override
@@ -61,7 +64,11 @@ class StartPage(Page):
         dpg.bind_item_handler_registry(self._flow_name_input_tag, handlers)
 
         dpg.add_spacer(height=8)
-        dpg.add_button(label="Load Flow", indent=20, callback=self._on_load_flow_clicked)
+        dpg.add_button(label="Open", indent=20, callback=self._on_open_clicked)
+
+        # Persistent file dialog used by the Open button. Same factory as
+        # NodeEditorPage so both pages share filter / layout.
+        make_open_flow_dialog(self._open_dialog_tag, self._on_flow_file_selected)
 
     @override
     def _install_menus(self) -> None:
@@ -88,5 +95,17 @@ class StartPage(Page):
         self._page_manager.editor_page.set_flow(flow)
         self._page_manager.activate(self._page_manager.editor_page)
 
-    def _on_load_flow_clicked(self, sender: DpgTag | None = None) -> None:
-        pass  # TODO: implement flow loading (file dialog + deserialization)
+    def _on_open_clicked(self, sender: DpgTag | None = None) -> None:
+        FLOW_DIR.mkdir(parents=True, exist_ok=True)
+        dpg.configure_item(self._open_dialog_tag, default_path=str(FLOW_DIR))
+        dpg.show_item(self._open_dialog_tag)
+
+    def _on_flow_file_selected(self, sender: DpgTag, app_data: dict) -> None:
+        path_str = app_data.get("file_path_name", "")
+        if not path_str:
+            return
+        # Delegate to NodeEditorPage — single source of truth for the load
+        # routine (clears canvas, rebuilds nodes/links, refreshes menu).
+        editor = self._page_manager.editor_page
+        editor.load_flow(Path(path_str))
+        self._page_manager.activate(editor)


### PR DESCRIPTION
## Summary
Adds a first cut of flow persistence: a **Save** button on the node editor (and a matching menu item) that writes the current flow to `<repo-root>/flow/<flow.name>.json`.

The flow name was already validated and sanitised on the start page (`a-zA-Z0-9_#+-`), so it's safe to use directly as a filename stem — no extra escaping needed.

### JSON payload
```jsonc
{
  "version": 1,
  "name": "my_flow",
  "nodes": [
    {
      "id": 0,
      "module": "nodes.sources.file_source",
      "class":  "FileSource",
      "position": [120.0, 80.0],
      "params": { "file_path": "/home/.../ship.jpg", "max_num_frames": -1 }
    },
    ...
  ],
  "connections": [
    { "src_node": 0, "src_output": 0, "dst_node": 1, "dst_input": 0 }
  ]
}
```

- Each node records its `module`/`class`, its current DPG canvas `position`, and every declared `NodeParam` value. `Path` values are coerced to strings via a small `_jsonable` helper so the payload is always JSON-compatible.
- Connections are derived from the live DPG links (since `Flow.connect` is not yet wired from the UI — that's a separate cleanup). A new `_attr_to_port` index, populated when a node is built (and cleared on delete), resolves a link's `attr_1`/`attr_2` tags back to `(node, 'input'|'output', port_index)`.

### Files
- `src/constants.py` — new `FLOW_DIR = <root>/flow`.
- `flow/.gitkeep` — creates the directory (matches the existing `input/.gitkeep`, `output/.gitkeep` pattern).
- `src/ui/node_editor_page.py` — Save button + menu item, `_save_flow`, `_serialize_flow`, `_node_to_dict`, `_connections_to_list`, `_index_node_attrs`, and a module-level `_jsonable` helper.

## Test plan
- [ ] Launch app, create a flow named `demo`, drop a `FileSource` → `Grayscale` → `FileSink`, link them, click **Save**. Check `flow/demo.json` exists with three nodes and two connections, and each node's `position` matches what you see on canvas.
- [ ] Set the `file_path` / `max_num_frames` on the source and `output_path` on the sink; save again; confirm the updated values show up in `params`.
- [ ] Verify the JSON parses cleanly: `python -c "import json; json.load(open('flow/demo.json'))"`.
- [ ] Exit to start page, create a new flow, save — a fresh JSON file with the new name appears.

## Notes / out of scope
- **Loading** is not implemented. When it lands, the current snapshot format already carries everything needed (module, class, position, params, connections).
- `Flow.connect` still isn't invoked when the UI draws a link. I chose not to fix that in this PR since the save path doesn't need it (walks DPG state directly), and the fix wants its own diff + test plan. Happy to follow up.
- Overwrite behaviour: saving reuses the same filename (`<name>.json`), so repeated saves overwrite silently. No confirmation dialog. Call out if you want that guarded.
