### PR TITLE
Simplify toolbar button sizing with fixed dimensions

### DIFF
--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -27,9 +27,9 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-# Size of icons rendered inside every toolbar button. Buttons render the
-# label beneath the icon, so this size also drives the button height.
-_TOOLBAR_ICON_SIZE = QSize(32, 32)
+# Icon size and fixed button dimensions for the main toolbar.
+_TOOLBAR_ICON_SIZE   = QSize(40, 40)
+_TOOLBAR_BUTTON_SIZE = QSize(72, 72)
 
 
 class MainWindow(QMainWindow):
@@ -194,32 +194,13 @@ class MainWindow(QMainWindow):
         self._apply_consistent_button_sizes()
 
     def _apply_consistent_button_sizes(self) -> None:
-        """Force every QToolButton in the main toolbar to the same size.
-
-        Computed as the max size hint across all buttons so the longest
-        label (plus icon) fits, and every button matches.
-        """
-        buttons: list[QToolButton] = []
+        """Apply a uniform fixed size to every QToolButton in the main toolbar."""
         for action in self._toolbar.actions():
             if action.isSeparator():
                 continue
             widget = self._toolbar.widgetForAction(action)
             if isinstance(widget, QToolButton):
-                # Clear any previously-set fixed size so sizeHint reflects
-                # the button's natural content for the current action set.
-                widget.setMinimumSize(0, 0)
-                widget.setMaximumSize(16777215, 16777215)
-                widget.adjustSize()
-                buttons.append(widget)
-
-        if not buttons:
-            return
-
-        max_w = max(b.sizeHint().width()  for b in buttons)
-        max_h = max(b.sizeHint().height() for b in buttons)
-        size  = QSize(max_w, max_h)
-        for b in buttons:
-            b.setFixedSize(size)
+                widget.setFixedSize(_TOOLBAR_BUTTON_SIZE)
 
     # ── Menus ──────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
Refactored the toolbar button sizing logic to use fixed dimensions instead of dynamically computing sizes based on content. This simplifies the code and provides more predictable UI layout.

## Key Changes
- Increased `_TOOLBAR_ICON_SIZE` from 32x32 to 40x40 pixels for better visibility
- Introduced new constant `_TOOLBAR_BUTTON_SIZE` set to 72x72 pixels for uniform button dimensions
- Replaced dynamic size computation in `_apply_consistent_button_sizes()` with a simple fixed size assignment
- Removed logic that cleared previous size constraints and calculated maximum dimensions across all buttons
- Simplified method documentation to reflect the new approach

## Implementation Details
The previous implementation dynamically calculated button sizes by:
1. Clearing any previously-set size constraints
2. Calling `adjustSize()` on each button to get its natural size hint
3. Finding the maximum width and height across all buttons
4. Applying that computed size to all buttons

The new implementation simply applies a fixed `_TOOLBAR_BUTTON_SIZE` to all toolbar buttons, eliminating the complexity of dynamic computation while maintaining consistent button sizing across the toolbar.

https://claude.ai/code/session_011ocJ2ncBPiyFzUGtmJMVek