### PR TITLE
Add Log page showing the last 1000 lines of the application log

### DIFF
--- a/src/ui/log_page.py
+++ b/src/ui/log_page.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+from typing_extensions import override
+
+from PySide6.QtGui import QAction, QIcon
+from PySide6.QtWidgets import (
+    QPlainTextEdit,
+    QVBoxLayout,
+    QWidget,
+)
+
+from constants import USER_CONFIG_DIR
+from ui.icons import material_icon
+from ui.page import PageBase, ToolbarSection
+
+_LOG_FILE = USER_CONFIG_DIR / "image-inquest.log"
+_MAX_LINES = 1000
+
+
+class LogPage(PageBase):
+    """Page that displays the last :data:`_MAX_LINES` lines of the application log.
+
+    The log file is read fresh every time the page is activated or the
+    user clicks the Refresh toolbar button.
+    """
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+
+        self._refresh_action = QAction(
+            material_icon("refresh"),
+            "Refresh",
+            self,
+        )
+        self._refresh_action.triggered.connect(self._load_log)
+
+        root = QVBoxLayout(self)
+        root.setContentsMargins(0, 0, 0, 0)
+
+        self._text = QPlainTextEdit()
+        self._text.setReadOnly(True)
+        self._text.setLineWrapMode(QPlainTextEdit.LineWrapMode.NoWrap)
+        font = self._text.font()
+        font.setFamily("Monospace")
+        font.setPointSize(9)
+        self._text.setFont(font)
+        root.addWidget(self._text)
+
+    # ── PageBase interface ─────────────────────────────────────────────────────
+
+    @override
+    def page_selector_label(self) -> str:
+        return "Log"
+
+    @override
+    def page_selector_icon(self) -> QIcon:
+        return material_icon("description")
+
+    def page_toolbar_sections(self) -> list[ToolbarSection]:
+        return [ToolbarSection("Log", [self._refresh_action])]
+
+    def on_activated(self) -> None:
+        self._load_log()
+
+    # ── Internals ──────────────────────────────────────────────────────────────
+
+    def _load_log(self) -> None:
+        """Read the last :data:`_MAX_LINES` lines from the log file."""
+        if not _LOG_FILE.exists():
+            self._text.setPlainText(f"Log file not found: {_LOG_FILE}")
+            return
+        try:
+            content = _LOG_FILE.read_text(encoding="utf-8", errors="replace")
+        except OSError as exc:
+            self._text.setPlainText(f"Could not read log file: {exc}")
+            return
+
+        lines = content.splitlines()
+        if len(lines) > _MAX_LINES:
+            lines = lines[-_MAX_LINES:]
+        self._text.setPlainText("\n".join(lines))
+        # Scroll to the bottom so the most recent entries are visible.
+        self._text.moveCursor(self._text.textCursor().MoveOperation.End)

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -18,6 +18,7 @@ from PySide6.QtWidgets import (
 from constants import APP_DISPLAY_NAME, BUILTIN_NODES_DIR, USER_NODES_DIR
 from core.flow import Flow
 from core.node_registry import NodeRegistry
+from ui.log_page import LogPage
 from ui.node_editor_page import NodeEditorPage
 from ui.page import PageBase
 from ui.start_page import StartPage
@@ -67,6 +68,7 @@ class MainWindow(QMainWindow):
 
         self._start_page  = StartPage()
         self._editor_page = NodeEditorPage(self._registry)
+        self._log_page    = LogPage()
         # Seed the editor with an empty flow so the user can switch to it
         # via the page-selector radio group at any time without first
         # visiting the start page to create one.
@@ -74,11 +76,12 @@ class MainWindow(QMainWindow):
 
         self._pages.addWidget(self._start_page)
         self._pages.addWidget(self._editor_page)
+        self._pages.addWidget(self._log_page)
 
         # Wire page signals.
         self._start_page.create_flow_requested.connect(self._on_create_flow)
         self._start_page.open_flow_requested.connect(self._on_open_flow_from_start)
-        for page in (self._start_page, self._editor_page):
+        for page in (self._start_page, self._editor_page, self._log_page):
             page.title_changed.connect(self._update_window_title)
 
         # ── Menu bar ──
@@ -94,7 +97,7 @@ class MainWindow(QMainWindow):
         self._page_selector_group = QActionGroup(self)
         self._page_selector_group.setExclusive(True)
         self._page_selector_actions: dict[PageBase, QAction] = {}
-        for page in (self._start_page, self._editor_page):
+        for page in (self._start_page, self._editor_page, self._log_page):
             self._add_page_selector_action(page)
         # Separator between the page-selector radio group and the
         # page-specific toolbar actions.


### PR DESCRIPTION
## Summary
- Create `LogPage` (a new `PageBase` subclass in `ui/log_page.py`) with:
  - A read-only monospace `QPlainTextEdit` showing the last 1 000 lines from `~/.image-inquest/image-inquest.log`
  - Auto-scrolls to the bottom so the most recent entries are visible immediately
  - A **Refresh** toolbar button to re-read the file on demand
  - Graceful fallback messages when the log file is absent or unreadable
- Register `LogPage` in `MainWindow` as the third page in the page-selector radio group (Start → Editor → **Log**)

## Test plan
- [ ] Open the application — confirm a "Log" button appears in the top toolbar
- [ ] Click **Log** — confirm the last 1 000 lines of the log are shown
- [ ] Switch away and back — confirm the view refreshes automatically
- [ ] Click **Refresh** — confirm the content updates
- [ ] Test on a fresh install (no log file yet) — confirm a friendly message is shown

Closes #56

https://claude.ai/code/session_01YLaaUTxhLyP1fcTX57qMGF