### PR TITLE
Unify pages under a global toolbar with page-selector radio group

### DIFF
--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -4,12 +4,15 @@ import logging
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from PySide6.QtGui import QAction, QKeySequence
+from PySide6.QtCore import QSize, Qt
+from PySide6.QtGui import QAction, QActionGroup, QKeySequence
 from PySide6.QtWidgets import (
     QMainWindow,
     QMenu,
     QMenuBar,
     QStackedWidget,
+    QToolBar,
+    QToolButton,
 )
 
 from constants import APP_NAME, BUILTIN_NODES_DIR, USER_NODES_DIR
@@ -58,7 +61,6 @@ class MainWindow(QMainWindow):
         # Wire page signals.
         self._start_page.create_flow_requested.connect(self._on_create_flow)
         self._start_page.open_flow_requested.connect(self._on_open_flow_from_start)
-        self._editor_page.back_requested.connect(self._go_to_start)
         for page in (self._start_page, self._editor_page):
             page.title_changed.connect(self._update_window_title)
 
@@ -66,6 +68,17 @@ class MainWindow(QMainWindow):
         self._menu_bar: QMenuBar = self.menuBar()
         self._app_menu = self._build_app_menu()
         self._installed_page_menus: list[QMenu] = []
+
+        # ── Toolbar ──
+        # A single global toolbar: page-selector radio group on the left,
+        # then the active page's own actions. Built once; the page-action
+        # tail is rebuilt on every page switch.
+        self._pages_in_order: list[Page] = [self._start_page, self._editor_page]
+        self._page_to_selector: dict[Page, QAction] = {}
+        self._installed_page_actions: list[QAction] = []
+        self._page_action_separator: QAction | None = None
+        self._toolbar = self._build_toolbar()
+        self.addToolBar(Qt.ToolBarArea.TopToolBarArea, self._toolbar)
 
         self._activate_page(self._start_page)
 
@@ -84,14 +97,22 @@ class MainWindow(QMainWindow):
     # ── Page switching ─────────────────────────────────────────────────────────
 
     def _activate_page(self, page: Page) -> None:
-        # Deactivate current.
+        # No-op when already on that page; otherwise we'd churn menus
+        # and re-emit on_activated for nothing.
         current = self._pages.currentWidget()
-        if isinstance(current, Page) and current is not page:
+        if current is page:
+            self._sync_page_selector(page)
+            return
+
+        # Deactivate current.
+        if isinstance(current, Page):
             current.on_deactivated()
 
         # Swap.
         self._pages.setCurrentWidget(page)
         self._install_page_menus(page)
+        self._install_page_actions(page)
+        self._sync_page_selector(page)
         self._update_window_title(page.page_title())
         page.on_activated()
 
@@ -110,6 +131,70 @@ class MainWindow(QMainWindow):
         for menu in page.page_menus():
             self._menu_bar.addMenu(menu)
             self._installed_page_menus.append(menu)
+
+    # ── Toolbar ────────────────────────────────────────────────────────────────
+
+    # Visual size shared by every toolbar button so the radio-style page
+    # selector and the page-specific actions all line up the same height.
+    _TOOLBAR_ICON_SIZE = QSize(20, 20)
+    _TOOLBAR_BUTTON_MIN_WIDTH = 110
+
+    def _build_toolbar(self) -> QToolBar:
+        tb = QToolBar("Main", self)
+        tb.setObjectName("MainToolbar")
+        tb.setMovable(False)
+        tb.setIconSize(self._TOOLBAR_ICON_SIZE)
+        tb.setToolButtonStyle(Qt.ToolButtonStyle.ToolButtonTextBesideIcon)
+
+        # Page-selector group: checkable, exclusive (radio behaviour).
+        group = QActionGroup(self)
+        group.setExclusive(True)
+        for page in self._pages_in_order:
+            action = QAction(page.page_label(), self)
+            action.setCheckable(True)
+            icon = page.page_icon()
+            if icon is not None:
+                action.setIcon(icon)
+            # `triggered` only fires when the user activates the button;
+            # an exclusive group never re-triggers an already-checked
+            # action, so guard against re-activating the same page anyway.
+            action.triggered.connect(lambda _checked, p=page: self._activate_page(p))
+            group.addAction(action)
+            tb.addAction(action)
+            self._page_to_selector[page] = action
+            self._enforce_button_size(tb, action)
+
+        # Separator before page-specific actions; recreated empty on each
+        # page switch through addAction calls below.
+        self._page_action_separator = tb.addSeparator()
+        return tb
+
+    def _install_page_actions(self, page: Page) -> None:
+        # Drop the previous page's actions but leave the page-selector
+        # group and the separator in place.
+        for action in self._installed_page_actions:
+            self._toolbar.removeAction(action)
+        self._installed_page_actions = []
+
+        for action in page.page_actions():
+            self._toolbar.addAction(action)
+            self._installed_page_actions.append(action)
+            self._enforce_button_size(self._toolbar, action)
+
+        # Hide the trailing separator when the active page contributes
+        # no actions, so we don't render a stray divider at the end.
+        if self._page_action_separator is not None:
+            self._page_action_separator.setVisible(bool(self._installed_page_actions))
+
+    def _sync_page_selector(self, page: Page) -> None:
+        action = self._page_to_selector.get(page)
+        if action is not None and not action.isChecked():
+            action.setChecked(True)
+
+    def _enforce_button_size(self, tb: QToolBar, action: QAction) -> None:
+        button = tb.widgetForAction(action)
+        if isinstance(button, QToolButton):
+            button.setMinimumWidth(self._TOOLBAR_BUTTON_MIN_WIDTH)
 
     # ── Menus ──────────────────────────────────────────────────────────────────
 
@@ -137,11 +222,6 @@ class MainWindow(QMainWindow):
             self._activate_page(self._editor_page)
         # On failure stay on the start page (status label won't help there
         # today; a follow-up could surface the error via QMessageBox).
-
-    def _go_to_start(self) -> None:
-        # Reset the editor so returning to it doesn't show stale nodes.
-        self._editor_page.set_flow(Flow())
-        self._activate_page(self._start_page)
 
     def _update_window_title(self, page_title: str) -> None:
         if page_title:

--- a/src/ui/node_editor_page.py
+++ b/src/ui/node_editor_page.py
@@ -5,9 +5,10 @@ from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from PySide6.QtCore import Qt, Signal
-from PySide6.QtGui import QAction
+from PySide6.QtCore import Qt
+from PySide6.QtGui import QAction, QIcon
 from PySide6.QtWidgets import (
+    QApplication,
     QDockWidget,
     QFileDialog,
     QLabel,
@@ -15,7 +16,7 @@ from PySide6.QtWidgets import (
     QMenu,
     QMessageBox,
     QStatusBar,
-    QToolBar,
+    QStyle,
     QVBoxLayout,
 )
 
@@ -46,11 +47,8 @@ class NodeEditorPage(Page):
     native Qt replacement for the old DPG show/hide button.
 
     Signals up to MainWindow:
-      * :attr:`back_requested` when the user clicks Back.
       * :attr:`title_changed` when the active flow name changes.
     """
-
-    back_requested = Signal()
 
     def __init__(self, registry: NodeRegistry) -> None:
         super().__init__()
@@ -89,10 +87,9 @@ class NodeEditorPage(Page):
         self._viewer_dock.setAllowedAreas(Qt.DockWidgetArea.AllDockWidgetAreas)
         self._inner.addDockWidget(Qt.DockWidgetArea.BottomDockWidgetArea, self._viewer_dock)
 
-        # Toolbar.
+        # Toolbar actions are owned by this page but installed on the
+        # outer MainWindow's global toolbar via page_actions().
         self._actions = self._build_actions()
-        self._toolbar = self._build_toolbar()
-        self._inner.addToolBar(Qt.ToolBarArea.TopToolBarArea, self._toolbar)
 
         # Status bar at the bottom of the inner window.
         self._status_bar = QStatusBar(self._inner)
@@ -109,6 +106,21 @@ class NodeEditorPage(Page):
         if self._flow is not None:
             return f"Node Editor [{self._flow.name}]"
         return "Node Editor"
+
+    def page_label(self) -> str:
+        return "Node Editor"
+
+    def page_icon(self) -> QIcon | None:
+        return QApplication.style().standardIcon(QStyle.StandardPixmap.SP_FileDialogDetailedView)
+
+    def page_actions(self) -> list[QAction]:
+        return [
+            self._actions["run"],
+            self._actions["save"],
+            self._actions["save_as"],
+            self._actions["open"],
+            self._actions["clear"],
+        ]
 
     def page_menus(self) -> list[QMenu]:
         # Single "Node Editor" menu mirroring the toolbar actions plus
@@ -127,9 +139,6 @@ class NodeEditorPage(Page):
         view_menu = menu.addMenu("View")
         view_menu.addAction(self._palette_dock.toggleViewAction())
         view_menu.addAction(self._viewer_dock.toggleViewAction())
-
-        menu.addSeparator()
-        menu.addAction(self._actions["back"])
         return [menu]
 
     def on_activated(self) -> None:
@@ -167,36 +176,28 @@ class NodeEditorPage(Page):
         )
         return True
 
-    # ── Toolbar and actions ────────────────────────────────────────────────────
+    # ── Toolbar actions ────────────────────────────────────────────────────────
 
     def _build_actions(self) -> dict[str, QAction]:
-        def mk(name: str, text: str, slot) -> QAction:
-            a = QAction(text, self)
+        style = QApplication.style()
+
+        def mk(name: str, text: str, slot, pixmap: QStyle.StandardPixmap) -> QAction:
+            a = QAction(style.standardIcon(pixmap), text, self)
             a.triggered.connect(slot)
             return a
-        return {
-            "run":     mk("run",     "Run",       self._on_run_clicked),
-            "save":    mk("save",    "Save",      self._on_save_clicked),
-            "save_as": mk("save_as", "Save As…",  self._on_save_as_clicked),
-            "open":    mk("open",    "Open",      self._on_open_clicked),
-            "clear":   mk("clear",   "Clear All", self._on_clear_clicked),
-            "back":    mk("back",    "Back",      self._on_back_clicked),
-        }
 
-    def _build_toolbar(self) -> QToolBar:
-        tb = QToolBar("Editor", self._inner)
-        tb.setObjectName("EditorToolbar")
-        tb.setMovable(False)
-        tb.addAction(self._actions["back"])
-        tb.addSeparator()
-        tb.addAction(self._actions["run"])
-        tb.addSeparator()
-        tb.addAction(self._actions["save"])
-        tb.addAction(self._actions["save_as"])
-        tb.addAction(self._actions["open"])
-        tb.addSeparator()
-        tb.addAction(self._actions["clear"])
-        return tb
+        return {
+            "run":     mk("run",     "Run",       self._on_run_clicked,
+                          QStyle.StandardPixmap.SP_MediaPlay),
+            "save":    mk("save",    "Save",      self._on_save_clicked,
+                          QStyle.StandardPixmap.SP_DialogSaveButton),
+            "save_as": mk("save_as", "Save As…",  self._on_save_as_clicked,
+                          QStyle.StandardPixmap.SP_DriveFDIcon),
+            "open":    mk("open",    "Open",      self._on_open_clicked,
+                          QStyle.StandardPixmap.SP_DialogOpenButton),
+            "clear":   mk("clear",   "Clear All", self._on_clear_clicked,
+                          QStyle.StandardPixmap.SP_DialogResetButton),
+        }
 
     # ── Action handlers ────────────────────────────────────────────────────────
 
@@ -291,9 +292,6 @@ class NodeEditorPage(Page):
         # Start from a fresh Flow with the same name so Save still targets
         # the same file. The scene clears via set_flow.
         self.set_flow(Flow(name=self._flow.name))
-
-    def _on_back_clicked(self) -> None:
-        self.back_requested.emit()
 
     # ── Status line ────────────────────────────────────────────────────────────
 

--- a/src/ui/page.py
+++ b/src/ui/page.py
@@ -6,7 +6,7 @@ from PySide6.QtCore import Signal
 from PySide6.QtWidgets import QWidget
 
 if TYPE_CHECKING:
-    from PySide6.QtGui import QAction
+    from PySide6.QtGui import QAction, QIcon
     from PySide6.QtWidgets import QMenu
 
 
@@ -26,6 +26,7 @@ class Page(QWidget):
 
     * build their widgets in ``__init__`` via a normal layout call,
     * return their per-page menus from :meth:`page_menus`,
+    * return their per-page toolbar actions from :meth:`page_actions`,
     * emit :attr:`title_changed` whenever their context (e.g. current
       flow name) changes.
     """
@@ -41,12 +42,26 @@ class Page(QWidget):
         return []
 
     def page_actions(self) -> list[QAction]:
-        """Optional list of toolbar actions the page contributes.
+        """Toolbar actions the page contributes.
 
-        Default: empty. MainWindow does not yet use this, but it keeps
-        the door open for shared toolbar slots.
+        MainWindow installs these on the global toolbar, immediately
+        after the page-selector buttons, while the page is active.
+        Default: empty.
         """
         return []
+
+    def page_label(self) -> str:
+        """Stable short label used by the page-selector toolbar button.
+
+        Distinct from :meth:`page_title` (which may include dynamic state
+        like the current flow name); this one is used for the toolbar
+        button and never changes.
+        """
+        return type(self).__name__
+
+    def page_icon(self) -> QIcon | None:
+        """Optional icon for the page-selector toolbar button."""
+        return None
 
     def page_title(self) -> str:
         """Human-readable page title used in the window caption."""

--- a/src/ui/start_page.py
+++ b/src/ui/start_page.py
@@ -4,7 +4,9 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from PySide6.QtCore import Qt, Signal
+from PySide6.QtGui import QIcon
 from PySide6.QtWidgets import (
+    QApplication,
     QFileDialog,
     QHBoxLayout,
     QLabel,
@@ -12,6 +14,7 @@ from PySide6.QtWidgets import (
     QPushButton,
     QSizePolicy,
     QSpacerItem,
+    QStyle,
     QVBoxLayout,
     QWidget,
 )
@@ -88,6 +91,12 @@ class StartPage(Page):
 
     def page_title(self) -> str:
         return ""  # MainWindow shows the bare app name on the start page
+
+    def page_label(self) -> str:
+        return "Start"
+
+    def page_icon(self) -> QIcon | None:
+        return QApplication.style().standardIcon(QStyle.StandardPixmap.SP_DirHomeIcon)
 
     def on_activated(self) -> None:
         self._name_input.setFocus(Qt.FocusReason.OtherFocusReason)


### PR DESCRIPTION
## Summary
- Each page now exposes its toolbar contributions via `Page.page_actions()`, plus a stable `page_label()` and optional `page_icon()` used by the page selector.
- `MainWindow` owns a single global toolbar split in two regions:
  - a checkable, exclusive `QActionGroup` acting as a radio-style page selector (one button per page, icon + text),
  - immediately to its right, the active page's own actions, rebuilt on every page switch.
- `NodeEditorPage` drops its inner toolbar and its Back action — the page selector handles navigation now — and decorates each action with a `QStyle` standard icon (Run, Save, Save As, Open, Clear).
- All toolbar buttons share the same icon size (20×20) and a common minimum width, so the selector and the page-specific buttons line up consistently.

## Test plan
- [ ] Launch the app — toolbar shows two radio-style buttons (Start / Node Editor) with icons; **Start** is checked.
- [ ] Click **Node Editor** in the selector → page switches, selector reflects the new page, and Run / Save / Save As… / Open / Clear All appear after a separator with consistent button width.
- [ ] Click **Start** in the selector → returns to the start page, page-specific buttons disappear, separator hidden.
- [ ] Click the already-checked button → no churn (no double-activation).
- [ ] From start page, click Create / Open → editor activates and the selector flips to **Node Editor**.
- [ ] Verify icons render on every button (page selector + page actions).

https://claude.ai/code/session_01BkVxRMWUmwUAbyLVD92D2B