### PR TITLE
Fix Delete key handling for embedded Qt widgets in flow scene

### DIFF
--- a/src/ui/flow_scene.py
+++ b/src/ui/flow_scene.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 from PySide6.QtCore import QPointF, Signal
 from PySide6.QtGui import QAction
 from PySide6.QtWidgets import (
+    QGraphicsProxyWidget,
     QGraphicsScene,
     QGraphicsSceneContextMenuEvent,
     QGraphicsSceneMouseEvent,
@@ -270,6 +271,13 @@ class FlowScene(QGraphicsScene):
     def keyPressEvent(self, event) -> None:  # type: ignore[override]
         from PySide6.QtCore import Qt
         if event.key() in (Qt.Key.Key_Delete, Qt.Key.Key_Backspace):
+            # If an embedded Qt widget (e.g. a node's path QLineEdit) holds
+            # focus, forward the key so the user can actually delete text.
+            # Otherwise Delete/Backspace would be swallowed here and the
+            # widget never sees it — instead deleting the selected node.
+            if isinstance(self.focusItem(), QGraphicsProxyWidget):
+                super().keyPressEvent(event)
+                return
             for s in list(self.selectedItems()):
                 if isinstance(s, NodeItem):
                     self.remove_node_item(s)


### PR DESCRIPTION
## Summary
Fixed an issue where the Delete/Backspace keys were being consumed by the flow scene instead of being forwarded to embedded Qt widgets (like QLineEdit) that have focus, preventing users from deleting text within those widgets.

## Changes
- Added import for `QGraphicsProxyWidget` from PySide6.QtWidgets
- Modified `keyPressEvent()` in `FlowScene` to check if focus is held by a `QGraphicsProxyWidget` before handling Delete/Backspace key events
- When an embedded widget has focus, the key event is now forwarded to the parent class instead of being consumed by the scene's node deletion logic

## Implementation Details
The fix adds a focus check that distinguishes between two scenarios:
1. **Embedded widget has focus**: The Delete/Backspace key is passed through via `super().keyPressEvent(event)` so the widget can handle text deletion
2. **Scene has focus**: The key event is handled normally, deleting selected nodes

This prevents the scene's node deletion behavior from interfering with text editing operations in embedded widgets like node property editors.

https://claude.ai/code/session_01BkVxRMWUmwUAbyLVD92D2B