### PR TITLE
Viewer panel: render every image output of the selected node

### DIFF
--- a/src/core/port.py
+++ b/src/core/port.py
@@ -64,6 +64,10 @@ class OutputPort:
         self.name = name
         self.emits: frozenset[IoDataType] = frozenset(emits)
         self._connections: list[InputPort] = []
+        # Last IoData the port emitted via send(); None until the first
+        # send. Used by the viewer panel to show the current output of a
+        # node without needing the flow to re-run on every selection.
+        self._last_emitted: IoData | None = None
 
     # ── Connection management ──────────────────────────────────────────────────
 
@@ -91,8 +95,18 @@ class OutputPort:
     def connections(self) -> list[InputPort]:
         return list(self._connections)
 
+    @property
+    def last_emitted(self) -> IoData | None:
+        """Most recent ``IoData`` passed to :meth:`send`, or ``None`` if the
+        port has not emitted anything yet (or since the port was cleared)."""
+        return self._last_emitted
+
+    def clear_last_emitted(self) -> None:
+        self._last_emitted = None
+
     # ── Data flow ──────────────────────────────────────────────────────────────
 
     def send(self, data: IoData) -> None:
+        self._last_emitted = data
         for port in self._connections:
             port.receive(data)

--- a/src/ui/dpg_flow_viewer_panel.py
+++ b/src/ui/dpg_flow_viewer_panel.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+import logging
+
+import cv2
+import dearpygui.dearpygui as dpg
+import numpy as np
+
+from core.io_data import IoDataType
+from core.node_base import NodeBase
+from ui._types import DpgTag
+
+logger = logging.getLogger(__name__)
+
+# Upper bound for the texture uploaded to DPG. Larger images are
+# downsampled preserving aspect ratio so 4K frames do not hammer VRAM.
+_MAX_TEXTURE_DIM: int = 1024
+
+# Horizontal padding subtracted from the panel width when computing the
+# target image width (accounts for the scroll-bar and child-window border).
+_PANEL_H_PADDING: int = 24
+
+
+class DpgFlowViewerPanel:
+    """Bottom-of-editor viewer that renders every image output of a node.
+
+    Call :meth:`show` with the currently-selected ``NodeBase`` (or ``None``).
+    The panel clears itself and re-creates one labelled ``dpg.add_image``
+    per ``IoDataType.IMAGE`` output port that has data cached on it.
+
+    The caller is responsible for creating the panel inside an active DPG
+    container; the panel itself owns its child window so its parent just
+    needs to exist.
+    """
+
+    def __init__(self, parent: DpgTag, *, height: int) -> None:
+        self._container_tag: DpgTag = dpg.generate_uuid()
+        self._texture_registry_tag: DpgTag = dpg.generate_uuid()
+        self._texture_tags: list[DpgTag] = []
+        self._current_node: NodeBase | None = None
+
+        # Textures live in a dedicated registry so they can be wiped
+        # without touching any other DPG texture state in the app.
+        with dpg.texture_registry(tag=self._texture_registry_tag):
+            pass
+
+        with dpg.child_window(
+            tag=self._container_tag,
+            parent=parent,
+            width=-1,
+            height=height,
+            border=True,
+        ):
+            dpg.add_text("(select a node to view its output)", color=(120, 120, 120, 255))
+
+    # ── Public API ─────────────────────────────────────────────────────────────
+
+    def show(self, node: NodeBase | None) -> None:
+        """Render every image output of ``node`` in the panel.
+
+        Non-image outputs are shown as a small placeholder line. If no
+        data has been emitted yet, a hint is shown instead of the image.
+        """
+        self._current_node = node
+        self._clear()
+
+        if node is None:
+            dpg.add_text("(select a node to view its output)",
+                         color=(120, 120, 120, 255),
+                         parent=self._container_tag)
+            return
+
+        if not node.outputs:
+            dpg.add_text(f"{node.display_name}: node has no outputs",
+                         color=(120, 120, 120, 255),
+                         parent=self._container_tag)
+            return
+
+        panel_w = max(64, dpg.get_item_rect_size(self._container_tag)[0] - _PANEL_H_PADDING)
+
+        for port in node.outputs:
+            if IoDataType.IMAGE not in port.emits:
+                dpg.add_text(f"{port.name}: (non-image output)",
+                             color=(120, 120, 120, 255),
+                             parent=self._container_tag)
+                continue
+
+            data = port.last_emitted
+            if data is None or data.is_end_of_stream() or data.type != IoDataType.IMAGE:
+                dpg.add_text(f"{port.name}: (no data — click Run)",
+                             color=(120, 120, 120, 255),
+                             parent=self._container_tag)
+                continue
+
+            try:
+                self._render_image(port.name, data.image, panel_w)
+            except Exception:
+                logger.exception("Viewer failed to render port '%s'", port.name)
+                dpg.add_text(f"{port.name}: (render error — see log)",
+                             color=(220, 80, 80, 255),
+                             parent=self._container_tag)
+
+    def refresh(self) -> None:
+        """Re-render the currently-shown node. Call this after a flow run."""
+        self.show(self._current_node)
+
+    # ── Internals ──────────────────────────────────────────────────────────────
+
+    def _render_image(self, label: str, image: np.ndarray, panel_width: int) -> None:
+        # OpenCV produces BGR or grayscale arrays; DPG expects RGBA float32.
+        rgba = self._to_rgba(image)
+
+        h, w = rgba.shape[:2]
+        # Downsample oversized images so the GPU upload stays cheap. The
+        # aspect ratio is preserved; the final on-screen width is set
+        # separately below via the add_image call.
+        max_dim = max(h, w)
+        if max_dim > _MAX_TEXTURE_DIM:
+            scale = _MAX_TEXTURE_DIM / max_dim
+            rgba = cv2.resize(rgba, (max(1, int(w * scale)), max(1, int(h * scale))),
+                              interpolation=cv2.INTER_AREA)
+            h, w = rgba.shape[:2]
+
+        tex_data = (rgba.astype(np.float32) / 255.0).flatten()
+        tex_tag = dpg.add_raw_texture(
+            width=w,
+            height=h,
+            default_value=tex_data,
+            format=dpg.mvFormat_Float_rgba,
+            parent=self._texture_registry_tag,
+        )
+        self._texture_tags.append(tex_tag)
+
+        # Fit-to-width: scale to the panel's current inner width, preserving
+        # aspect ratio. Don't upscale beyond the texture's native size.
+        display_w = min(panel_width, w)
+        display_h = max(1, round(display_w * (h / w)))
+
+        dpg.add_text(f"{label}  ({w}×{h})", parent=self._container_tag)
+        dpg.add_image(tex_tag, width=display_w, height=display_h, parent=self._container_tag)
+        dpg.add_spacer(height=6, parent=self._container_tag)
+
+    @staticmethod
+    def _to_rgba(image: np.ndarray) -> np.ndarray:
+        """Coerce a NumPy image to a uint8 RGBA array (H, W, 4)."""
+        if image.dtype != np.uint8:
+            # Normalise floats / ints into 0..255 uint8 before colour conversion.
+            image = np.clip(image, 0, 255).astype(np.uint8)
+
+        if image.ndim == 2:
+            return cv2.cvtColor(image, cv2.COLOR_GRAY2RGBA)
+        if image.shape[2] == 3:
+            return cv2.cvtColor(image, cv2.COLOR_BGR2RGBA)
+        if image.shape[2] == 4:
+            return cv2.cvtColor(image, cv2.COLOR_BGRA2RGBA)
+        raise ValueError(f"Unsupported image shape {image.shape}")
+
+    def _clear(self) -> None:
+        for child in list(dpg.get_item_children(self._container_tag, 1) or []):
+            if dpg.does_item_exist(child):
+                dpg.delete_item(child)
+        for tex in self._texture_tags:
+            if dpg.does_item_exist(tex):
+                dpg.delete_item(tex)
+        self._texture_tags.clear()

--- a/src/ui/dpg_node_list_builder.py
+++ b/src/ui/dpg_node_list_builder.py
@@ -23,8 +23,11 @@ class DpgNodeListBuilder:
 
     def __init__(self, registry: NodeRegistry, *, width: int = 200) -> None:
         self._items: list[tuple[DpgTag, str]] = []
+        # Expose the container tag so embedding pages can show/hide the
+        # whole palette with a single dpg.configure_item call.
+        self._container_tag: DpgTag = dpg.generate_uuid()
 
-        with dpg.child_window(width=width, height=-1, border=True):
+        with dpg.child_window(tag=self._container_tag, width=width, height=-1, border=True):
             dpg.add_input_text(hint="Search…", width=-1, callback=self._on_search)
             dpg.add_separator()
 
@@ -36,6 +39,13 @@ class DpgNodeListBuilder:
                         dpg.add_text("(none)", color=(120, 120, 120, 255))
                     for entry in entries:
                         self._add_draggable_entry(entry)
+
+    @property
+    def container_tag(self) -> DpgTag:
+        """Tag of the surrounding child window. Use with ``dpg.show_item`` /
+        ``dpg.hide_item`` or ``dpg.configure_item(tag, show=...)`` to
+        toggle palette visibility."""
+        return self._container_tag
 
     # ── Internals ──────────────────────────────────────────────────────────────
 

--- a/src/ui/node_editor_page.py
+++ b/src/ui/node_editor_page.py
@@ -15,6 +15,7 @@ from core.flow import Flow
 from core.node_base import NodeBase
 from core.node_registry import NodeEntry, NodeRegistry
 from ui._types import DpgTag
+from ui.dpg_flow_viewer_panel import DpgFlowViewerPanel
 from ui.dpg_node_builder import DpgNodeBuilder
 from ui.dpg_node_list_builder import DpgNodeListBuilder
 from ui.flow_file_dialog import FLOW_FILE_EXTENSION, make_open_flow_dialog
@@ -25,6 +26,9 @@ _PortKind = Literal["input", "output"]
 
 _SAVE_OK_COLOR   = ( 90, 200, 100, 255)
 _SAVE_FAIL_COLOR = (220,  80,  80, 255)
+
+# Fixed height of the viewer panel at the bottom of the editor page.
+_VIEWER_HEIGHT: int = 300
 
 logger = logging.getLogger(__name__)
 
@@ -50,6 +54,13 @@ class NodeEditorPage(Page):
         self._flow:     Flow | None    = None
         self._registry: NodeRegistry    = registry
         self._node_builder: DpgNodeBuilder = DpgNodeBuilder(self._node_editor_tag, themes)
+        # Palette widget and bottom viewer are created in _build_ui.
+        self._palette:  DpgNodeListBuilder | None = None
+        self._viewer:   DpgFlowViewerPanel  | None = None
+        self._palette_visible: bool = True
+        # Last polled node-editor selection, used to avoid rebuilding the
+        # viewer panel on every frame.
+        self._last_selected_nodes: tuple[DpgTag, ...] = ()
 
         # Node tracking for delete / context-menu / save support
         self._node_map:        dict[DpgTag, NodeBase]       = {}
@@ -82,36 +93,48 @@ class NodeEditorPage(Page):
             dpg.add_mouse_click_handler(button=dpg.mvMouseButton_Right, callback=self._on_right_click)
             dpg.add_mouse_click_handler(button=dpg.mvMouseButton_Left,  callback=self._on_left_click)
 
-        dpg.add_spacer(height=20)
+        dpg.add_spacer(height=8)
         with dpg.group(horizontal=True):
-            DpgNodeListBuilder(self._registry)
-            with dpg.group():
-                with dpg.group(horizontal=True):
-                    dpg.add_button(label="Save",      callback=self._save_flow)
-                    dpg.add_button(label="Open",      callback=self._on_open_flow)
-                    dpg.add_button(label="Clear All", callback=self._clear_nodes)
-                    dpg.add_spacer(width=16)
-                    # Status readout updated by _save_flow / _load_flow.
-                    # Empty until the first save or open attempt.
-                    dpg.add_text("", tag=self._save_status_tag)
+            dpg.add_button(label="Palette",   callback=self._toggle_palette)
+            dpg.add_button(label="Run",       callback=self._run_flow)
+            dpg.add_button(label="Save",      callback=self._save_flow)
+            dpg.add_button(label="Open",      callback=self._on_open_flow)
+            dpg.add_button(label="Clear All", callback=self._clear_nodes)
+            dpg.add_spacer(width=16)
+            # Status readout updated by _save_flow / load_flow / _run_flow.
+            # Empty until the first action attempt.
+            dpg.add_text("", tag=self._save_status_tag)
 
-                with dpg.child_window(
-                    tag=self._canvas_tag,
-                    drop_callback=self._on_node_dropped,
-                    payload_type=DpgNodeListBuilder.PAYLOAD_TYPE,
+        # Palette (left) + canvas (right), sized to leave room for the
+        # viewer panel below. Negative height means "fill minus N".
+        with dpg.group(horizontal=True, height=-_VIEWER_HEIGHT - 8):
+            self._palette = DpgNodeListBuilder(self._registry)
+            with dpg.child_window(
+                tag=self._canvas_tag,
+                drop_callback=self._on_node_dropped,
+                payload_type=DpgNodeListBuilder.PAYLOAD_TYPE,
+                width=-1,
+                height=-1,
+                border=False,
+            ):
+                dpg.add_node_editor(
+                    tag=self._node_editor_tag,
+                    callback=self._link,
+                    delink_callback=self._delink,
                     width=-1,
                     height=-1,
-                    border=False):
-                    dpg.add_node_editor(
-                        tag=self._node_editor_tag,
-                        callback=self._link,
-                        delink_callback=self._delink,
-                        width=-1,
-                        height=-1)
+                )
+
+        # Bottom: viewer panel. Shows every IoDataType.IMAGE output of
+        # the currently-selected node. Populated via selection polling.
+        self._viewer = DpgFlowViewerPanel(parent=self._content_tag, height=_VIEWER_HEIGHT)
 
         # Persistent file dialog used by the Open button. Shared factory
         # so StartPage and NodeEditorPage stay in sync on filter / layout.
         make_open_flow_dialog(self._open_dialog_tag, self._on_flow_file_selected)
+
+        # Start polling the node-editor selection so the viewer follows it.
+        self._schedule_selection_poll()
 
     @staticmethod
     def _build_ctx_menu(tag: DpgTag, item_label: str, callback: Callable[..., None]) -> None:
@@ -252,11 +275,61 @@ class NodeEditorPage(Page):
     # ── Link callbacks ─────────────────────────────────────────────────────────
 
     def _link(self, sender: DpgTag, app_data: tuple[DpgTag, DpgTag]) -> None:
+        """Create the visual link and mirror the connection into self._flow."""
+        endpoints = self._resolve_endpoints(app_data[0], app_data[1])
+        if endpoints is None:
+            return
+        src, dst = endpoints
+        if self._flow is not None:
+            try:
+                self._flow.connect(src[0], src[2], dst[0], dst[2])
+            except TypeError:
+                logger.warning("Rejected incompatible connection", exc_info=True)
+                return
         link_tag = dpg.add_node_link(app_data[0], app_data[1], parent=sender)
         self._themes.apply_to_link(link_tag)
 
     def _delink(self, sender: DpgTag, app_data: DpgTag) -> None:
-        dpg.delete_item(app_data)
+        """Delete the visual link and tear down the matching Flow connection."""
+        link_tag = app_data
+        endpoints = self._link_endpoints(link_tag)
+        if endpoints is not None and self._flow is not None:
+            src, dst = endpoints
+            try:
+                self._flow.disconnect(src[0], src[2], dst[0], dst[2])
+            except Exception:
+                logger.debug("Flow.disconnect failed on delink", exc_info=True)
+        if dpg.does_item_exist(link_tag):
+            dpg.delete_item(link_tag)
+
+    def _resolve_endpoints(
+        self,
+        attr_a: DpgTag,
+        attr_b: DpgTag,
+    ) -> tuple[tuple[NodeBase, _PortKind, int], tuple[NodeBase, _PortKind, int]] | None:
+        """Translate a pair of node_attribute tags to (output_endpoint, input_endpoint)
+        using self._attr_to_port. Returns None when the pair is invalid
+        (unknown attr, same-kind pair, etc.)."""
+        a = self._attr_to_port.get(attr_a)
+        b = self._attr_to_port.get(attr_b)
+        if a is None or b is None:
+            return None
+        if a[1] == "output" and b[1] == "input":
+            return a, b
+        if a[1] == "input" and b[1] == "output":
+            return b, a
+        return None
+
+    def _link_endpoints(
+        self,
+        link_tag: DpgTag,
+    ) -> tuple[tuple[NodeBase, _PortKind, int], tuple[NodeBase, _PortKind, int]] | None:
+        """Return (output, input) endpoints for an existing node_link."""
+        try:
+            conf = dpg.get_item_configuration(link_tag)
+        except SystemError:
+            return None
+        return self._resolve_endpoints(conf.get("attr_1"), conf.get("attr_2"))
 
     # ── Clear ──────────────────────────────────────────────────────────────────
 
@@ -497,11 +570,19 @@ class NodeEditorPage(Page):
         src_attrs = self._port_attrs(src_tag, src_node, "output")
         dst_attrs = self._port_attrs(dst_tag, dst_node, "input")
         try:
-            src_attr = src_attrs[conn["src_output"]]
-            dst_attr = dst_attrs[conn["dst_input"]]
+            src_idx = conn["src_output"]
+            dst_idx = conn["dst_input"]
+            src_attr = src_attrs[src_idx]
+            dst_attr = dst_attrs[dst_idx]
         except (IndexError, KeyError):
             logger.warning("Skipping connection with out-of-range port index: %s", conn)
             return
+        if self._flow is not None:
+            try:
+                self._flow.connect(src_node, src_idx, dst_node, dst_idx)
+            except TypeError:
+                logger.warning("Skipping incompatible connection: %s", conn, exc_info=True)
+                return
         link_tag = dpg.add_node_link(src_attr, dst_attr, parent=self._node_editor_tag)
         self._themes.apply_to_link(link_tag)
 
@@ -517,6 +598,53 @@ class NodeEditorPage(Page):
         if kind == "input":
             return list(children[params_len : params_len + inputs_len])
         return list(children[params_len + inputs_len : params_len + inputs_len + len(node.outputs)])
+
+    # ── Run / viewer / palette ─────────────────────────────────────────────────
+
+    def _run_flow(self, *_: object) -> None:
+        """Execute the active flow once and refresh the viewer panel."""
+        if self._flow is None:
+            self._set_save_status("No flow to run", _SAVE_FAIL_COLOR)
+            return
+        try:
+            self._flow.run()
+        except Exception as err:
+            logger.exception("Flow run failed")
+            self._set_save_status(f"Run failed ({type(err).__name__})", _SAVE_FAIL_COLOR)
+            return
+        self._set_save_status(
+            f"Ran at {datetime.now().strftime('%H:%M:%S')}",
+            _SAVE_OK_COLOR,
+        )
+        if self._viewer is not None:
+            self._viewer.refresh()
+
+    def _toggle_palette(self, *_: object) -> None:
+        if self._palette is None:
+            return
+        self._palette_visible = not self._palette_visible
+        dpg.configure_item(self._palette.container_tag, show=self._palette_visible)
+
+    def _schedule_selection_poll(self) -> None:
+        """Arrange for :meth:`_poll_selection` to run on the next DPG frame."""
+        dpg.set_frame_callback(dpg.get_frame_count() + 1, self._poll_selection)
+
+    def _poll_selection(self) -> None:
+        """Push the current node-editor selection into the viewer panel.
+
+        Re-schedules itself every frame. Cheap: ``get_selected_nodes`` is a
+        list lookup and we only touch the viewer on actual changes.
+        """
+        try:
+            if self._active and dpg.does_item_exist(self._node_editor_tag):
+                selected = tuple(dpg.get_selected_nodes(self._node_editor_tag) or ())
+                if selected != self._last_selected_nodes:
+                    self._last_selected_nodes = selected
+                    if self._viewer is not None:
+                        node = self._node_map.get(selected[0]) if selected else None
+                        self._viewer.show(node)
+        finally:
+            self._schedule_selection_poll()
 
     # ── Button / menu callbacks ────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
Adds the bottom image-viewer panel, a Run button, and a Palette show/hide toggle. Selecting a node routes every one of its image outputs to the viewer.

### Layout
```
 ┌───────────────────────────────────────────────┐
 │ [Palette] [Run] [Save] [Open] [Clear All]  …  │   button row
 ├─────────┬─────────────────────────────────────┤
 │ palette │  node editor canvas                 │   fills remaining height
 │ (tog-   │                                     │
 │ glable) │                                     │
 ├─────────┴─────────────────────────────────────┤
 │  viewer panel  (300 px)                       │   ← new
 │   port_name  (1920×1080)                      │
 │   ┌─────────────────────────────────────────┐ │
 │   │  <image 1>                              │ │
 │   └─────────────────────────────────────────┘ │
 │   port_name_2  (640×480)                      │
 │   ┌─────────────┐                             │
 │   │  <image 2>  │                             │
 │   └─────────────┘                             │
 └───────────────────────────────────────────────┘
```

### Viewer behaviour
- Selecting any node pushes its output ports to the viewer.
- Every `IoDataType.IMAGE` output is rendered; non-image outputs show a small placeholder line.
- Output without data (e.g. before Run has been pressed) shows `(no data — click Run)`.
- **Fit-to-width, preserving aspect ratio, no upscaling past native size.** Textures are downsampled to max 1024 px before upload so 4K frames don't thrash VRAM.
- Accepts grayscale, BGR, and BGRA numpy arrays; float / int dtypes are clipped to uint8 before conversion.
- Selection polling via a recursive `dpg.set_frame_callback` — one callback handles mouse, rubber-band and keyboard selection.

### Run button
- Calls `Flow.run()` synchronously on the active flow. Status text reports `Ran at HH:MM:SS` (green) or `Run failed (<ExceptionClass>)` (red) and the viewer refreshes afterwards so previews reflect the latest run.
- `OutputPort.last_emitted` caches the most recent `IoData` passed to `send()`. The viewer reads this cache rather than re-running anything on selection changes.

### Flow ↔ UI connection plumbing (prerequisite for Run)
- `NodeEditorPage._link` now calls `Flow.connect(src_node, src_port, dst_node, dst_port)` after validating endpoints via the existing `_attr_to_port` index. Incompatible port pairs are rejected (the DPG link is not created).
- `NodeEditorPage._delink` calls `Flow.disconnect(...)` before deleting the visual link.
- `load_flow`'s restored connections also call `Flow.connect`, so reopened flows run correctly.

### Palette show/hide
- `DpgNodeListBuilder` now exposes `container_tag`.
- New **Palette** button toggles the palette's visibility. Canvas reclaims the horizontal space automatically.

## Files
- `src/core/port.py` — `OutputPort.last_emitted` + `clear_last_emitted`.
- `src/ui/dpg_flow_viewer_panel.py` *(new)* — `DpgFlowViewerPanel` class.
- `src/ui/dpg_node_list_builder.py` — expose `container_tag`.
- `src/ui/node_editor_page.py` — layout rewrite, Run, palette toggle, selection polling, connection wiring.

## Test plan
- [ ] Drop `FileSource` → `Grayscale` → `FileSink`, connect them (`Flow.connect` should now be invoked on each link — drag an input-typed output to a mismatched port and confirm the link is rejected).
- [ ] Click **Run** → status reads `Ran at HH:MM:SS`, `flow/…/out.png` is written by the sink, and clicking each node shows its output in the bottom panel.
- [ ] Click the source → see the loaded image. Click the filter → see the grayscale result. Click the sink → no output port → placeholder `"no outputs"` line.
- [ ] Click **Palette** → palette hides, canvas expands. Click again → palette returns.
- [ ] Delete a link via right-click → select the node on either side → the previously-fed outputs now read `(no data — click Run)` (because we wiped the flow connection and re-running would produce no output for those ports).
- [ ] Save a flow, Open it again → links are restored; Run works without fresh manual linking.

## Known follow-ups / out of scope
- Auto-run on edit. Currently the user must hit **Run** explicitly.
- Partial execution (run up to selected node). Currently **Run** executes the whole flow from sources.
- Non-image renderers (histograms, keypoints). The viewer shows a placeholder for those ports.
- Draggable splitter between canvas and viewer. Viewer height is fixed at 300 px for now.
- Multiple simultaneous viewers (e.g. compare two branches side by side). One panel, tracks selection.
