### PR TITLE
Page-selector toolbar driven by per-page toolbar items

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -10,6 +10,7 @@ from PySide6.QtGui import QCursor, QGuiApplication, QPixmap, QScreen
 from PySide6.QtWidgets import QApplication, QSplashScreen
 
 from constants import (
+    APP_DISPLAY_NAME,
     APP_NAME,
     APP_VERSION,
     FLOW_DIR,
@@ -116,7 +117,7 @@ def main(argv: list[str]) -> int:
     # with the program name so QApplication.arguments() behaves normally.
     app = QApplication([sys.argv[0], *qt_args])
     app.setApplicationName(APP_NAME)
-    app.setApplicationDisplayName(APP_NAME)
+    app.setApplicationDisplayName(APP_DISPLAY_NAME)
     app.setApplicationVersion(APP_VERSION)
     apply_dark_theme(app)
 

--- a/src/main.py
+++ b/src/main.py
@@ -10,7 +10,6 @@ from PySide6.QtGui import QCursor, QGuiApplication, QPixmap, QScreen
 from PySide6.QtWidgets import QApplication, QSplashScreen
 
 from constants import (
-    APP_DISPLAY_NAME,
     APP_NAME,
     APP_VERSION,
     FLOW_DIR,
@@ -117,7 +116,11 @@ def main(argv: list[str]) -> int:
     # with the program name so QApplication.arguments() behaves normally.
     app = QApplication([sys.argv[0], *qt_args])
     app.setApplicationName(APP_NAME)
-    app.setApplicationDisplayName(APP_DISPLAY_NAME)
+    # Qt and some window managers auto-append applicationDisplayName to
+    # every window caption, which would duplicate the prefix MainWindow
+    # already renders (e.g. "Sparklehoof — flow — Sparklehoof"). We
+    # build the full caption ourselves, so clear the display name.
+    app.setApplicationDisplayName("")
     app.setApplicationVersion(APP_VERSION)
     apply_dark_theme(app)
 

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -15,7 +15,7 @@ from PySide6.QtWidgets import (
     QToolButton,
 )
 
-from constants import APP_NAME, BUILTIN_NODES_DIR, USER_NODES_DIR
+from constants import APP_DISPLAY_NAME, BUILTIN_NODES_DIR, USER_NODES_DIR
 from core.flow import Flow
 from core.node_registry import NodeRegistry
 from ui.node_editor_page import NodeEditorPage
@@ -50,7 +50,7 @@ class MainWindow(QMainWindow):
 
     def __init__(self, initial_flow_path: Path | None = None) -> None:
         super().__init__()
-        self.setWindowTitle(APP_NAME)
+        self.setWindowTitle(APP_DISPLAY_NAME)
 
         # ── Node registry ──
         self._registry = NodeRegistry()
@@ -249,6 +249,6 @@ class MainWindow(QMainWindow):
 
     def _update_window_title(self, page_title: str) -> None:
         if page_title:
-            self.setWindowTitle(f"{APP_NAME} — {page_title}")
+            self.setWindowTitle(f"{APP_DISPLAY_NAME} — {page_title}")
         else:
-            self.setWindowTitle(APP_NAME)
+            self.setWindowTitle(APP_DISPLAY_NAME)

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -4,12 +4,15 @@ import logging
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from PySide6.QtGui import QAction, QKeySequence
+from PySide6.QtCore import QSize, Qt
+from PySide6.QtGui import QAction, QActionGroup, QKeySequence
 from PySide6.QtWidgets import (
     QMainWindow,
     QMenu,
     QMenuBar,
     QStackedWidget,
+    QToolBar,
+    QToolButton,
 )
 
 from constants import APP_NAME, BUILTIN_NODES_DIR, USER_NODES_DIR
@@ -24,12 +27,24 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+# Size of icons rendered inside every toolbar button.
+_TOOLBAR_ICON_SIZE = QSize(20, 20)
+
 
 class MainWindow(QMainWindow):
-    """Top-level window. Hosts the page stack and the global menu bar.
+    """Top-level window. Hosts the page stack, the global menu bar, and
+    the application toolbar.
+
+    The toolbar is split into two regions:
+
+    * a **page-selector** radio group (one checkable action per page),
+      which swaps the active page when toggled, and
+    * **page-specific actions** installed next to the selector,
+      contributed by the active page via :meth:`Page.page_toolbar_actions`.
 
     MainWindow is the only place that knows about all pages. Each page
-    contributes its own menus via :meth:`Page.page_menus`; MainWindow
+    contributes its own menus via :meth:`Page.page_menus` and its own
+    toolbar items via :meth:`Page.page_toolbar_actions`; MainWindow
     clears and re-installs them on every page switch.
     """
 
@@ -51,6 +66,10 @@ class MainWindow(QMainWindow):
 
         self._start_page  = StartPage()
         self._editor_page = NodeEditorPage(self._registry)
+        # Seed the editor with an empty flow so the user can switch to it
+        # via the page-selector radio group at any time without first
+        # visiting the start page to create one.
+        self._editor_page.set_flow(Flow())
 
         self._pages.addWidget(self._start_page)
         self._pages.addWidget(self._editor_page)
@@ -58,7 +77,6 @@ class MainWindow(QMainWindow):
         # Wire page signals.
         self._start_page.create_flow_requested.connect(self._on_create_flow)
         self._start_page.open_flow_requested.connect(self._on_open_flow_from_start)
-        self._editor_page.back_requested.connect(self._go_to_start)
         for page in (self._start_page, self._editor_page):
             page.title_changed.connect(self._update_window_title)
 
@@ -66,6 +84,20 @@ class MainWindow(QMainWindow):
         self._menu_bar: QMenuBar = self.menuBar()
         self._app_menu = self._build_app_menu()
         self._installed_page_menus: list[QMenu] = []
+
+        # ── Toolbar ──
+        self._toolbar = self._build_toolbar()
+        self._installed_page_actions: list[QAction] = []
+        self._page_separator: QAction | None = None
+
+        self._page_selector_group = QActionGroup(self)
+        self._page_selector_group.setExclusive(True)
+        self._page_selector_actions: dict[Page, QAction] = {}
+        for page in (self._start_page, self._editor_page):
+            self._add_page_selector_action(page)
+        # Separator between the page-selector radio group and the
+        # page-specific toolbar actions.
+        self._page_separator = self._toolbar.addSeparator()
 
         self._activate_page(self._start_page)
 
@@ -92,6 +124,10 @@ class MainWindow(QMainWindow):
         # Swap.
         self._pages.setCurrentWidget(page)
         self._install_page_menus(page)
+        self._install_page_toolbar_actions(page)
+        selector = self._page_selector_actions.get(page)
+        if selector is not None and not selector.isChecked():
+            selector.setChecked(True)
         self._update_window_title(page.page_title())
         page.on_activated()
 
@@ -110,6 +146,79 @@ class MainWindow(QMainWindow):
         for menu in page.page_menus():
             self._menu_bar.addMenu(menu)
             self._installed_page_menus.append(menu)
+
+    # ── Toolbar ────────────────────────────────────────────────────────────────
+
+    def _build_toolbar(self) -> QToolBar:
+        tb = QToolBar("Main", self)
+        tb.setObjectName("MainToolbar")
+        tb.setMovable(False)
+        tb.setFloatable(False)
+        tb.setIconSize(_TOOLBAR_ICON_SIZE)
+        tb.setToolButtonStyle(Qt.ToolButtonStyle.ToolButtonTextBesideIcon)
+        self.addToolBar(Qt.ToolBarArea.TopToolBarArea, tb)
+        return tb
+
+    def _add_page_selector_action(self, page: Page) -> None:
+        action = QAction(page.page_selector_icon(), page.page_selector_label(), self)
+        action.setCheckable(True)
+        action.setToolTip(f"Switch to {page.page_selector_label()}")
+        # ``toggled`` fires both for user clicks and for programmatic
+        # ``setChecked`` calls; guard against re-entering _activate_page
+        # when the selector is being driven from _activate_page itself.
+        action.toggled.connect(lambda checked, p=page: self._on_page_selector_toggled(p, checked))
+        self._page_selector_group.addAction(action)
+        self._toolbar.addAction(action)
+        self._page_selector_actions[page] = action
+
+    def _on_page_selector_toggled(self, page: Page, checked: bool) -> None:
+        if not checked:
+            return
+        if self._pages.currentWidget() is page:
+            return
+        self._activate_page(page)
+
+    def _install_page_toolbar_actions(self, page: Page) -> None:
+        # Remove previously-installed page-specific actions. These
+        # QActions are owned by the page, so we only detach them from the
+        # toolbar — do not deleteLater.
+        for action in self._installed_page_actions:
+            self._toolbar.removeAction(action)
+        self._installed_page_actions = []
+
+        for action in page.page_toolbar_actions():
+            self._toolbar.addAction(action)
+            self._installed_page_actions.append(action)
+
+        self._apply_consistent_button_sizes()
+
+    def _apply_consistent_button_sizes(self) -> None:
+        """Force every QToolButton in the main toolbar to the same size.
+
+        Computed as the max size hint across all buttons so the longest
+        label (plus icon) fits, and every button matches.
+        """
+        buttons: list[QToolButton] = []
+        for action in self._toolbar.actions():
+            if action.isSeparator():
+                continue
+            widget = self._toolbar.widgetForAction(action)
+            if isinstance(widget, QToolButton):
+                # Clear any previously-set fixed size so sizeHint reflects
+                # the button's natural content for the current action set.
+                widget.setMinimumSize(0, 0)
+                widget.setMaximumSize(16777215, 16777215)
+                widget.adjustSize()
+                buttons.append(widget)
+
+        if not buttons:
+            return
+
+        max_w = max(b.sizeHint().width()  for b in buttons)
+        max_h = max(b.sizeHint().height() for b in buttons)
+        size  = QSize(max_w, max_h)
+        for b in buttons:
+            b.setFixedSize(size)
 
     # ── Menus ──────────────────────────────────────────────────────────────────
 
@@ -137,11 +246,6 @@ class MainWindow(QMainWindow):
             self._activate_page(self._editor_page)
         # On failure stay on the start page (status label won't help there
         # today; a follow-up could surface the error via QMessageBox).
-
-    def _go_to_start(self) -> None:
-        # Reset the editor so returning to it doesn't show stale nodes.
-        self._editor_page.set_flow(Flow())
-        self._activate_page(self._start_page)
 
     def _update_window_title(self, page_title: str) -> None:
         if page_title:

--- a/src/ui/node_editor_page.py
+++ b/src/ui/node_editor_page.py
@@ -102,9 +102,12 @@ class NodeEditorPage(Page):
     # ── Page hooks ─────────────────────────────────────────────────────────────
 
     def page_title(self) -> str:
+        # Return just the flow name (or empty) so MainWindow renders a
+        # title like "Sparklehoof — MyFlow" rather than embedding the
+        # page's role in the window caption.
         if self._flow is not None:
-            return f"Node Editor [{self._flow.name}]"
-        return "Node Editor"
+            return self._flow.name
+        return ""
 
     def page_selector_label(self) -> str:
         return "Editor"

--- a/src/ui/node_editor_page.py
+++ b/src/ui/node_editor_page.py
@@ -5,8 +5,8 @@ from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from PySide6.QtCore import Qt, Signal
-from PySide6.QtGui import QAction
+from PySide6.QtCore import Qt
+from PySide6.QtGui import QAction, QIcon
 from PySide6.QtWidgets import (
     QDockWidget,
     QFileDialog,
@@ -15,7 +15,7 @@ from PySide6.QtWidgets import (
     QMenu,
     QMessageBox,
     QStatusBar,
-    QToolBar,
+    QStyle,
     QVBoxLayout,
 )
 
@@ -42,15 +42,13 @@ class NodeEditorPage(Page):
     """The editor. Central canvas + palette dock (left) + viewer dock (bottom).
 
     Dockable panels are hosted on an inner QMainWindow so the palette and
-    viewer can be dragged around, floated, or closed by the user — the
-    native Qt replacement for the old DPG show/hide button.
+    viewer can be dragged around, floated, or closed by the user. Toolbar
+    actions are exposed via :meth:`page_toolbar_actions` so MainWindow can
+    render them in the global toolbar next to the page-selector radio group.
 
-    Signals up to MainWindow:
-      * :attr:`back_requested` when the user clicks Back.
-      * :attr:`title_changed` when the active flow name changes.
+    Signal :attr:`title_changed` fires up to MainWindow whenever the active
+    flow name changes.
     """
-
-    back_requested = Signal()
 
     def __init__(self, registry: NodeRegistry) -> None:
         super().__init__()
@@ -89,10 +87,8 @@ class NodeEditorPage(Page):
         self._viewer_dock.setAllowedAreas(Qt.DockWidgetArea.AllDockWidgetAreas)
         self._inner.addDockWidget(Qt.DockWidgetArea.BottomDockWidgetArea, self._viewer_dock)
 
-        # Toolbar.
+        # Actions: reused by both the page menu and the main toolbar.
         self._actions = self._build_actions()
-        self._toolbar = self._build_toolbar()
-        self._inner.addToolBar(Qt.ToolBarArea.TopToolBarArea, self._toolbar)
 
         # Status bar at the bottom of the inner window.
         self._status_bar = QStatusBar(self._inner)
@@ -109,6 +105,21 @@ class NodeEditorPage(Page):
         if self._flow is not None:
             return f"Node Editor [{self._flow.name}]"
         return "Node Editor"
+
+    def page_selector_label(self) -> str:
+        return "Editor"
+
+    def page_selector_icon(self) -> QIcon:
+        return self.style().standardIcon(QStyle.StandardPixmap.SP_FileDialogListView)
+
+    def page_toolbar_actions(self) -> list[QAction]:
+        return [
+            self._actions["run"],
+            self._actions["save"],
+            self._actions["save_as"],
+            self._actions["open"],
+            self._actions["clear"],
+        ]
 
     def page_menus(self) -> list[QMenu]:
         # Single "Node Editor" menu mirroring the toolbar actions plus
@@ -127,9 +138,6 @@ class NodeEditorPage(Page):
         view_menu = menu.addMenu("View")
         view_menu.addAction(self._palette_dock.toggleViewAction())
         view_menu.addAction(self._viewer_dock.toggleViewAction())
-
-        menu.addSeparator()
-        menu.addAction(self._actions["back"])
         return [menu]
 
     def on_activated(self) -> None:
@@ -167,36 +175,23 @@ class NodeEditorPage(Page):
         )
         return True
 
-    # ── Toolbar and actions ────────────────────────────────────────────────────
+    # ── Actions ────────────────────────────────────────────────────────────────
 
     def _build_actions(self) -> dict[str, QAction]:
-        def mk(name: str, text: str, slot) -> QAction:
-            a = QAction(text, self)
+        style = self.style()
+
+        def mk(text: str, icon_id: QStyle.StandardPixmap, slot) -> QAction:
+            a = QAction(style.standardIcon(icon_id), text, self)
             a.triggered.connect(slot)
             return a
-        return {
-            "run":     mk("run",     "Run",       self._on_run_clicked),
-            "save":    mk("save",    "Save",      self._on_save_clicked),
-            "save_as": mk("save_as", "Save As…",  self._on_save_as_clicked),
-            "open":    mk("open",    "Open",      self._on_open_clicked),
-            "clear":   mk("clear",   "Clear All", self._on_clear_clicked),
-            "back":    mk("back",    "Back",      self._on_back_clicked),
-        }
 
-    def _build_toolbar(self) -> QToolBar:
-        tb = QToolBar("Editor", self._inner)
-        tb.setObjectName("EditorToolbar")
-        tb.setMovable(False)
-        tb.addAction(self._actions["back"])
-        tb.addSeparator()
-        tb.addAction(self._actions["run"])
-        tb.addSeparator()
-        tb.addAction(self._actions["save"])
-        tb.addAction(self._actions["save_as"])
-        tb.addAction(self._actions["open"])
-        tb.addSeparator()
-        tb.addAction(self._actions["clear"])
-        return tb
+        return {
+            "run":     mk("Run",      QStyle.StandardPixmap.SP_MediaPlay,        self._on_run_clicked),
+            "save":    mk("Save",     QStyle.StandardPixmap.SP_DialogSaveButton, self._on_save_clicked),
+            "save_as": mk("Save As…", QStyle.StandardPixmap.SP_DriveFDIcon,      self._on_save_as_clicked),
+            "open":    mk("Open",     QStyle.StandardPixmap.SP_DirOpenIcon,      self._on_open_clicked),
+            "clear":   mk("Clear",    QStyle.StandardPixmap.SP_TrashIcon,        self._on_clear_clicked),
+        }
 
     # ── Action handlers ────────────────────────────────────────────────────────
 
@@ -291,9 +286,6 @@ class NodeEditorPage(Page):
         # Start from a fresh Flow with the same name so Save still targets
         # the same file. The scene clears via set_flow.
         self.set_flow(Flow(name=self._flow.name))
-
-    def _on_back_clicked(self) -> None:
-        self.back_requested.emit()
 
     # ── Status line ────────────────────────────────────────────────────────────
 

--- a/src/ui/page.py
+++ b/src/ui/page.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from PySide6.QtCore import Signal
+from PySide6.QtGui import QIcon
 from PySide6.QtWidgets import QWidget
 
 if TYPE_CHECKING:
@@ -14,9 +15,12 @@ class Page(QWidget):
     """Base class for every top-level page stacked inside MainWindow.
 
     A page owns a QWidget body (populated by the subclass) and optionally
-    a list of QMenus that the host main-window installs on the global
-    menu bar while the page is active, and removes when the page is
-    deactivated.
+    contributes:
+
+    * a list of QMenus installed on the global menu bar while the page
+      is active (see :meth:`page_menus`), and
+    * a list of QActions installed on the application toolbar next to
+      the page-selector radio group (see :meth:`page_toolbar_actions`).
 
     The :attr:`title_changed` signal lets a page request that the main
     window update the window title without knowing about the main window
@@ -26,6 +30,7 @@ class Page(QWidget):
 
     * build their widgets in ``__init__`` via a normal layout call,
     * return their per-page menus from :meth:`page_menus`,
+    * return their per-page toolbar items from :meth:`page_toolbar_actions`,
     * emit :attr:`title_changed` whenever their context (e.g. current
       flow name) changes.
     """
@@ -40,17 +45,31 @@ class Page(QWidget):
         """
         return []
 
-    def page_actions(self) -> list[QAction]:
-        """Optional list of toolbar actions the page contributes.
+    def page_toolbar_actions(self) -> list[QAction]:
+        """Return the actions this page contributes to the main toolbar.
 
-        Default: empty. MainWindow does not yet use this, but it keeps
-        the door open for shared toolbar slots.
+        MainWindow installs these next to the page-selector radio group
+        while the page is active and removes them when the page is
+        deactivated. Default: empty.
         """
         return []
 
     def page_title(self) -> str:
         """Human-readable page title used in the window caption."""
         return ""
+
+    def page_selector_label(self) -> str:
+        """Short label for the page-selector radio group.
+
+        Kept separate from :meth:`page_title` because the window caption
+        may be long and context-dependent (e.g. including a flow name)
+        while the selector button needs a terse fixed label.
+        """
+        return self.page_title() or type(self).__name__
+
+    def page_selector_icon(self) -> QIcon:
+        """Icon for the page-selector radio group. Default: empty."""
+        return QIcon()
 
     # ── Lifecycle ──────────────────────────────────────────────────────────────
 

--- a/src/ui/start_page.py
+++ b/src/ui/start_page.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from PySide6.QtCore import Qt, Signal
+from PySide6.QtGui import QAction, QIcon
 from PySide6.QtWidgets import (
     QFileDialog,
     QHBoxLayout,
@@ -12,6 +13,7 @@ from PySide6.QtWidgets import (
     QPushButton,
     QSizePolicy,
     QSpacerItem,
+    QStyle,
     QVBoxLayout,
     QWidget,
 )
@@ -39,6 +41,15 @@ class StartPage(Page):
 
     def __init__(self, parent: QWidget | None = None) -> None:
         super().__init__(parent)
+
+        # Toolbar action: mirrors the "Open" button in the body so the
+        # start page contributes at least one item to the main toolbar.
+        self._open_action = QAction(
+            self.style().standardIcon(QStyle.StandardPixmap.SP_DirOpenIcon),
+            "Open",
+            self,
+        )
+        self._open_action.triggered.connect(self._on_open_clicked)
 
         root = QVBoxLayout(self)
         root.setContentsMargins(40, 60, 40, 40)
@@ -88,6 +99,15 @@ class StartPage(Page):
 
     def page_title(self) -> str:
         return ""  # MainWindow shows the bare app name on the start page
+
+    def page_selector_label(self) -> str:
+        return "Start"
+
+    def page_selector_icon(self) -> QIcon:
+        return self.style().standardIcon(QStyle.StandardPixmap.SP_DirHomeIcon)
+
+    def page_toolbar_actions(self) -> list[QAction]:
+        return [self._open_action]
 
     def on_activated(self) -> None:
         self._name_input.setFocus(Qt.FocusReason.OtherFocusReason)

--- a/src/ui/theme.py
+++ b/src/ui/theme.py
@@ -66,6 +66,13 @@ QToolButton:hover, QPushButton:hover {
 QToolButton:pressed, QPushButton:pressed {
     background: #2c2c30;
 }
+QToolButton:checked {
+    background: #3a5b8a;
+    border-color: #5a7bb0;
+}
+QToolButton:checked:hover {
+    background: #456bac;
+}
 QPushButton:disabled {
     background: #2d2d30;
     color: #707070;


### PR DESCRIPTION
## Summary

- Each `Page` now exports its own toolbar items via a new `page_toolbar_actions()` hook, plus a short label and icon for the page selector.
- `MainWindow` hosts a single top toolbar: a page-selector radio group on the left (checkable `QAction`s in an exclusive `QActionGroup`) and the active page's actions next to it.
- Every toolbar button carries an icon (standard Qt pixmaps) and is forced to the same width/height — max sizeHint across all buttons — so sizes stay uniform as page-specific actions swap in and out.
- The old `NodeEditorPage` internal toolbar and back-to-start flow reset are gone; switching between pages via the selector now preserves full editor state (flow, scene, nodes, flow name). The editor is seeded with an empty `Flow` at startup so it's always reachable.
- Dark theme gains a `QToolButton:checked` style so the currently-active page stands out in the selector.

## Test plan

- [x] `pytest tests/` — 28/28 pass
- [x] Offscreen smoke test: switch Start → Editor → Start → Editor repeatedly; assert `Flow` and `FlowScene` identities are preserved and the flow name survives.
- [x] Offscreen smoke test: every toolbar button on the editor page has the same (105×33) size and every button has a non-null icon.
- [ ] Manual: verify visual appearance of radio group + per-page buttons with a real display server.

https://claude.ai/code/session_01Ho3Ew3ai1CV2zPxq7mZBsi