### PR TITLE
Remove duplicate Open button from start page; add icon to Create button

### DIFF
--- a/src/ui/start_page.py
+++ b/src/ui/start_page.py
@@ -80,20 +80,13 @@ class StartPage(PageBase):
         self._name_input.returnPressed.connect(self._on_create_clicked)
         row.addWidget(self._name_input)
 
-        self._create_button = QPushButton("Create")
+        self._create_button = QPushButton(material_icon("add"), "Create")
         self._create_button.setEnabled(False)
+        self._create_button.setFixedSize(120, 40)
         self._create_button.clicked.connect(self._on_create_clicked)
         row.addWidget(self._create_button)
         row.addStretch(1)
         root.addLayout(row)
-
-        # Open button.
-        open_row = QHBoxLayout()
-        open_button = QPushButton("Open")
-        open_button.clicked.connect(self._on_open_clicked)
-        open_row.addWidget(open_button)
-        open_row.addStretch(1)
-        root.addLayout(open_row)
 
         root.addStretch(1)
 


### PR DESCRIPTION
## Summary
- Remove the `Open` button from the start page client area — it duplicated the `Open` action already present in the page toolbar
- Add a Material Design `add` icon to the `Create` button and give it a fixed 120×40 px size consistent with other action buttons

## Test plan
- [ ] Open the application — confirm only the text-input + Create button appear in the body (no Open button)
- [ ] Confirm the Create button shows an icon and is sized correctly
- [ ] Confirm the `Open` toolbar button (top bar) still works to open an existing flow

Closes #53

https://claude.ai/code/session_01YLaaUTxhLyP1fcTX57qMGF