### PR TITLE
Fix segfault when opening a page's menu

### DIFF
--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -99,13 +99,15 @@ class MainWindow(QMainWindow):
         # Remove previously-installed page menus. The app menu is persistent.
         for menu in self._installed_page_menus:
             self._menu_bar.removeAction(menu.menuAction())
+            menu.deleteLater()
         self._installed_page_menus = []
 
-        # Install new page's menus before the Help menu (by inserting
-        # actions in order: each page menu goes at the end before Help).
+        # Install the new page's menus. Do NOT call ``menu.setParent(menu_bar)``
+        # — QMenuBar manages menus by their menuAction() and giving the QMenu
+        # the menubar as its Qt parent corrupts popup handling and crashes on
+        # first open. Holding a Python reference in ``_installed_page_menus``
+        # keeps the menu alive for as long as it is attached.
         for menu in page.page_menus():
-            # Re-parent so the menu's signals are owned by this window.
-            menu.setParent(self._menu_bar)
             self._menu_bar.addMenu(menu)
             self._installed_page_menus.append(menu)
 

--- a/src/ui/node_editor_page.py
+++ b/src/ui/node_editor_page.py
@@ -115,7 +115,7 @@ class NodeEditorPage(Page):
         # a View submenu to toggle the docks. The menu itself is rebuilt
         # on every activation because QMenu cannot be easily re-parented
         # across hosts.
-        menu = QMenu(self.page_title())
+        menu = QMenu("Node Editor")
         menu.addAction(self._actions["run"])
         menu.addAction(self._actions["save"])
         menu.addAction(self._actions["open"])


### PR DESCRIPTION
## Summary
- Calling `menu.setParent(menu_bar)` before `menu_bar.addMenu(menu)` corrupts Qt's menu ownership and segfaults the first time the user opens the menu.
- `QMenuBar.addMenu()` already wires the menu in via its `menuAction()`, and `_installed_page_menus` already holds a Python reference, so the explicit reparent was both unnecessary and harmful.
- Old page menus are now `deleteLater()`'d on page switches so they don't accumulate.

## Test plan
- [x] Reproduce the crash headless (`QT_QPA_PLATFORM=offscreen`) — `popup()` segfaults before the fix.
- [x] After the fix: open the Node Editor menu, switch pages, reopen the menu, trigger **Back**, open the persistent **File** menu — all succeed.
- [x] `--flow FILE` startup path + opening the Node Editor menu — succeeds.
- [ ] Manual smoke test on a real desktop session.

https://claude.ai/code/session_01HjE8tJ1nFtSWRUKQMPHiDL