### PR TITLE
Rebrand to Sparklehoof: splash screen, start page, README, and RGB filters

### DIFF
--- a/src/nodes/filters/rgb_join.py
+++ b/src/nodes/filters/rgb_join.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import cv2
+import numpy as np
+from typing_extensions import override
+
+from core.io_data import IoData, IoDataType
+from core.node_base import NodeBase, NodeParam, NodeParamType
+from core.port import InputPort, OutputPort
+
+
+class RgbJoin(NodeBase):
+    """Merge three single-channel images into a BGR image.
+
+    Inputs ``B``, ``G`` and ``R`` are combined with ``cv2.merge``. When
+    ``three_color`` is enabled, the merged image is further rendered into
+    a stylised BGR pattern on a 1.5×/2× upscaled canvas — ported unchanged
+    from the original OCVL ``RbgJoinProcessor``.
+    """
+
+    def __init__(self) -> None:
+        super().__init__("RGB Join")
+        self._three_color: bool = False
+
+        self._add_input(InputPort("B", {IoDataType.IMAGE}))
+        self._add_input(InputPort("G", {IoDataType.IMAGE}))
+        self._add_input(InputPort("R", {IoDataType.IMAGE}))
+        self._add_output(OutputPort("image", {IoDataType.IMAGE}))
+
+        # Sync attributes with declared NodeParam defaults; see
+        # NodeBase._apply_default_params for rationale.
+        self._apply_default_params()
+
+    # ── Parameters ─────────────────────────────────────────────────────────────
+
+    @property
+    @override
+    def params(self) -> list[NodeParam]:
+        return [NodeParam("three_color", NodeParamType.BOOL, {"default": False})]
+
+    # ── Properties ─────────────────────────────────────────────────────────────
+
+    @property
+    def three_color(self) -> bool:
+        return self._three_color
+
+    @three_color.setter
+    def three_color(self, value: bool) -> None:
+        self._three_color = bool(value)
+
+    # ── NodeBase interface ─────────────────────────────────────────────────────
+
+    @override
+    def process(self) -> None:
+        b = self.inputs[0].data.image
+        g = self.inputs[1].data.image
+        r = self.inputs[2].data.image
+
+        merged = cv2.merge((b, g, r))
+        if self._three_color:
+            merged = _rgbify(merged)
+        self.outputs[0].send(IoData.from_image(merged))
+
+
+def _rgbify(image: np.ndarray) -> np.ndarray:
+    """Scatter each source pixel's BGR samples across an upscaled canvas.
+
+    Faithful port of OCVL's ``RbgJoinProcessor.__rgbify``. No numba here —
+    the loop is O(w*h), so expect it to be slow on large frames; enable
+    ``three_color`` only when you want the stylised visualisation.
+    """
+    h, w, _ = image.shape
+    nh = h * 2
+    nw = int(w * 1.5)
+    rgb = np.zeros((nh, nw, 3), dtype=np.uint8)
+
+    for x in range(w):
+        for y in range(h):
+            b, g, r = image[y, x, :]
+            if x % 2 == 0:
+                ox = int(x * 1.5)
+                rgb[2 * y + 0, ox,     :] = (0, g, 0)
+                rgb[2 * y + 0, ox + 1, :] = (b, 0, 0)
+                rgb[2 * y + 1, ox,     :] = (0, 0, r)
+            else:
+                ox = 1 + int(x * 1.5 - 0.5)
+                rgb[2 * y + 0, ox,     :] = (0, 0, r)
+                rgb[2 * y + 1, ox,     :] = (b, 0, 0)
+                rgb[2 * y + 1, ox - 1, :] = (0, g, 0)
+    return rgb

--- a/src/nodes/filters/rgb_split.py
+++ b/src/nodes/filters/rgb_split.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import cv2
+import numpy as np
+from typing_extensions import override
+
+from core.io_data import IoData, IoDataType
+from core.node_base import NodeBase, NodeParam
+from core.port import InputPort, OutputPort
+
+
+class RgbSplit(NodeBase):
+    """Split a BGR image into its three channels.
+
+    Emits three single-channel (H×W) images on the ``B``, ``G`` and ``R``
+    output ports — matching ``cv2.split``'s channel order. Ported from the
+    original OCVL ``RgbSplitProcessor``.
+    """
+
+    def __init__(self) -> None:
+        super().__init__("RGB Split")
+        self._add_input(InputPort("image", {IoDataType.IMAGE}))
+        self._add_output(OutputPort("B", {IoDataType.IMAGE}))
+        self._add_output(OutputPort("G", {IoDataType.IMAGE}))
+        self._add_output(OutputPort("R", {IoDataType.IMAGE}))
+
+    @property
+    @override
+    def params(self) -> list[NodeParam]:
+        return []
+
+    @override
+    def process(self) -> None:
+        image: np.ndarray = self.inputs[0].data.image
+        b, g, r = cv2.split(image)
+        self.outputs[0].send(IoData.from_image(b))
+        self.outputs[1].send(IoData.from_image(g))
+        self.outputs[2].send(IoData.from_image(r))

--- a/src/ui/param_widgets.py
+++ b/src/ui/param_widgets.py
@@ -6,6 +6,7 @@ from typing import Callable
 
 from PySide6.QtCore import Qt
 from PySide6.QtWidgets import (
+    QCheckBox,
     QFileDialog,
     QHBoxLayout,
     QLineEdit,
@@ -83,9 +84,18 @@ def _build_int_param(node: NodeBase, param: NodeParam) -> QWidget:
     return spin
 
 
+def _build_bool_param(node: NodeBase, param: NodeParam) -> QWidget:
+    check = QCheckBox()
+    check.toggled.connect(_make_setter(node, param.name))
+    # See _build_file_path_param for the order rationale.
+    check.setChecked(bool(_initial_value(node, param, False)))
+    return check
+
+
 _PARAM_BUILDERS: dict[NodeParamType, Callable[[NodeBase, NodeParam], QWidget]] = {
     NodeParamType.FILE_PATH: _build_file_path_param,
     NodeParamType.INT:       _build_int_param,
+    NodeParamType.BOOL:      _build_bool_param,
 }
 
 


### PR DESCRIPTION
## Summary

Start of the **Sparklehoof** rebrand, plus the two RGB filter nodes that `flow/rgb_split.flowjs` was already referencing but that had never been committed.

The rebrand is intentionally partial: the user-facing surface (splash, start-page title, README) now says **Sparklehoof**, while `APP_NAME` / the log file / the user config dir (`~/.image-inquest/`) stay on `Image-Inquest` so existing installs don't quietly relocate their state. A full rename can follow in its own PR.

## Changes

### Splash screen (commit `3f7d2cf`)
- New `ASSETS_DIR`, `SPLASH_IMAGE_PATH` (→ `assets/title.png`), and `SPLASH_DURATION_MS` (1800 ms) constants.
- `main.py` builds a `QSplashScreen` before `MainWindow()` is constructed so the splash is visible during registry scanning.
- `QTimer.singleShot` enforces a minimum splash duration even on fast machines; `splash.finish(window)` hands off cleanly.
- Degrades gracefully: missing / unreadable `title.png` just skips the splash (logged, never fatal).
- New `--no-splash` CLI flag for iteration.

### Start-page display name (commit `0c4abf9`)
- New `APP_DISPLAY_NAME = "Sparklehoof"` alongside the existing `APP_NAME = "Image-Inquest"`.
- `StartPage` title label now reads from `APP_DISPLAY_NAME`; window title, log paths and user config dir are untouched.

### README refresh (commit `9ce5343`)
- Adds the splash image at the top (centered, 640 px).
- Retitle to **Sparklehoof** with a note about the in-progress rename.
- Correct the tech stack: **DearPyGUI → PySide6**; add NumPy, OpenCV, rawpy; switch install instructions to `pip install -r requirements.txt`.
- Drop the outdated "not yet implemented" status line — `Run`, flow save/load, and the source/filter/sink nodes are real now.
- Document the new `--no-splash` flag.
- Rewrite the Usage steps to match today's Create/Open/Palette/Run UI.

### RGB Split / RGB Join filter nodes (commit `90861f2`)
Ports of the OCVL `RgbSplitProcessor` and `RbgJoinProcessor` into proper `NodeBase` wrappers so `flow/rgb_split.flowjs` can be loaded.

- **`RgbSplit`** — 1 `image` input, 3 single-channel outputs (`B`, `G`, `R`) via `cv2.split`.
- **`RgbJoin`**  — 3 single-channel inputs merged with `cv2.merge`. Optional `three_color` BOOL param enables the faithful port of OCVL's `__rgbify` upscaled-scatter pattern. Dropped numba (not a project dependency) — the pure-python loop is correct but slow; only worth enabling for the stylised visualisation.
- **Param builders**: added `_build_bool_param` using `QCheckBox` and registered it under `NodeParamType.BOOL`. BOOL params previously rendered nothing and logged a warning.

## Files

| File | Change |
|---|---|
| `assets/title.png` | new — splash artwork |
| `src/constants.py` | `ASSETS_DIR`, `SPLASH_IMAGE_PATH`, `SPLASH_DURATION_MS`, `APP_DISPLAY_NAME` |
| `src/main.py` | splash wiring + `--no-splash` flag |
| `src/ui/start_page.py` | display `APP_DISPLAY_NAME` |
| `src/ui/param_widgets.py` | new BOOL builder (`QCheckBox`) |
| `src/nodes/filters/rgb_split.py` | new — `RgbSplit` node |
| `src/nodes/filters/rgb_join.py` | new — `RgbJoin` node |
| `README.md` | rebrand + accuracy pass |

## Test plan

- [ ] `python src/main.py` — splash appears briefly with the unicorn, then main window opens.
- [ ] `python src/main.py --no-splash` — no splash, main window opens immediately.
- [ ] Start page shows **Sparklehoof** as the large title; window title and logs still say `Image-Inquest`.
- [ ] Delete `assets/title.png` temporarily and relaunch — app still starts; log shows the "not found" debug line.
- [ ] Palette lists `RGB Split` and `RGB Join` under Filters.
- [ ] Drag a `File Source → RGB Split → RGB Join → File Sink` flow, connect B/G/R straight through; **Run** produces an output image identical to the input.
- [ ] Toggle `three_color` on `RgbJoin` via the new checkbox, **Run** — output is the upscaled stylised pattern.
- [ ] Open `flow/rgb_split.flowjs` — loads without missing-module errors. (See known issue below.)
- [ ] README renders on GitHub with the splash image at the top.

## Known issue / follow-up

`flow/rgb_split.flowjs` wires `RgbSplit → Grayscale → RgbJoin` on the G branch. It now **loads**, but may not **run**: `Grayscale.process()` calls `cv2.cvtColor(..., BGR2GRAY)`, which needs a 3-channel image, while `RgbSplit` emits single-channel arrays. Options (out of scope here):

1. Make `Grayscale` single-channel-tolerant (pass through when `ndim == 2`).
2. Remove the `Grayscale` step from that sample flow.

Happy to do either in a follow-up PR.

https://claude.ai/code/session_01KtUCaoDmH1K9fsbWPfXRaV