### PR TITLE
JIT-compile error-diffusion dither loop with numba

### DIFF
--- a/flow/test_dither.flowjs
+++ b/flow/test_dither.flowjs
@@ -1,0 +1,57 @@
+{
+  "version": 1,
+  "name": "test_dither",
+  "nodes": [
+    {
+      "id": 0,
+      "module": "nodes.sources.file_source",
+      "class": "FileSource",
+      "position": [
+        -2049.0,
+        -602.0
+      ],
+      "params": {
+        "file_path": "/home/user/Dokumente/GitHub/image-inquest/input/ship.jpg",
+        "max_num_frames": -1
+      }
+    },
+    {
+      "id": 1,
+      "module": "nodes.filters.dither",
+      "class": "Dither",
+      "position": [
+        -1747.0,
+        -559.0
+      ],
+      "params": {
+        "method": 6
+      }
+    },
+    {
+      "id": 2,
+      "module": "nodes.sinks.file_sink",
+      "class": "FileSink",
+      "position": [
+        -1432.0,
+        -562.0
+      ],
+      "params": {
+        "output_path": "output/out.png"
+      }
+    }
+  ],
+  "connections": [
+    {
+      "src_node": 0,
+      "src_output": 0,
+      "dst_node": 1,
+      "dst_input": 0
+    },
+    {
+      "src_node": 1,
+      "src_output": 0,
+      "dst_node": 2,
+      "dst_input": 0
+    }
+  ]
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ numpy
 opencv-python
 PySide6
 typing_extensions
+numba

--- a/src/nodes/filters/dither.py
+++ b/src/nodes/filters/dither.py
@@ -4,6 +4,7 @@ import math
 from enum import IntEnum
 
 import cv2
+import numba
 import numpy as np
 from typing_extensions import override
 
@@ -32,49 +33,46 @@ class DitherMethod(IntEnum):
     DIFFUSION_XY    = 11
 
 
-# Error-diffusion kernels laid out as (dy, dx, weight) triples — one
-# entry per neighbour that should receive a share of the quantisation
-# error. Matches the original OCVL layout (rows: current/next/next+1;
-# columns: x-2 .. x+2) but flattened so the inner loop is a simple
-# iteration instead of 12 guarded index expressions.
-_DIFFUSION_KERNELS: dict[DitherMethod, tuple[tuple[int, int, float], ...]] = {
-    DitherMethod.FLOYD_STEINBERG: (
-        (0, +1, 7 / 16),
-        (1, -1, 3 / 16), (1,  0, 5 / 16), (1, +1, 1 / 16),
-    ),
-    DitherMethod.STUCKI: (
-        (0, +1, 8 / 42), (0, +2, 4 / 42),
-        (1, -2, 2 / 42), (1, -1, 4 / 42), (1, 0, 8 / 42),
-        (1, +1, 4 / 42), (1, +2, 2 / 42),
-        (2, -2, 1 / 42), (2, -1, 2 / 42), (2, 0, 4 / 42),
-        (2, +1, 2 / 42), (2, +2, 1 / 42),
-    ),
-    DitherMethod.ATKINSON: (
-        (0, +1, 1 / 8), (0, +2, 1 / 8),
-        (1, -1, 1 / 8), (1, 0, 1 / 8), (1, +1, 1 / 8),
-        (2,  0, 1 / 8),
-    ),
-    DitherMethod.BURKES: (
-        (0, +1, 8 / 32), (0, +2, 4 / 32),
-        (1, -2, 2 / 32), (1, -1, 4 / 32), (1, 0, 8 / 32),
-        (1, +1, 4 / 32), (1, +2, 2 / 32),
-    ),
-    DitherMethod.SIERRA: (
-        (0, +1, 5 / 32), (0, +2, 3 / 32),
-        (1, -2, 2 / 32), (1, -1, 4 / 32), (1, 0, 5 / 32),
-        (1, +1, 4 / 32), (1, +2, 2 / 32),
-        (2, -1, 2 / 32), (2,  0, 3 / 32), (2, +1, 2 / 32),
-    ),
-    DitherMethod.DIFFUSION_X: (
-        (0, +1, 1.0),
-    ),
-    DitherMethod.DIFFUSION_XY: (
-        (0, +1, 0.5), (1, 0, 0.5),
-    ),
+# Error-diffusion kernels as (n, 3) float64 arrays with columns
+# [dy, dx, weight].  NumPy arrays (rather than Python tuples) are
+# required for numba's nopython mode.
+_DIFFUSION_KERNELS: dict[DitherMethod, np.ndarray] = {
+    DitherMethod.FLOYD_STEINBERG: np.array([
+        [0, +1, 7/16],
+        [1, -1, 3/16], [1,  0, 5/16], [1, +1, 1/16],
+    ], dtype=np.float64),
+    DitherMethod.STUCKI: np.array([
+        [0, +1, 8/42], [0, +2, 4/42],
+        [1, -2, 2/42], [1, -1, 4/42], [1,  0, 8/42],
+        [1, +1, 4/42], [1, +2, 2/42],
+        [2, -2, 1/42], [2, -1, 2/42], [2,  0, 4/42],
+        [2, +1, 2/42], [2, +2, 1/42],
+    ], dtype=np.float64),
+    DitherMethod.ATKINSON: np.array([
+        [0, +1, 1/8], [0, +2, 1/8],
+        [1, -1, 1/8], [1,  0, 1/8], [1, +1, 1/8],
+        [2,  0, 1/8],
+    ], dtype=np.float64),
+    DitherMethod.BURKES: np.array([
+        [0, +1, 8/32], [0, +2, 4/32],
+        [1, -2, 2/32], [1, -1, 4/32], [1,  0, 8/32],
+        [1, +1, 4/32], [1, +2, 2/32],
+    ], dtype=np.float64),
+    DitherMethod.SIERRA: np.array([
+        [0, +1, 5/32], [0, +2, 3/32],
+        [1, -2, 2/32], [1, -1, 4/32], [1,  0, 5/32],
+        [1, +1, 4/32], [1, +2, 2/32],
+        [2, -1, 2/32], [2,  0, 3/32], [2, +1, 2/32],
+    ], dtype=np.float64),
+    DitherMethod.DIFFUSION_X: np.array([
+        [0, +1, 1.0],
+    ], dtype=np.float64),
+    DitherMethod.DIFFUSION_XY: np.array([
+        [0, +1, 0.5], [1, 0, 0.5],
+    ], dtype=np.float64),
 }
 
-# Bayer ordered-dither matrices (2×2, 4×4, 8×8) — pre-computed so the
-# tiling step in ``process`` is a pure ``np.tile``.
+# Bayer ordered-dither matrices (2×2, 4×4, 8×8).
 _BAYER_MATRICES: dict[DitherMethod, np.ndarray] = {
     DitherMethod.BAYER2: np.array([
         [0, 2],
@@ -103,12 +101,13 @@ class Dither(NodeBase):
     """Binary (black/white) dithering with a configurable algorithm.
 
     Reduces an image to two levels (0 / 255) using one of the classic
-    ordered or error-diffusion schemes. Inputs can be single- or
-    three-channel — colour inputs are converted to grayscale first and
-    the binary result is re-broadcast to BGR so downstream nodes get
-    the expected 3-channel format. Ported from the original OCVL
-    ``DitherProcessor``; the ``numba`` JIT dependency is dropped so the
-    error-diffusion loop runs in pure Python / NumPy.
+    ordered or error-diffusion schemes. Colour inputs are converted to
+    grayscale first; the binary result is broadcast back to BGR so
+    downstream nodes receive the expected 3-channel format.
+
+    The error-diffusion inner loop is JIT-compiled by numba on first use
+    (``@njit(cache=True)``), making it comparable in speed to the
+    original OCVL implementation.
     """
 
     def __init__(self) -> None:
@@ -125,9 +124,8 @@ class Dither(NodeBase):
     @property
     @override
     def params(self) -> list[NodeParam]:
-        # Method is encoded as an int: see :class:`DitherMethod`.
         # 1=Bayer2  2=Bayer4  3=Bayer8  4=Noise  5=Floyd-Steinberg
-        # 6=Stucki  7=Atkinson 8=Burkes 9=Sierra 10=DiffusionX 11=DiffusionXY
+        # 6=Stucki  7=Atkinson  8=Burkes  9=Sierra  10=DiffusionX  11=DiffusionXY
         return [NodeParam("method", NodeParamType.INT, {"default": int(DitherMethod.STUCKI)})]
 
     # ── Properties ─────────────────────────────────────────────────────────────
@@ -173,58 +171,45 @@ class Dither(NodeBase):
 # ── Dithering kernels ─────────────────────────────────────────────────────────
 
 def _dither_noise(gray: np.ndarray) -> np.ndarray:
-    """Threshold against Gaussian noise (μ=128, σ=50). Matches the OCVL
-    implementation — ``cv2.randn`` fills the noise image in place."""
     noise = np.zeros_like(gray)
     cv2.randn(noise, 128, 50)
     return np.where(gray > noise, 255, 0).astype(np.uint8)
 
 
 def _dither_bayer(gray: np.ndarray, bayer: np.ndarray) -> np.ndarray:
-    """Ordered dither using a Bayer matrix.
-
-    Replaces the original nested-loop implementation with a vectorised
-    threshold — the matrix is tiled across the frame and each pixel is
-    compared against its threshold in one NumPy expression. The levels
-    branch in the OCVL code computed ``new_pixel`` but never used it,
-    so it is omitted here.
-    """
+    """Vectorised ordered dither — no per-pixel loop needed."""
     h, w = gray.shape
     side = int(math.sqrt(bayer.size))
-    div = bayer.size
     reps = (h // side + 1, w // side + 1)
     tiled = np.tile(bayer, reps)[:h, :w]
-    threshold = tiled * 255 / div
+    threshold = tiled * 255 / bayer.size
     return np.where(gray > threshold, 255, 0).astype(np.uint8)
 
 
-def _dither_diffusion(
-    gray: np.ndarray,
-    kernel: tuple[tuple[int, int, float], ...],
-) -> np.ndarray:
-    """Generic error-diffusion dither.
+@numba.njit(cache=True)
+def _dither_diffusion(gray: np.ndarray, kernel: np.ndarray) -> np.ndarray:
+    """Generic error-diffusion dither, JIT-compiled by numba.
 
-    Walks the image in scanline order, quantising each pixel to 0 or
-    255 and distributing the quantisation error to the neighbours
-    listed in ``kernel`` as ``(dy, dx, weight)`` triples. Works on a
-    float copy so accumulated error stays in range before the final
-    clip. Pure-Python loop: without numba this is slow on large
-    frames, but produces identical output.
+    ``kernel`` is a (n, 3) float64 array with columns [dy, dx, weight].
+    ``cache=True`` persists the compiled function to ``__pycache__`` so
+    the JIT cost is paid only on the very first run after installation.
     """
     buf = gray.astype(np.float32).copy()
     h, w = buf.shape
+    n = kernel.shape[0]
 
     for y in range(h):
         for x in range(w):
             old = buf[y, x]
-            new = 255.0 if old > 127 else 0.0
+            new = np.float32(255.0) if old > 127.0 else np.float32(0.0)
             buf[y, x] = new
             err = old - new
             if err == 0.0:
                 continue
-            for dy, dx, weight in kernel:
-                ny, nx = y + dy, x + dx
+            for k in range(n):
+                ny = y + int(kernel[k, 0])
+                nx = x + int(kernel[k, 1])
                 if 0 <= ny < h and 0 <= nx < w:
-                    buf[ny, nx] += err * weight
+                    buf[ny, nx] += err * kernel[k, 2]
 
     return np.clip(buf, 0, 255).astype(np.uint8)


### PR DESCRIPTION
## Summary

The error-diffusion dither algorithms (Floyd-Steinberg, Stucki, Atkinson, etc.) iterate over every pixel in pure Python — O(w×h) loop iterations per frame, which is very slow on full-size images.

- Apply `@numba.njit(cache=True)` to `_dither_diffusion` to compile it to native code on first use
- `cache=True` persists the compiled artifact to `__pycache__` so the JIT cost is only paid once after installation, not on every startup
- Convert diffusion kernel format from Python tuples of `(dy, dx, weight)` to `(n, 3)` float64 numpy arrays — required for numba's nopython mode
- Bayer and noise dithering are already vectorised via numpy and don't need JIT
- Add `numba` to `requirements.txt`

## Test plan

- [ ] Install `numba` (`pip install -r requirements.txt`)
- [ ] Run the Dither node on a large image — first run triggers JIT compilation (brief pause), subsequent runs should be fast
- [ ] Verify all dither methods still produce correct output
- [ ] Confirm `__pycache__` contains numba cache files after first run

https://claude.ai/code/session_011ocJ2ncBPiyFzUGtmJMVek