### PR TITLE
Fix file-path field overlapping the browse button on nodes

### DIFF
--- a/src/ui/param_widgets.py
+++ b/src/ui/param_widgets.py
@@ -54,7 +54,11 @@ def _build_file_path_param(node: NodeBase, param: NodeParam) -> QWidget:
 
     line = QLineEdit()
     line.setPlaceholderText("Select a file…")
-    line.setMinimumWidth(180)
+    # Min width must leave room for the 28 px browse button + spacing
+    # inside the fixed-width node body, otherwise the line edit overflows
+    # and visually overlaps the button. The stretch factor below already
+    # makes the field fill any extra horizontal space.
+    line.setMinimumWidth(80)
     line.textChanged.connect(_make_setter(node, param.name))
     # Set the initial text *after* connecting so loaded flows / declared
     # defaults visibly populate the widget. Reading from the node first


### PR DESCRIPTION
## Summary
- The file-path param widget set `QLineEdit.setMinimumWidth(180)`, but the fixed 220 px node body (minus padding, spacing and the 28 px browse button) only leaves ~170 px. The minimum forced the line edit to overflow and visually cover the **…** button on every File Source / File Sink node.
- Lowered the minimum to 80 px so the `QHBoxLayout` can place both children within the node body. The existing `stretch=1` on the line edit still makes it fill any extra horizontal space, so wider nodes get a wider field.

## Test plan
- [ ] Add a File Source node — the path field and the **…** button are both fully visible inside the node, with no overlap.
- [ ] Same check for a File Sink node.
- [ ] Click the **…** button → file dialog opens (not blocked by the field).
- [ ] Type a long path into the field → text scrolls inside the field, button still visible.

https://claude.ai/code/session_01BkVxRMWUmwUAbyLVD92D2B