### PR TITLE
Rename PaletteWidget to NodeList; introduce section-based palette grouping

### DIFF
--- a/src/core/node_base.py
+++ b/src/core/node_base.py
@@ -48,8 +48,9 @@ class NodeBase(ABC):
         outputs so the signal propagates to the end of the graph.
     """
 
-    def __init__(self, display_name: str) -> None:
+    def __init__(self, display_name: str, section: str = "") -> None:
         self._display_name = display_name
+        self._section = section
         self._inputs: list[InputPort] = []
         self._outputs: list[OutputPort] = []
 
@@ -106,6 +107,11 @@ class NodeBase(ABC):
     @property
     def display_name(self) -> str:
         return self._display_name
+
+    @property
+    def section(self) -> str:
+        """Palette section this node belongs to (e.g. 'Sources', 'Transform')."""
+        return self._section
 
     @property
     def inputs(self) -> list[InputPort]:

--- a/src/core/node_registry.py
+++ b/src/core/node_registry.py
@@ -21,6 +21,7 @@ class NodeEntry:
     display_name: str   # Human-readable name, e.g. "File Source"
     category:     str   # "Sources" | "Filters" | "Sinks"
     module:       str   # Importable dotted path, e.g. "nodes.sources.file_source"
+    section:      str = ""  # Palette section, e.g. "Sources", "Color Spaces", "Transform"
 
 
 class NodeRegistry:
@@ -72,7 +73,7 @@ class NodeRegistry:
             module = ".".join(path.relative_to(src_root).with_suffix("").parts)
             found, file_errors = _parse_node_file(path)
             errors.extend(file_errors)
-            for class_name, display_name, category in found:
+            for class_name, display_name, category, section in found:
                 if reject_conflicts and class_name in self._nodes:
                     errors.append(ScanError(
                         file=path,
@@ -87,6 +88,7 @@ class NodeRegistry:
                         display_name=display_name,
                         category=category,
                         module=module,
+                        section=section,
                     )
         return errors
 
@@ -97,6 +99,21 @@ class NodeRegistry:
         result: dict[str, list[NodeEntry]] = {"Sources": [], "Filters": [], "Sinks": []}
         for entry in self._nodes.values():
             result.setdefault(entry.category, []).append(entry)
+        for entries in result.values():
+            entries.sort(key=lambda e: e.display_name)
+        return result
+
+    def nodes_by_section(self) -> dict[str, list[NodeEntry]]:
+        """Return entries grouped by section, each list sorted by display name.
+
+        Sections are finer-grained than categories and are set explicitly on
+        each node via the ``section`` keyword argument of
+        :meth:`NodeBase.__init__`.  Nodes that omit a section fall back to
+        their category name (``"Sources"``, ``"Sinks"``, or ``"Processing"``).
+        """
+        result: dict[str, list[NodeEntry]] = {}
+        for entry in self._nodes.values():
+            result.setdefault(entry.section, []).append(entry)
         for entries in result.values():
             entries.sort(key=lambda e: e.display_name)
         return result
@@ -133,8 +150,8 @@ _CATEGORY_MAP: dict[str, str] = {
 
 def _parse_node_file(
     path: Path,
-) -> tuple[list[tuple[str, str, str]], list[ScanError]]:
-    """Return ([(class_name, display_name, category), ...], [errors]) for a file."""
+) -> tuple[list[tuple[str, str, str, str]], list[ScanError]]:
+    """Return ([(class_name, display_name, category, section), ...], [errors]) for a file."""
     try:
         source = path.read_text(encoding="utf-8")
         tree = ast.parse(source, filename=str(path))
@@ -143,7 +160,7 @@ def _parse_node_file(
     except OSError as e:
         return [], [ScanError(file=path, message=f"Could not read file: {e}")]
 
-    results: list[tuple[str, str, str]] = []
+    results: list[tuple[str, str, str, str]] = []
     errors: list[ScanError] = []
     for node in ast.walk(tree):
         if isinstance(node, ast.ClassDef):
@@ -161,8 +178,8 @@ def _parse_node_file(
 
 def _extract_node_entry(
     class_node: ast.ClassDef,
-) -> tuple[str, str, str] | None:
-    """Return (class_name, display_name, category) if the class is a node, else None."""
+) -> tuple[str, str, str, str] | None:
+    """Return (class_name, display_name, category, section) if the class is a node, else None."""
     init = _find_init(class_node)
     if init is None or not _has_super_init(init):
         return None
@@ -170,7 +187,8 @@ def _extract_node_entry(
         return None
     display_name = _extract_super_init_name(init) or class_node.name
     category = _detect_category(class_node)
-    return class_node.name, display_name, category
+    section = _extract_super_init_section(init) or _default_section(category)
+    return class_node.name, display_name, category, section
 
 
 def _detect_category(class_node: ast.ClassDef) -> str:
@@ -249,6 +267,31 @@ def _extract_super_init_name(init_node: ast.FunctionDef) -> str | None:
         if node.args and isinstance(node.args[0], ast.Constant) and isinstance(node.args[0].value, str):
             return node.args[0].value
     return None
+
+
+def _extract_super_init_section(init_node: ast.FunctionDef) -> str | None:
+    """Return the ``section`` keyword value passed to ``super().__init__()``, or None."""
+    for node in ast.walk(init_node):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if not (isinstance(func, ast.Attribute) and func.attr == "__init__"):
+            continue
+        if not (isinstance(func.value, ast.Call) and isinstance(func.value.func, ast.Name) and func.value.func.id == "super"):
+            continue
+        for kw in node.keywords:
+            if kw.arg == "section" and isinstance(kw.value, ast.Constant) and isinstance(kw.value.value, str):
+                return kw.value.value
+    return None
+
+
+def _default_section(category: str) -> str:
+    """Return the palette section to use when a node declares none."""
+    if category == "Sources":
+        return "Sources"
+    if category == "Sinks":
+        return "Sinks"
+    return "Processing"
 
 
 def _count_self_calls(init_node: ast.FunctionDef, method_name: str) -> int:

--- a/src/nodes/filters/adaptive_gaussian_threshold.py
+++ b/src/nodes/filters/adaptive_gaussian_threshold.py
@@ -24,7 +24,7 @@ class AdaptiveGaussianThreshold(NodeBase):
     """
 
     def __init__(self) -> None:
-        super().__init__("Adaptive Gaussian Threshold")
+        super().__init__("Adaptive Gaussian Threshold", section="Processing")
         self._block_size: int = 101
         self._c: int = -32
 

--- a/src/nodes/filters/dither.py
+++ b/src/nodes/filters/dither.py
@@ -111,7 +111,7 @@ class Dither(NodeBase):
     """
 
     def __init__(self) -> None:
-        super().__init__("Dither")
+        super().__init__("Dither", section="Processing")
         self._method: int = int(DitherMethod.STUCKI)
 
         self._add_input(InputPort("image", {IoDataType.IMAGE}))

--- a/src/nodes/filters/grayscale.py
+++ b/src/nodes/filters/grayscale.py
@@ -18,7 +18,7 @@ class Grayscale(NodeBase):
     """
 
     def __init__(self) -> None:
-        super().__init__("Grayscale")
+        super().__init__("Grayscale", section="Color Spaces")
         self._add_input(InputPort("image",  {IoDataType.IMAGE}))
         self._add_output(OutputPort("image", {IoDataType.IMAGE}))
 

--- a/src/nodes/filters/median.py
+++ b/src/nodes/filters/median.py
@@ -17,7 +17,7 @@ class Median(NodeBase):
     """
 
     def __init__(self) -> None:
-        super().__init__("Median")
+        super().__init__("Median", section="Processing")
         self._size: int = 3
 
         self._add_input(InputPort("image", {IoDataType.IMAGE}))

--- a/src/nodes/filters/normalize.py
+++ b/src/nodes/filters/normalize.py
@@ -19,7 +19,7 @@ class Normalize(NodeBase):
     """
 
     def __init__(self) -> None:
-        super().__init__("Normalize")
+        super().__init__("Normalize", section="Processing")
         self._add_input(InputPort("image", {IoDataType.IMAGE}))
         self._add_output(OutputPort("image", {IoDataType.IMAGE}))
 

--- a/src/nodes/filters/rgb_join.py
+++ b/src/nodes/filters/rgb_join.py
@@ -19,7 +19,7 @@ class RgbJoin(NodeBase):
     """
 
     def __init__(self) -> None:
-        super().__init__("RGB Join")
+        super().__init__("RGB Join", section="Color Spaces")
         self._three_color: bool = False
 
         self._add_input(InputPort("B", {IoDataType.IMAGE}))

--- a/src/nodes/filters/rgb_split.py
+++ b/src/nodes/filters/rgb_split.py
@@ -18,7 +18,7 @@ class RgbSplit(NodeBase):
     """
 
     def __init__(self) -> None:
-        super().__init__("RGB Split")
+        super().__init__("RGB Split", section="Color Spaces")
         self._add_input(InputPort("image", {IoDataType.IMAGE}))
         self._add_output(OutputPort("B", {IoDataType.IMAGE}))
         self._add_output(OutputPort("G", {IoDataType.IMAGE}))

--- a/src/nodes/filters/scale.py
+++ b/src/nodes/filters/scale.py
@@ -29,7 +29,7 @@ class Scale(NodeBase):
     """
 
     def __init__(self) -> None:
-        super().__init__("Scale")
+        super().__init__("Scale", section="Transform")
         self._scale_percent: int = 100
         self._interpolation: int = 1  # Linear
 

--- a/src/nodes/filters/shift.py
+++ b/src/nodes/filters/shift.py
@@ -20,7 +20,7 @@ class Shift(NodeBase):
     """
 
     def __init__(self) -> None:
-        super().__init__("Shift")
+        super().__init__("Shift", section="Transform")
         self._offset_x: int = 0
         self._offset_y: int = 0
 

--- a/src/nodes/sinks/file_sink.py
+++ b/src/nodes/sinks/file_sink.py
@@ -18,7 +18,7 @@ class OutputFormat(Enum):
 
 class FileSink(SinkNodeBase):
     def __init__(self):
-        super().__init__("File Sink")
+        super().__init__("File Sink", section="Sinks")
 
         self._output_path: str = "output/out.png"
         self._output_format: OutputFormat = OutputFormat.SAME_AS_INPUT

--- a/src/nodes/sources/file_source.py
+++ b/src/nodes/sources/file_source.py
@@ -30,7 +30,7 @@ class FileSource(SourceNodeBase):
     """
 
     def __init__(self) -> None:
-        super().__init__("File Source")
+        super().__init__("File Source", section="Sources")
         self._file_path: Path = Path()
         self._max_num_frames: int = -1
         self._add_output(OutputPort("image", {IoDataType.IMAGE}))

--- a/src/nodes/sources/image_source.py
+++ b/src/nodes/sources/image_source.py
@@ -28,7 +28,7 @@ class ImageSource(SourceNodeBase):
     """
 
     def __init__(self) -> None:
-        super().__init__("Image Source")
+        super().__init__("Image Source", section="Sources")
         self._file_path: Path = Path()
         self._add_output(OutputPort("image", {IoDataType.IMAGE}))
         self._apply_default_params()

--- a/src/nodes/sources/video_source.py
+++ b/src/nodes/sources/video_source.py
@@ -27,7 +27,7 @@ class VideoSource(SourceNodeBase):
     """
 
     def __init__(self) -> None:
-        super().__init__("Video Source")
+        super().__init__("Video Source", section="Sources")
         self._file_path: Path = Path()
         self._max_num_frames: int = -1
         self._add_output(OutputPort("image", {IoDataType.IMAGE}))

--- a/src/ui/flow_view.py
+++ b/src/ui/flow_view.py
@@ -153,6 +153,7 @@ class FlowView(QGraphicsView):
             category=data.get("category", ""),
             module=data["module"],
             class_name=data["class_name"],
+            section=data.get("section", ""),
         )
 
         scene_pos = self.mapToScene(event.position().toPoint())

--- a/src/ui/node_editor_page.py
+++ b/src/ui/node_editor_page.py
@@ -29,7 +29,7 @@ from ui.icons import material_icon
 from typing_extensions import override
 
 from ui.page import PageBase, ToolbarSection
-from ui.palette_widget import PaletteWidget
+from ui.palette_widget import NodeList
 from ui.theme import STATUS_FAIL_COLOR, STATUS_MUTED_COLOR, STATUS_OK_COLOR
 from ui.viewer_panel import ViewerPanel
 
@@ -75,8 +75,8 @@ class NodeEditorPage(PageBase):
         self._view  = FlowView(self._scene)
         self._inner.setCentralWidget(self._view)
 
-        # Palette dock (left).
-        self._palette = PaletteWidget(registry)
+        # Node list dock (left).
+        self._palette = NodeList(registry)
         self._palette_dock = QDockWidget("Palette", self._inner)
         self._palette_dock.setObjectName("PaletteDock")
         self._palette_dock.setWidget(self._palette)

--- a/src/ui/palette_widget.py
+++ b/src/ui/palette_widget.py
@@ -21,19 +21,31 @@ if TYPE_CHECKING:
 NODE_LIST_MIME_TYPE: str = "application/x-image-inquest-node"
 
 
-class PaletteWidget(QWidget):
-    """Palette listing every registered node by category.
+class NodeList(QWidget):
+    """Node list panel grouping every registered node by section.
 
     Each entry is a :class:`QListWidgetItem` that emits a drag with the
     :data:`NODE_LIST_MIME_TYPE` MIME type carrying a JSON descriptor of
-    the node (module, class_name, display_name, category). The flow
-    canvas reads that payload on drop and instantiates the node.
+    the node (module, class_name, display_name, category, section). The
+    flow canvas reads that payload on drop and instantiates the node.
+
+    Sections are finer-grained than the three base-class categories; nodes
+    declare their section via the ``section`` keyword in
+    :meth:`NodeBase.__init__`.  Nodes that omit a section fall back to a
+    category-derived default (``"Sources"``, ``"Sinks"``, or ``"Processing"``).
 
     A search box filters the list live; matching falls back to case-
     insensitive ``in`` on display names.
     """
 
-    _CATEGORIES: tuple[str, ...] = ("Sources", "Filters", "Sinks")
+    #: Preferred display order for built-in sections.
+    _SECTION_ORDER: tuple[str, ...] = (
+        "Sources",
+        "Sinks",
+        "Color Spaces",
+        "Transform",
+        "Processing",
+    )
 
     def __init__(self, registry: NodeRegistry, parent: QWidget | None = None) -> None:
         super().__init__(parent)
@@ -55,11 +67,17 @@ class PaletteWidget(QWidget):
     # ── Internals ──────────────────────────────────────────────────────────────
 
     def _populate(self, registry: NodeRegistry) -> None:
-        categorized = registry.nodes_by_category()
-        for category in self._CATEGORIES:
-            entries = categorized.get(category, [])
-            # Category header is a non-selectable, non-draggable item.
-            header = QListWidgetItem(f"{category}  ({len(entries)})")
+        by_section = registry.nodes_by_section()
+        # Show known sections first in the preferred order, then any extra
+        # sections contributed by user nodes in alphabetical order.
+        known = [s for s in self._SECTION_ORDER if s in by_section]
+        extras = sorted(s for s in by_section if s not in self._SECTION_ORDER)
+        ordered_sections = known + extras
+
+        for section in ordered_sections:
+            entries = by_section.get(section, [])
+            # Section header is a non-selectable, non-draggable item.
+            header = QListWidgetItem(f"{section}  ({len(entries)})")
             font = header.font()
             font.setBold(True)
             header.setFont(font)
@@ -81,6 +99,7 @@ class PaletteWidget(QWidget):
                     "class_name":   entry.class_name,
                     "display_name": entry.display_name,
                     "category":     entry.category,
+                    "section":      entry.section,
                 })
                 item.setData(Qt.ItemDataRole.UserRole, payload)
                 item.setToolTip(f"{entry.module}.{entry.class_name}")


### PR DESCRIPTION
## Summary
- Add `section: str` parameter to `NodeBase.__init__` so each node declares which palette section it belongs to
- Extend `NodeEntry` with a `section` field; update the AST scanner to extract it from `super().__init__(section=...)` calls (with a category-based fallback for nodes that omit it)
- Add `NodeRegistry.nodes_by_section()` — entries grouped by section and sorted alphabetically
- Rename `PaletteWidget` → `NodeList`; switch `_populate` to use `nodes_by_section()` and display sections in preferred order: Sources → Sinks → Color Spaces → Transform → Processing
- Carry `section` through the drag MIME payload and `FlowView.dropEvent` reconstruction
- Assign sections to all built-in nodes:
  - **Sources**: FileSource, ImageSource, VideoSource
  - **Sinks**: FileSink
  - **Color Spaces**: Grayscale, RGB Split, RGB Join
  - **Transform**: Scale, Shift
  - **Processing**: Adaptive Gaussian Threshold, Dither, Median, Normalize

## Test plan
- [ ] Open the editor — confirm the left dock shows the new section headers (Sources, Sinks, Color Spaces, Transform, Processing)
- [ ] Confirm nodes appear in the correct sections
- [ ] Drag a node from each section onto the canvas — verify it instantiates correctly
- [ ] Confirm the search box still filters across all sections

Closes #52

https://claude.ai/code/session_01YLaaUTxhLyP1fcTX57qMGF