### PR TITLE
Add node validation and flow execution safeguards

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,6 +10,16 @@
                 "request" : "launch",
                 "program" : "${workspaceFolder}/src/main.py",
                 "console" : "integratedTerminal"
+            },
+            {
+                "name" : "Unit Tests (pytest)",
+                "type" : "debugpy",
+                "request" : "launch",
+                "module" : "pytest",
+                "args" : ["tests/", "-v"],
+                "cwd" : "${workspaceFolder}",
+                "console" : "integratedTerminal",
+                "justMyCode" : false
             }
     ]
 }

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,2 @@
+-r requirements.txt
+pytest

--- a/src/core/flow.py
+++ b/src/core/flow.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import re
 
-from core.node_base import NodeBase, SourceNodeBase
+from core.node_base import NodeBase, SinkNodeBase, SourceNodeBase
 from core.port import InputPort, OutputPort
 
 
@@ -115,12 +115,32 @@ class Flow:
 
     # ── Execution ──────────────────────────────────────────────────────────────
 
-    def run(self) -> None:
-        """Start all source nodes in registration order.
+    @property
+    def sources(self) -> list[SourceNodeBase]:
+        """Return the flow's source nodes in registration order."""
+        return [n for n in self._nodes if isinstance(n, SourceNodeBase)]
 
-        The push-based execution model means calling start() on each source
-        propagates data downstream automatically through connected ports.
+    @property
+    def sinks(self) -> list[SinkNodeBase]:
+        """Return the flow's sink nodes in registration order."""
+        return [n for n in self._nodes if isinstance(n, SinkNodeBase)]
+
+    def run(self) -> None:
+        """Start every source node in the flow.
+
+        A runnable flow must contain at least one source (an entry point
+        that drives data through the graph) and at least one sink (a node
+        that consumes the result). Multi-source flows are legal — e.g.
+        three file sources feeding an RGB-join filter — so every source is
+        started in registration order. In the push-based execution model,
+        each start() propagates data downstream through connected ports.
+
+        Raises:
+            RuntimeError: if the flow has no source node or no sink node.
         """
-        for node in self._nodes:
-            if isinstance(node, SourceNodeBase):
-                node.start()
+        if not self.sources:
+            raise RuntimeError("Flow has no source node; at least one is required")
+        if not self.sinks:
+            raise RuntimeError("Flow has no sink node; at least one is required")
+        for source in self.sources:
+            source.start()

--- a/src/core/node_base.py
+++ b/src/core/node_base.py
@@ -54,6 +54,10 @@ class NodeBase(ABC):
 
     def _add_input(self, port: InputPort) -> None:
         self._inputs.append(port)
+        # Wire the port so that data arriving at it drives this node's
+        # dispatcher: _signal_input_ready checks whether every input has
+        # data and, if so, invokes process() (or _on_end_of_stream()).
+        port.set_on_data_received(self._signal_input_ready)
 
     def _add_output(self, port: OutputPort) -> None:
         self._outputs.append(port)

--- a/src/core/node_registry.py
+++ b/src/core/node_registry.py
@@ -143,13 +143,20 @@ def _parse_node_file(
     except OSError as e:
         return [], [ScanError(file=path, message=f"Could not read file: {e}")]
 
-    results = []
+    results: list[tuple[str, str, str]] = []
+    errors: list[ScanError] = []
     for node in ast.walk(tree):
         if isinstance(node, ast.ClassDef):
             entry = _extract_node_entry(node)
-            if entry is not None:
-                results.append(entry)
-    return results, []
+            if entry is None:
+                continue
+            validation_errors = _validate_node_class(node, entry[2], path)
+            if validation_errors:
+                # Reject invalid node classes so they never reach the palette.
+                errors.extend(validation_errors)
+                continue
+            results.append(entry)
+    return results, errors
 
 
 def _extract_node_entry(
@@ -177,6 +184,38 @@ def _detect_category(class_node: ast.ClassDef) -> str:
         if name and name in _CATEGORY_MAP:
             return _CATEGORY_MAP[name]
     return "Filters"
+
+
+def _validate_node_class(
+    class_node: ast.ClassDef,
+    category: str,
+    path: Path,
+) -> list[ScanError]:
+    """Return structural errors for a node class.
+
+    Enforced rules:
+      - ``start()`` is only valid on source nodes. Only source nodes can be
+        entry points for a flow (see :meth:`Flow.run`), so a non-source class
+        that defines ``start()`` would silently never be called. Reject it.
+    """
+    errors: list[ScanError] = []
+    if category != "Sources" and _has_method(class_node, "start"):
+        errors.append(ScanError(
+            file=path,
+            message=(
+                f"'{class_node.name}' defines start(), but start() is only "
+                f"valid on source nodes. Only source nodes can be entry "
+                f"points for a flow."
+            ),
+        ))
+    return errors
+
+
+def _has_method(class_node: ast.ClassDef, method_name: str) -> bool:
+    for item in class_node.body:
+        if isinstance(item, ast.FunctionDef) and item.name == method_name:
+            return True
+    return False
 
 
 def _find_init(class_node: ast.ClassDef) -> ast.FunctionDef | None:

--- a/src/core/port.py
+++ b/src/core/port.py
@@ -47,6 +47,14 @@ class InputPort:
         if self._on_data_received is not None:
             self._on_data_received()
 
+    def set_on_data_received(self, callback: Callable[[], None]) -> None:
+        """Set the callback invoked each time new data arrives at this port.
+
+        NodeBase uses this during port registration to wire every input to
+        the owning node's ``_signal_input_ready`` dispatcher.
+        """
+        self._on_data_received = callback
+
     def clear(self) -> None:
         self._data = None
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,13 @@
+"""Pytest configuration for the image-inquest test suite.
+
+Puts ``src/`` on ``sys.path`` so tests can import ``core.*`` and ``nodes.*``
+with the same import layout the application uses at runtime.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_SRC = Path(__file__).resolve().parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))

--- a/tests/test_basic_flow.py
+++ b/tests/test_basic_flow.py
@@ -1,0 +1,37 @@
+"""Unit tests for the most basic end-to-end flow: source -> sink."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import cv2
+import numpy as np
+
+from nodes.sinks.file_sink import FileSink
+from nodes.sources.file_source import FileSource
+
+
+def test_file_source_to_file_sink_saves_image(tmp_path: Path) -> None:
+    """A FileSource wired to a FileSink should, after source.start(),
+    write the frame the source read to the sink's output path."""
+    in_path = tmp_path / "in.png"
+    out_path = tmp_path / "out.png"
+
+    # Write a small, distinctive synthetic image so we can assert on the
+    # exact bytes that come out of the sink.
+    expected = np.full((8, 8, 3), fill_value=128, dtype=np.uint8)
+    assert cv2.imwrite(str(in_path), expected), "failed to write input fixture"
+
+    source = FileSource()
+    source.file_path = in_path
+
+    sink = FileSink()
+    sink.output_path = str(out_path)
+
+    # Wire source -> sink and drive the flow by starting the source directly.
+    source.outputs[0].connect(sink.inputs[0])
+    source.start()
+
+    assert out_path.exists(), "sink did not write an output file"
+    loaded = cv2.imread(str(out_path))
+    assert loaded is not None, "sink wrote a file but it is not a readable image"
+    np.testing.assert_array_equal(loaded, expected)


### PR DESCRIPTION
## Summary
This PR adds structural validation for node classes during registry scanning and implements safeguards for flow execution. It ensures that only valid nodes reach the palette and that flows have the required source and sink nodes before running.

## Key Changes

- **Node validation in registry**: Added `_validate_node_class()` to enforce that `start()` methods are only defined on source nodes. Non-source nodes with `start()` are now rejected during scanning with a clear error message, preventing silent failures at runtime.

- **Flow execution safeguards**: Enhanced `Flow.run()` to validate that the flow contains at least one source node (entry point) and at least one sink node (consumer) before execution. Raises `RuntimeError` with descriptive messages if either is missing.

- **Flow introspection properties**: Added `sources` and `sinks` properties to `Flow` for convenient access to filtered node lists in registration order.

- **Port callback registration**: Implemented `InputPort.set_on_data_received()` to allow nodes to register callbacks when ports are added. `NodeBase._add_input()` now wires each input port to the node's `_signal_input_ready` dispatcher, enabling the push-based execution model.

- **Test infrastructure**: Added `conftest.py` to configure pytest with proper import paths for `core.*` and `nodes.*` modules, and added `test_basic_flow.py` demonstrating end-to-end flow execution (FileSource → FileSink).

## Implementation Details

- Node validation occurs during `_parse_node_file()` and accumulates errors alongside valid node entries
- The `_has_method()` helper uses AST inspection to detect method definitions without requiring runtime imports
- Flow validation happens at the start of `run()` before any source nodes are started
- Port callbacks enable automatic signal propagation in the push-based execution model without requiring manual wiring

https://claude.ai/code/session_01XxNWWN2aNHcSPFuvFpamUb