### PR TITLE
Port six OCVL processors as built-in filter nodes

### DIFF
--- a/src/nodes/filters/adaptive_gaussian_threshold.py
+++ b/src/nodes/filters/adaptive_gaussian_threshold.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import cv2
+import numpy as np
+from typing_extensions import override
+
+from core.io_data import IoData, IoDataType
+from core.node_base import NodeBase, NodeParam, NodeParamType
+from core.port import InputPort, OutputPort
+
+
+class AdaptiveGaussianThreshold(NodeBase):
+    """Adaptive Gaussian binary threshold.
+
+    Wraps ``cv2.adaptiveThreshold`` with
+    ``ADAPTIVE_THRESH_GAUSSIAN_C`` and ``THRESH_BINARY``. ``block_size``
+    must be odd and > 1; ``c`` is the constant subtracted from the
+    weighted mean. Ported from the original OCVL
+    ``AdaptiveGuaussianThresholdProcessor`` [sic].
+
+    3-channel inputs are converted to grayscale first and the binary
+    result is re-broadcast to BGR so downstream nodes get the expected
+    3-channel format.
+    """
+
+    def __init__(self) -> None:
+        super().__init__("Adaptive Gaussian Threshold")
+        self._block_size: int = 101
+        self._c: int = -32
+
+        self._add_input(InputPort("image", {IoDataType.IMAGE}))
+        self._add_output(OutputPort("image", {IoDataType.IMAGE}))
+
+        self._apply_default_params()
+
+    # ── Parameters ─────────────────────────────────────────────────────────────
+
+    @property
+    @override
+    def params(self) -> list[NodeParam]:
+        return [
+            NodeParam("block_size", NodeParamType.INT, {"default": 101}),
+            NodeParam("c",          NodeParamType.INT, {"default": -32}),
+        ]
+
+    # ── Properties ─────────────────────────────────────────────────────────────
+
+    @property
+    def block_size(self) -> int:
+        return self._block_size
+
+    @block_size.setter
+    def block_size(self, value: int) -> None:
+        v = int(value)
+        if v < 3:
+            raise ValueError(f"block_size must be >= 3 (got {v})")
+        if v % 2 == 0:
+            # cv2.adaptiveThreshold requires odd — coerce like Median does.
+            v += 1
+        self._block_size = v
+
+    @property
+    def c(self) -> int:
+        return self._c
+
+    @c.setter
+    def c(self, value: int) -> None:
+        self._c = int(value)
+
+    # ── NodeBase interface ─────────────────────────────────────────────────────
+
+    @override
+    def process(self) -> None:
+        image: np.ndarray = self.inputs[0].data.image
+
+        if image.ndim == 3:
+            gray = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)
+        else:
+            gray = image
+
+        th = cv2.adaptiveThreshold(
+            gray,
+            255,
+            cv2.ADAPTIVE_THRESH_GAUSSIAN_C,
+            cv2.THRESH_BINARY,
+            self._block_size,
+            self._c,
+        )
+        out = cv2.cvtColor(th, cv2.COLOR_GRAY2BGR)
+        self.outputs[0].send(IoData.from_image(out))

--- a/src/nodes/filters/dither.py
+++ b/src/nodes/filters/dither.py
@@ -1,0 +1,230 @@
+from __future__ import annotations
+
+import math
+from enum import IntEnum
+
+import cv2
+import numpy as np
+from typing_extensions import override
+
+from core.io_data import IoData, IoDataType
+from core.node_base import NodeBase, NodeParam, NodeParamType
+from core.port import InputPort, OutputPort
+
+
+class DitherMethod(IntEnum):
+    """Dithering algorithms supported by :class:`Dither`.
+
+    The integer values match the ``method`` parameter so the node can
+    be driven from a plain INT UI control until a dedicated enum param
+    type exists.
+    """
+    BAYER2          = 1
+    BAYER4          = 2
+    BAYER8          = 3
+    NOISE           = 4
+    FLOYD_STEINBERG = 5
+    STUCKI          = 6
+    ATKINSON        = 7
+    BURKES          = 8
+    SIERRA          = 9
+    DIFFUSION_X     = 10
+    DIFFUSION_XY    = 11
+
+
+# Error-diffusion kernels laid out as (dy, dx, weight) triples — one
+# entry per neighbour that should receive a share of the quantisation
+# error. Matches the original OCVL layout (rows: current/next/next+1;
+# columns: x-2 .. x+2) but flattened so the inner loop is a simple
+# iteration instead of 12 guarded index expressions.
+_DIFFUSION_KERNELS: dict[DitherMethod, tuple[tuple[int, int, float], ...]] = {
+    DitherMethod.FLOYD_STEINBERG: (
+        (0, +1, 7 / 16),
+        (1, -1, 3 / 16), (1,  0, 5 / 16), (1, +1, 1 / 16),
+    ),
+    DitherMethod.STUCKI: (
+        (0, +1, 8 / 42), (0, +2, 4 / 42),
+        (1, -2, 2 / 42), (1, -1, 4 / 42), (1, 0, 8 / 42),
+        (1, +1, 4 / 42), (1, +2, 2 / 42),
+        (2, -2, 1 / 42), (2, -1, 2 / 42), (2, 0, 4 / 42),
+        (2, +1, 2 / 42), (2, +2, 1 / 42),
+    ),
+    DitherMethod.ATKINSON: (
+        (0, +1, 1 / 8), (0, +2, 1 / 8),
+        (1, -1, 1 / 8), (1, 0, 1 / 8), (1, +1, 1 / 8),
+        (2,  0, 1 / 8),
+    ),
+    DitherMethod.BURKES: (
+        (0, +1, 8 / 32), (0, +2, 4 / 32),
+        (1, -2, 2 / 32), (1, -1, 4 / 32), (1, 0, 8 / 32),
+        (1, +1, 4 / 32), (1, +2, 2 / 32),
+    ),
+    DitherMethod.SIERRA: (
+        (0, +1, 5 / 32), (0, +2, 3 / 32),
+        (1, -2, 2 / 32), (1, -1, 4 / 32), (1, 0, 5 / 32),
+        (1, +1, 4 / 32), (1, +2, 2 / 32),
+        (2, -1, 2 / 32), (2,  0, 3 / 32), (2, +1, 2 / 32),
+    ),
+    DitherMethod.DIFFUSION_X: (
+        (0, +1, 1.0),
+    ),
+    DitherMethod.DIFFUSION_XY: (
+        (0, +1, 0.5), (1, 0, 0.5),
+    ),
+}
+
+# Bayer ordered-dither matrices (2×2, 4×4, 8×8) — pre-computed so the
+# tiling step in ``process`` is a pure ``np.tile``.
+_BAYER_MATRICES: dict[DitherMethod, np.ndarray] = {
+    DitherMethod.BAYER2: np.array([
+        [0, 2],
+        [3, 1],
+    ]),
+    DitherMethod.BAYER4: np.array([
+        [ 0,  8,  2, 10],
+        [12,  4, 14,  6],
+        [ 3, 11,  1,  9],
+        [15,  7, 13,  5],
+    ]),
+    DitherMethod.BAYER8: np.array([
+        [ 0, 32,  8, 40,  2, 34, 10, 42],
+        [48, 16, 56, 24, 50, 18, 58, 26],
+        [12, 44,  4, 36, 14, 46,  6, 38],
+        [60, 28, 52, 20, 62, 30, 54, 22],
+        [ 3, 35, 11, 43,  1, 33,  9, 41],
+        [51, 19, 59, 27, 49, 17, 57, 25],
+        [15, 47,  7, 39, 13, 45,  5, 37],
+        [63, 31, 55, 23, 61, 29, 53, 21],
+    ]),
+}
+
+
+class Dither(NodeBase):
+    """Binary (black/white) dithering with a configurable algorithm.
+
+    Reduces an image to two levels (0 / 255) using one of the classic
+    ordered or error-diffusion schemes. Inputs can be single- or
+    three-channel — colour inputs are converted to grayscale first and
+    the binary result is re-broadcast to BGR so downstream nodes get
+    the expected 3-channel format. Ported from the original OCVL
+    ``DitherProcessor``; the ``numba`` JIT dependency is dropped so the
+    error-diffusion loop runs in pure Python / NumPy.
+    """
+
+    def __init__(self) -> None:
+        super().__init__("Dither")
+        self._method: int = int(DitherMethod.STUCKI)
+
+        self._add_input(InputPort("image", {IoDataType.IMAGE}))
+        self._add_output(OutputPort("image", {IoDataType.IMAGE}))
+
+        self._apply_default_params()
+
+    # ── Parameters ─────────────────────────────────────────────────────────────
+
+    @property
+    @override
+    def params(self) -> list[NodeParam]:
+        # Method is encoded as an int: see :class:`DitherMethod`.
+        # 1=Bayer2  2=Bayer4  3=Bayer8  4=Noise  5=Floyd-Steinberg
+        # 6=Stucki  7=Atkinson 8=Burkes 9=Sierra 10=DiffusionX 11=DiffusionXY
+        return [NodeParam("method", NodeParamType.INT, {"default": int(DitherMethod.STUCKI)})]
+
+    # ── Properties ─────────────────────────────────────────────────────────────
+
+    @property
+    def method(self) -> int:
+        return self._method
+
+    @method.setter
+    def method(self, value: int) -> None:
+        v = int(value)
+        try:
+            DitherMethod(v)
+        except ValueError as e:
+            raise ValueError(
+                f"method must be one of {[m.value for m in DitherMethod]} (got {v})"
+            ) from e
+        self._method = v
+
+    # ── NodeBase interface ─────────────────────────────────────────────────────
+
+    @override
+    def process(self) -> None:
+        image: np.ndarray = self.inputs[0].data.image
+
+        if image.ndim == 3:
+            gray = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)
+        else:
+            gray = image
+
+        method = DitherMethod(self._method)
+        if method == DitherMethod.NOISE:
+            out = _dither_noise(gray)
+        elif method in _BAYER_MATRICES:
+            out = _dither_bayer(gray, _BAYER_MATRICES[method])
+        else:
+            out = _dither_diffusion(gray, _DIFFUSION_KERNELS[method])
+
+        out_bgr = cv2.cvtColor(out, cv2.COLOR_GRAY2BGR)
+        self.outputs[0].send(IoData.from_image(out_bgr))
+
+
+# ── Dithering kernels ─────────────────────────────────────────────────────────
+
+def _dither_noise(gray: np.ndarray) -> np.ndarray:
+    """Threshold against Gaussian noise (μ=128, σ=50). Matches the OCVL
+    implementation — ``cv2.randn`` fills the noise image in place."""
+    noise = np.zeros_like(gray)
+    cv2.randn(noise, 128, 50)
+    return np.where(gray > noise, 255, 0).astype(np.uint8)
+
+
+def _dither_bayer(gray: np.ndarray, bayer: np.ndarray) -> np.ndarray:
+    """Ordered dither using a Bayer matrix.
+
+    Replaces the original nested-loop implementation with a vectorised
+    threshold — the matrix is tiled across the frame and each pixel is
+    compared against its threshold in one NumPy expression. The levels
+    branch in the OCVL code computed ``new_pixel`` but never used it,
+    so it is omitted here.
+    """
+    h, w = gray.shape
+    side = int(math.sqrt(bayer.size))
+    div = bayer.size
+    reps = (h // side + 1, w // side + 1)
+    tiled = np.tile(bayer, reps)[:h, :w]
+    threshold = tiled * 255 / div
+    return np.where(gray > threshold, 255, 0).astype(np.uint8)
+
+
+def _dither_diffusion(
+    gray: np.ndarray,
+    kernel: tuple[tuple[int, int, float], ...],
+) -> np.ndarray:
+    """Generic error-diffusion dither.
+
+    Walks the image in scanline order, quantising each pixel to 0 or
+    255 and distributing the quantisation error to the neighbours
+    listed in ``kernel`` as ``(dy, dx, weight)`` triples. Works on a
+    float copy so accumulated error stays in range before the final
+    clip. Pure-Python loop: without numba this is slow on large
+    frames, but produces identical output.
+    """
+    buf = gray.astype(np.float32).copy()
+    h, w = buf.shape
+
+    for y in range(h):
+        for x in range(w):
+            old = buf[y, x]
+            new = 255.0 if old > 127 else 0.0
+            buf[y, x] = new
+            err = old - new
+            if err == 0.0:
+                continue
+            for dy, dx, weight in kernel:
+                ny, nx = y + dy, x + dx
+                if 0 <= ny < h and 0 <= nx < w:
+                    buf[ny, nx] += err * weight
+
+    return np.clip(buf, 0, 255).astype(np.uint8)

--- a/src/nodes/filters/median.py
+++ b/src/nodes/filters/median.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import cv2
+import numpy as np
+from typing_extensions import override
+
+from core.io_data import IoData, IoDataType
+from core.node_base import NodeBase, NodeParam, NodeParamType
+from core.port import InputPort, OutputPort
+
+
+class Median(NodeBase):
+    """Apply a median blur with a square kernel.
+
+    Wraps ``cv2.medianBlur``; the kernel ``size`` must be odd and ≥ 1.
+    Ported from the original OCVL ``MedianProcessor``.
+    """
+
+    def __init__(self) -> None:
+        super().__init__("Median")
+        self._size: int = 3
+
+        self._add_input(InputPort("image", {IoDataType.IMAGE}))
+        self._add_output(OutputPort("image", {IoDataType.IMAGE}))
+
+        self._apply_default_params()
+
+    # ── Parameters ─────────────────────────────────────────────────────────────
+
+    @property
+    @override
+    def params(self) -> list[NodeParam]:
+        return [NodeParam("size", NodeParamType.INT, {"default": 3})]
+
+    # ── Properties ─────────────────────────────────────────────────────────────
+
+    @property
+    def size(self) -> int:
+        return self._size
+
+    @size.setter
+    def size(self, value: int) -> None:
+        v = int(value)
+        if v < 1:
+            raise ValueError(f"size must be >= 1 (got {v})")
+        if v % 2 == 0:
+            # cv2.medianBlur requires an odd kernel — round up rather than
+            # reject so the UI spinbox feels natural when the user types
+            # an even number mid-edit.
+            v += 1
+        self._size = v
+
+    # ── NodeBase interface ─────────────────────────────────────────────────────
+
+    @override
+    def process(self) -> None:
+        image: np.ndarray = self.inputs[0].data.image
+        blurred = cv2.medianBlur(image, self._size)
+        self.outputs[0].send(IoData.from_image(blurred))

--- a/src/nodes/filters/normalize.py
+++ b/src/nodes/filters/normalize.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import cv2
+import numpy as np
+from typing_extensions import override
+
+from core.io_data import IoData, IoDataType
+from core.node_base import NodeBase, NodeParam
+from core.port import InputPort, OutputPort
+
+
+class Normalize(NodeBase):
+    """Equalise the histogram of an image.
+
+    Applies ``cv2.equalizeHist`` — a per-channel operation on 8-bit
+    single-channel data. For BGR inputs each channel is equalised
+    independently (matching how downstream nodes expect a 3-channel
+    image). Ported from the original OCVL ``NormalizeProcessor``.
+    """
+
+    def __init__(self) -> None:
+        super().__init__("Normalize")
+        self._add_input(InputPort("image", {IoDataType.IMAGE}))
+        self._add_output(OutputPort("image", {IoDataType.IMAGE}))
+
+    @property
+    @override
+    def params(self) -> list[NodeParam]:
+        return []
+
+    @override
+    def process(self) -> None:
+        image: np.ndarray = self.inputs[0].data.image
+
+        if image.ndim == 2:
+            result = cv2.equalizeHist(image)
+        else:
+            # equalizeHist is single-channel only; split/apply/merge to
+            # keep a consistent 3-channel BGR output for downstream nodes.
+            channels = cv2.split(image)
+            equalised = [cv2.equalizeHist(c) for c in channels]
+            result = cv2.merge(equalised)
+
+        self.outputs[0].send(IoData.from_image(result))

--- a/src/nodes/filters/scale.py
+++ b/src/nodes/filters/scale.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import cv2
+import numpy as np
+from typing_extensions import override
+
+from core.io_data import IoData, IoDataType
+from core.node_base import NodeBase, NodeParam, NodeParamType
+from core.port import InputPort, OutputPort
+
+# OpenCV interpolation flags — exposed as a small int param so the UI
+# can offer "nearest / linear / cubic / area / lanczos4" as plain values.
+_INTERPOLATIONS: dict[int, int] = {
+    0: cv2.INTER_NEAREST,
+    1: cv2.INTER_LINEAR,
+    2: cv2.INTER_CUBIC,
+    3: cv2.INTER_AREA,
+    4: cv2.INTER_LANCZOS4,
+}
+
+
+class Scale(NodeBase):
+    """Resize an image by a percentage factor.
+
+    The input is resized by ``scale_percent`` (100 = no change). Ported
+    from the original OCVL ``ScaleProcessor`` — the target-size mode is
+    omitted here because there is no tuple param type; if an absolute
+    size is needed, compute the matching scale factor.
+    """
+
+    def __init__(self) -> None:
+        super().__init__("Scale")
+        self._scale_percent: int = 100
+        self._interpolation: int = 1  # Linear
+
+        self._add_input(InputPort("image", {IoDataType.IMAGE}))
+        self._add_output(OutputPort("image", {IoDataType.IMAGE}))
+
+        self._apply_default_params()
+
+    # ── Parameters ─────────────────────────────────────────────────────────────
+
+    @property
+    @override
+    def params(self) -> list[NodeParam]:
+        return [
+            NodeParam("scale_percent", NodeParamType.INT, {"default": 100}),
+            # 0=nearest, 1=linear, 2=cubic, 3=area, 4=lanczos4
+            NodeParam("interpolation", NodeParamType.INT, {"default": 1}),
+        ]
+
+    # ── Properties ─────────────────────────────────────────────────────────────
+
+    @property
+    def scale_percent(self) -> int:
+        return self._scale_percent
+
+    @scale_percent.setter
+    def scale_percent(self, value: int) -> None:
+        v = int(value)
+        if v <= 0:
+            raise ValueError(f"scale_percent must be > 0 (got {v})")
+        self._scale_percent = v
+
+    @property
+    def interpolation(self) -> int:
+        return self._interpolation
+
+    @interpolation.setter
+    def interpolation(self, value: int) -> None:
+        v = int(value)
+        if v not in _INTERPOLATIONS:
+            raise ValueError(
+                f"interpolation must be one of {sorted(_INTERPOLATIONS)} (got {v})"
+            )
+        self._interpolation = v
+
+    # ── NodeBase interface ─────────────────────────────────────────────────────
+
+    @override
+    def process(self) -> None:
+        image: np.ndarray = self.inputs[0].data.image
+        h, w = image.shape[:2]
+        factor = self._scale_percent / 100.0
+        new_w = max(1, int(round(w * factor)))
+        new_h = max(1, int(round(h * factor)))
+
+        resized = cv2.resize(
+            image,
+            (new_w, new_h),
+            interpolation=_INTERPOLATIONS[self._interpolation],
+        )
+        self.outputs[0].send(IoData.from_image(resized))

--- a/src/nodes/filters/shift.py
+++ b/src/nodes/filters/shift.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import cv2
+import numpy as np
+from typing_extensions import override
+
+from core.io_data import IoData, IoDataType
+from core.node_base import NodeBase, NodeParam, NodeParamType
+from core.port import InputPort, OutputPort
+
+
+class Shift(NodeBase):
+    """Translate an image by integer pixel offsets.
+
+    Uses ``cv2.warpAffine`` with a pure translation matrix so that the
+    output canvas keeps the input's width and height — pixels shifted
+    outside the frame are dropped and exposed areas are filled with
+    black (OpenCV's default border). Ported from the original OCVL
+    ``ShiftProcessor``.
+    """
+
+    def __init__(self) -> None:
+        super().__init__("Shift")
+        self._offset_x: int = 0
+        self._offset_y: int = 0
+
+        self._add_input(InputPort("image", {IoDataType.IMAGE}))
+        self._add_output(OutputPort("image", {IoDataType.IMAGE}))
+
+        self._apply_default_params()
+
+    # ── Parameters ─────────────────────────────────────────────────────────────
+
+    @property
+    @override
+    def params(self) -> list[NodeParam]:
+        return [
+            NodeParam("offset_x", NodeParamType.INT, {"default": 0}),
+            NodeParam("offset_y", NodeParamType.INT, {"default": 0}),
+        ]
+
+    # ── Properties ─────────────────────────────────────────────────────────────
+
+    @property
+    def offset_x(self) -> int:
+        return self._offset_x
+
+    @offset_x.setter
+    def offset_x(self, value: int) -> None:
+        self._offset_x = int(value)
+
+    @property
+    def offset_y(self) -> int:
+        return self._offset_y
+
+    @offset_y.setter
+    def offset_y(self, value: int) -> None:
+        self._offset_y = int(value)
+
+    # ── NodeBase interface ─────────────────────────────────────────────────────
+
+    @override
+    def process(self) -> None:
+        image: np.ndarray = self.inputs[0].data.image
+        h, w = image.shape[:2]
+        matrix = np.float32([[1, 0, self._offset_x],
+                             [0, 1, self._offset_y]])
+        shifted = cv2.warpAffine(image, matrix, (w, h))
+        self.outputs[0].send(IoData.from_image(shifted))

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1,0 +1,197 @@
+"""Unit tests for the filter nodes ported from OCVL."""
+from __future__ import annotations
+
+import cv2
+import numpy as np
+import pytest
+
+from core.io_data import IoData
+from nodes.filters.adaptive_gaussian_threshold import AdaptiveGaussianThreshold
+from nodes.filters.dither import Dither, DitherMethod
+from nodes.filters.median import Median
+from nodes.filters.normalize import Normalize
+from nodes.filters.scale import Scale
+from nodes.filters.shift import Shift
+
+
+def _bgr(h: int = 32, w: int = 32, value: int = 128) -> np.ndarray:
+    return np.full((h, w, 3), value, dtype=np.uint8)
+
+
+def _gradient(h: int = 16, w: int = 16) -> np.ndarray:
+    """Deterministic grayscale gradient useful for dither tests."""
+    row = np.linspace(0, 255, w, dtype=np.uint8)
+    return np.tile(row, (h, 1))
+
+
+def _run(node, image: np.ndarray) -> np.ndarray:
+    """Feed ``image`` into ``node``'s first input and return the first output."""
+    node.inputs[0].receive(IoData.from_image(image))
+    out = node.outputs[0].last_emitted
+    assert out is not None, "node did not emit on output 0"
+    return out.image
+
+
+# ── Shift ─────────────────────────────────────────────────────────────────────
+
+def test_shift_translates_image_by_offset() -> None:
+    image = np.zeros((8, 8, 3), dtype=np.uint8)
+    image[0, 0] = (255, 255, 255)
+
+    node = Shift()
+    node.offset_x = 2
+    node.offset_y = 1
+    out = _run(node, image)
+
+    assert out.shape == image.shape
+    np.testing.assert_array_equal(out[1, 2], (255, 255, 255))
+    np.testing.assert_array_equal(out[0, 0], (0, 0, 0))
+
+
+def test_shift_defaults_to_identity() -> None:
+    image = _bgr(8, 8, 200)
+    out = _run(Shift(), image)
+    np.testing.assert_array_equal(out, image)
+
+
+# ── Scale ─────────────────────────────────────────────────────────────────────
+
+def test_scale_doubles_dimensions_at_200_percent() -> None:
+    image = _bgr(10, 20)
+
+    node = Scale()
+    node.scale_percent = 200
+    out = _run(node, image)
+
+    assert out.shape == (20, 40, 3)
+
+
+def test_scale_halves_dimensions_at_50_percent() -> None:
+    image = _bgr(10, 20)
+
+    node = Scale()
+    node.scale_percent = 50
+    out = _run(node, image)
+
+    assert out.shape == (5, 10, 3)
+
+
+def test_scale_rejects_invalid_interpolation() -> None:
+    node = Scale()
+    with pytest.raises(ValueError):
+        node.interpolation = 99
+
+
+def test_scale_rejects_non_positive_percent() -> None:
+    node = Scale()
+    with pytest.raises(ValueError):
+        node.scale_percent = 0
+
+
+# ── Median ────────────────────────────────────────────────────────────────────
+
+def test_median_blurs_single_salt_pixel() -> None:
+    image = np.zeros((8, 8, 3), dtype=np.uint8)
+    image[4, 4] = (255, 255, 255)
+
+    out = _run(Median(), image)
+
+    # A single white pixel in a field of black vanishes under a 3×3 median.
+    assert out[4, 4].tolist() == [0, 0, 0]
+
+
+def test_median_coerces_even_size_to_next_odd() -> None:
+    node = Median()
+    node.size = 4
+    assert node.size == 5
+
+
+def test_median_rejects_non_positive_size() -> None:
+    node = Median()
+    with pytest.raises(ValueError):
+        node.size = 0
+
+
+# ── Normalize ─────────────────────────────────────────────────────────────────
+
+def test_normalize_matches_cv2_equalize_hist_per_channel() -> None:
+    rng = np.random.default_rng(0)
+    image = rng.integers(0, 128, size=(16, 16, 3), dtype=np.uint8)
+
+    out = _run(Normalize(), image)
+    expected = cv2.merge([cv2.equalizeHist(c) for c in cv2.split(image)])
+
+    np.testing.assert_array_equal(out, expected)
+
+
+def test_normalize_passes_through_grayscale_input() -> None:
+    rng = np.random.default_rng(1)
+    image = rng.integers(0, 128, size=(16, 16), dtype=np.uint8)
+
+    out = _run(Normalize(), image)
+    np.testing.assert_array_equal(out, cv2.equalizeHist(image))
+
+
+# ── AdaptiveGaussianThreshold ─────────────────────────────────────────────────
+
+def test_agauss_threshold_produces_bgr_binary_output() -> None:
+    rng = np.random.default_rng(2)
+    image = rng.integers(0, 256, size=(128, 128, 3), dtype=np.uint8)
+
+    node = AdaptiveGaussianThreshold()
+    out = _run(node, image)
+
+    assert out.shape == (128, 128, 3)
+    # Binary output: every channel is either 0 or 255, and all three
+    # channels are equal (GRAY2BGR).
+    unique = np.unique(out)
+    assert set(unique.tolist()).issubset({0, 255})
+    np.testing.assert_array_equal(out[..., 0], out[..., 1])
+    np.testing.assert_array_equal(out[..., 1], out[..., 2])
+
+
+def test_agauss_threshold_coerces_even_block_size() -> None:
+    node = AdaptiveGaussianThreshold()
+    node.block_size = 50
+    assert node.block_size == 51
+
+
+def test_agauss_threshold_rejects_tiny_block_size() -> None:
+    node = AdaptiveGaussianThreshold()
+    with pytest.raises(ValueError):
+        node.block_size = 1
+
+
+# ── Dither ────────────────────────────────────────────────────────────────────
+
+@pytest.mark.parametrize("method", list(DitherMethod))
+def test_dither_produces_bgr_binary_output(method: DitherMethod) -> None:
+    image = _gradient(h=8, w=8)
+
+    node = Dither()
+    node.method = int(method)
+    out = _run(node, image)
+
+    assert out.shape == (8, 8, 3)
+    assert set(np.unique(out).tolist()).issubset({0, 255})
+    np.testing.assert_array_equal(out[..., 0], out[..., 1])
+    np.testing.assert_array_equal(out[..., 1], out[..., 2])
+
+
+def test_dither_accepts_bgr_input() -> None:
+    # Gradient broadcast to 3 channels — the node should grayscale it.
+    gray = _gradient(h=8, w=8)
+    bgr = cv2.cvtColor(gray, cv2.COLOR_GRAY2BGR)
+
+    node = Dither()
+    node.method = int(DitherMethod.BAYER4)
+    out = _run(node, bgr)
+
+    assert out.shape == (8, 8, 3)
+    assert set(np.unique(out).tolist()).issubset({0, 255})
+
+
+def test_dither_rejects_unknown_method() -> None:
+    node = Dither()
+    with pytest.raises(ValueError):
+        node.method = 99


### PR DESCRIPTION
## Summary
- Adds `Dither`, `Shift`, `Scale`, `AdaptiveGaussianThreshold`, `Median`, and `Normalize` to `src/nodes/filters/`, each ported from the original OCVL processors.
- All six are picked up automatically by `NodeRegistry.scan_builtin` and appear in the Filters palette.
- Adapts each processor to the push-based `NodeBase` pipeline, drops the `numba` dependency (the dither error-diffusion path is pure NumPy), and exposes parameters using only the types the UI currently renders (`INT` / `BOOL`).
- Colour-sensitive filters (`Dither`, `AdaptiveGaussianThreshold`) accept BGR input, convert to grayscale internally, and re-broadcast the binary result back to BGR so downstream nodes keep a uniform three-channel contract — consistent with the existing `Grayscale` filter.

## Notes
- `Scale` omits the tuple-based target-size mode of the original because there is no tuple param type yet — a percentage factor covers the common case.
- Kernel-size setters coerce even values to the next odd value so a spinbox edit in the UI never lands on an invalid `cv2` input mid-typing.
- `Dither.method` is driven by an integer id (1–11) matching the `DitherMethod` enum; it can move to a dedicated enum/dropdown param type once one exists.

## Test plan
- [x] `pytest tests/test_filters.py` — 27 cases passing, including a parametrised sweep over every `DitherMethod`, shape / binary-output invariants, and validation-error paths.
- [x] Verified `NodeRegistry` discovers all six new classes (no scan errors, correct category / display names).

https://claude.ai/code/session_013v3V59aUvBjvQ8uxPoWDL6