### PR TITLE
Fix viewer not showing output after running a flow

### DIFF
--- a/src/core/port.py
+++ b/src/core/port.py
@@ -115,6 +115,9 @@ class OutputPort:
     # ── Data flow ──────────────────────────────────────────────────────────────
 
     def send(self, data: IoData) -> None:
-        self._last_emitted = data
+        # Only cache real payload; EOS is a control signal and should not
+        # overwrite the last meaningful result the viewer wants to display.
+        if not data.is_end_of_stream():
+            self._last_emitted = data
         for port in self._connections:
             port.receive(data)

--- a/src/ui/node_editor_page.py
+++ b/src/ui/node_editor_page.py
@@ -248,11 +248,7 @@ class NodeEditorPage(PageBase):
             if isinstance(node, SinkNodeBase):
                 continue
             for port in node.outputs:
-                if (
-                    IoDataType.IMAGE in port.emits
-                    and port.last_emitted is not None
-                    and not port.last_emitted.is_end_of_stream()
-                ):
+                if IoDataType.IMAGE in port.emits and port.last_emitted is not None:
                     return node
         return None
 

--- a/src/ui/node_editor_page.py
+++ b/src/ui/node_editor_page.py
@@ -20,6 +20,8 @@ from PySide6.QtWidgets import (
 
 from constants import FLOW_DIR
 from core.flow import Flow, is_valid_flow_name
+from core.io_data import IoDataType
+from core.node_base import SinkNodeBase
 from ui.flow_io import FlowIoError, load_flow_into, save_flow_to
 from ui.flow_scene import FlowScene
 from ui.flow_view import FlowView
@@ -223,7 +225,36 @@ class NodeEditorPage(PageBase):
             f"Ran at {datetime.now().strftime('%H:%M:%S')}",
             kind="ok",
         )
-        self._viewer.refresh()
+        if self._viewer.current_node is None:
+            # Nothing selected yet — auto-show the most downstream node
+            # that produced image data so the user sees a result immediately.
+            best = self._best_viewer_node()
+            if best is not None:
+                self._viewer.show_node(best)
+        else:
+            self._viewer.refresh()
+
+    def _best_viewer_node(self):
+        """Return the most downstream non-sink node with IMAGE output data.
+
+        Iterates the flow's nodes in reverse registration order (later-added
+        nodes tend to be further downstream) and returns the first one that
+        has at least one IMAGE output port with data after a run.  Returns
+        ``None`` when the flow has no such node.
+        """
+        if self._flow is None:
+            return None
+        for node in reversed(self._flow.nodes):
+            if isinstance(node, SinkNodeBase):
+                continue
+            for port in node.outputs:
+                if (
+                    IoDataType.IMAGE in port.emits
+                    and port.last_emitted is not None
+                    and not port.last_emitted.is_end_of_stream()
+                ):
+                    return node
+        return None
 
     def _on_save_clicked(self) -> None:
         if self._flow is None:

--- a/src/ui/viewer_panel.py
+++ b/src/ui/viewer_panel.py
@@ -78,7 +78,7 @@ class ViewerPanel(QWidget):
                 continue
 
             data = port.last_emitted
-            if data is None or data.is_end_of_stream() or data.type != IoDataType.IMAGE:
+            if data is None or data.type != IoDataType.IMAGE:
                 self._placeholder(f"{port.name}: (no data — click Run)", muted=True)
                 continue
 

--- a/src/ui/viewer_panel.py
+++ b/src/ui/viewer_panel.py
@@ -88,6 +88,11 @@ class ViewerPanel(QWidget):
                 logger.exception("Viewer failed to render port '%s'", port.name)
                 self._placeholder(f"{port.name}: (render error — see log)", error=True)
 
+    @property
+    def current_node(self) -> NodeBase | None:
+        """The node currently displayed in the viewer, or ``None``."""
+        return self._current_node
+
     def refresh(self) -> None:
         """Re-render the currently-shown node (called after Run)."""
         self.show_node(self._current_node)


### PR DESCRIPTION
## Summary

- `OutputPort.send()` was overwriting `_last_emitted` with the EOS signal, so every port's cached result was EOS by the time the run completed — the viewer found no displayable data
- After a successful run with no node selected, the viewer now auto-picks the most downstream non-sink node with image data and displays it immediately
- Added `ViewerPanel.current_node` property so `NodeEditorPage` can check whether a node is already being shown

## Root cause

Sources always send real data followed by EOS. Because `OutputPort.send()` updated `_last_emitted` unconditionally, the EOS overwrote the actual image. The viewer's `is_end_of_stream()` guard was correct in principle but was never reached — `last_emitted` was always EOS so the "no data" placeholder was shown instead.

## Test plan

- [ ] Open `test_dither` flow and hit Run — viewer should automatically show the Dither node's output without having to click a node first
- [ ] Select a node manually, hit Run — viewer should refresh the selected node (existing behaviour preserved)
- [ ] Verify clicking a different node in the canvas still updates the viewer

https://claude.ai/code/session_011ocJ2ncBPiyFzUGtmJMVek