### PR TITLE
Show exception message in Run/Save status line

### DIFF
--- a/src/ui/node_editor_page.py
+++ b/src/ui/node_editor_page.py
@@ -205,7 +205,8 @@ class NodeEditorPage(Page):
             self._flow.run()
         except Exception as err:
             logger.exception("Flow run failed")
-            self._set_status(f"Run failed ({type(err).__name__})", kind="fail")
+            detail = str(err).strip() or "(no message)"
+            self._set_status(f"Run failed ({type(err).__name__}): {detail}", kind="fail")
             return
         self._set_status(
             f"Ran at {datetime.now().strftime('%H:%M:%S')}",
@@ -222,10 +223,8 @@ class NodeEditorPage(Page):
             save_flow_to(path, self._scene, self._flow)
         except OSError as err:
             logger.exception("Failed to save flow '%s'", self._flow.name)
-            self._set_status(
-                f"Save failed ({err.strerror or err.__class__.__name__})",
-                kind="fail",
-            )
+            detail = err.strerror or str(err) or err.__class__.__name__
+            self._set_status(f"Save failed: {detail}", kind="fail")
             return
         self._set_status(
             f"Saved to {_display_path(path)} at {datetime.now().strftime('%H:%M:%S')}",
@@ -266,6 +265,9 @@ class NodeEditorPage(Page):
             "muted": STATUS_MUTED_COLOR,
         }.get(kind, STATUS_MUTED_COLOR)
         self._status_label.setText(message)
+        # Show the full message in a tooltip so long exception text isn't
+        # lost when the status bar truncates the label.
+        self._status_label.setToolTip(message)
         self._status_label.setStyleSheet(
             f"color: rgb({color.red()},{color.green()},{color.blue()});"
         )


### PR DESCRIPTION
## Summary
Before, a failing `Flow.run()` showed `Run failed (ValueError)` in the status bar — just the class name, no hint at *why*. You had to consult the log file for the actual message.

## Changes
- **`_on_run_clicked`** — status is now `"Run failed ({ExceptionClass}): {message}"`. If `str(err)` is blank we fall back to `(no message)`.
- **`_on_save_clicked`** — mirror treatment: `err.strerror` (OSError-populated) or `str(err)` before falling back to class name. So "Permission denied", "No space left on device", etc. actually surface.
- **`_set_status`** — also writes the message into the label's `toolTip`. A `QLabel` inside a `QStatusBar` truncates long text with ellipses; the tooltip keeps the full message reachable on hover.

No other files touched; no behaviour change to Flow execution itself.

## Test plan
- [ ] Drop a `FileSource` pointing at a missing file, hit **Run** → status line reads `Run failed (FileNotFoundError): Input file not found: …`, hover shows the full text even if the window is narrow.
- [ ] Hit **Save** with `FLOW_DIR` read-only (e.g. `chmod -w flow`) → status reads `Save failed: Permission denied`.
- [ ] Normal successful Run still shows `Ran at HH:MM:SS` in green.
