### PR TITLE
Fix file-dialog browse button showing '.' instead of '...'

### DIFF
--- a/src/ui/param_widgets.py
+++ b/src/ui/param_widgets.py
@@ -154,8 +154,8 @@ class FilePathParamWidget(ParamWidgetBase):
         self._line.textChanged.connect(self._on_value_changed)
         self._line.setText(str(self._initial_value("")))
 
-        browse = QPushButton("…")
-        browse.setFixedWidth(28)
+        browse = QPushButton("...")
+        browse.setFixedWidth(36)
         browse.clicked.connect(self._browse)
 
         layout = QHBoxLayout(self)


### PR DESCRIPTION
## Summary
- Replace the Unicode ellipsis character `…` with the literal string `"..."` in `FilePathParamWidget`
- Widen the browse button from 28 px to 36 px so all three dots are always visible

## Test plan
- [ ] Drop a File Source or File Sink node onto the canvas
- [ ] Confirm the browse button shows `...` (three dots) instead of a single period
- [ ] Confirm clicking the button still opens the file dialog correctly

Closes #50

https://claude.ai/code/session_01YLaaUTxhLyP1fcTX57qMGF