### PR TITLE
Fix #51: ENUM param type with combo-box widget; apply to Dither.method

### DIFF
--- a/src/core/node_base.py
+++ b/src/core/node_base.py
@@ -20,6 +20,7 @@ class NodeParamType(Enum):
     FLOAT = 3,
     STRING = 4,
     BOOL = 5,
+    ENUM = 6,
 
 
 class NodeParam:

--- a/src/nodes/filters/dither.py
+++ b/src/nodes/filters/dither.py
@@ -16,9 +16,10 @@ from core.port import InputPort, OutputPort
 class DitherMethod(IntEnum):
     """Dithering algorithms supported by :class:`Dither`.
 
-    The integer values match the ``method`` parameter so the node can
-    be driven from a plain INT UI control until a dedicated enum param
-    type exists.
+    Backed by :class:`IntEnum` so the integer representation (persisted
+    in saved flows) round-trips cleanly: JSON stores the int, the
+    setter accepts both ints and enum members, and the ``ENUM`` param
+    widget renders a combo box of ``name``-based labels.
     """
     BAYER2          = 1
     BAYER4          = 2
@@ -112,7 +113,7 @@ class Dither(NodeBase):
 
     def __init__(self) -> None:
         super().__init__("Dither")
-        self._method: int = int(DitherMethod.STUCKI)
+        self._method: DitherMethod = DitherMethod.STUCKI
 
         self._add_input(InputPort("image", {IoDataType.IMAGE}))
         self._add_output(OutputPort("image", {IoDataType.IMAGE}))
@@ -124,26 +125,28 @@ class Dither(NodeBase):
     @property
     @override
     def params(self) -> list[NodeParam]:
-        # 1=Bayer2  2=Bayer4  3=Bayer8  4=Noise  5=Floyd-Steinberg
-        # 6=Stucki  7=Atkinson  8=Burkes  9=Sierra  10=DiffusionX  11=DiffusionXY
-        return [NodeParam("method", NodeParamType.INT, {"default": int(DitherMethod.STUCKI)})]
+        return [NodeParam(
+            "method",
+            NodeParamType.ENUM,
+            {"default": DitherMethod.STUCKI, "enum": DitherMethod},
+        )]
 
     # ── Properties ─────────────────────────────────────────────────────────────
 
     @property
-    def method(self) -> int:
+    def method(self) -> DitherMethod:
         return self._method
 
     @method.setter
-    def method(self, value: int) -> None:
-        v = int(value)
+    def method(self, value: int | DitherMethod) -> None:
         try:
-            DitherMethod(v)
+            # DitherMethod(int) validates the integer and raises on unknown
+            # values; passing a DitherMethod member just returns itself.
+            self._method = DitherMethod(value)
         except ValueError as e:
             raise ValueError(
-                f"method must be one of {[m.value for m in DitherMethod]} (got {v})"
+                f"method must be one of {[m.value for m in DitherMethod]} (got {value!r})"
             ) from e
-        self._method = v
 
     # ── NodeBase interface ─────────────────────────────────────────────────────
 
@@ -156,7 +159,7 @@ class Dither(NodeBase):
         else:
             gray = image
 
-        method = DitherMethod(self._method)
+        method = self._method
         if method == DitherMethod.NOISE:
             out = _dither_noise(gray)
         elif method in _BAYER_MATRICES:

--- a/src/ui/flow_io.py
+++ b/src/ui/flow_io.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import importlib
 import json
 import logging
+from enum import Enum
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -158,6 +159,11 @@ def _jsonable(value: object) -> object:
     """Coerce ``value`` to a JSON-serialisable form (recursive for containers)."""
     if isinstance(value, Path):
         return str(value)
+    if isinstance(value, Enum):
+        # Persist the underlying value (e.g. IntEnum → int, str-backed Enum
+        # → str) so the node setter can reconstruct the member on load,
+        # and saved flows stay human-readable.
+        return _jsonable(value.value)
     if isinstance(value, (list, tuple)):
         return [_jsonable(v) for v in value]
     if isinstance(value, dict):

--- a/src/ui/param_widgets.py
+++ b/src/ui/param_widgets.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+from enum import Enum
 from pathlib import Path
 
 from typing_extensions import override
@@ -8,6 +9,7 @@ from typing_extensions import override
 from PySide6.QtCore import Qt, Signal
 from PySide6.QtWidgets import (
     QCheckBox,
+    QComboBox,
     QFileDialog,
     QHBoxLayout,
     QLineEdit,
@@ -138,6 +140,93 @@ class BoolParamWidget(ParamWidgetBase):
         return self._check.isChecked()
 
 
+class EnumParamWidget(ParamWidgetBase):
+    """Combo-box editor for :attr:`NodeParamType.ENUM` parameters.
+
+    The param's ``metadata["enum"]`` must hold the :class:`enum.Enum`
+    subclass whose members are the legal values.  The combo lists every
+    member (in declaration order) using its ``name`` formatted for
+    readability (``FLOYD_STEINBERG`` → ``Floyd Steinberg``).  Selection
+    writes the enum *member* back to the node; value round-trips through
+    the setter even if the node stores it as an int internally (works
+    seamlessly for :class:`enum.IntEnum`).
+    """
+
+    def __init__(self, node: NodeBase, param: NodeParam) -> None:
+        super().__init__(node, param)
+        enum_cls = param.metadata.get("enum")
+        if not (isinstance(enum_cls, type) and issubclass(enum_cls, Enum)):
+            raise ValueError(
+                f"NodeParam {param.name!r}: ENUM params require "
+                f"metadata['enum'] to be an Enum subclass "
+                f"(got {enum_cls!r})."
+            )
+        self._enum_cls: type[Enum] = enum_cls
+
+        self._combo = QComboBox()
+        self._combo.setMinimumWidth(96)
+        for member in self._enum_cls:
+            self._combo.addItem(self._label_for(member), member)
+
+        initial = self._coerce(self._initial_value(next(iter(self._enum_cls))))
+        idx = self._combo.findData(initial)
+        if idx >= 0:
+            self._combo.setCurrentIndex(idx)
+        # Connect after the initial setCurrentIndex so we don't echo the
+        # initial value back to the node via the setter (and fire a
+        # spurious param_changed).
+        self._combo.currentIndexChanged.connect(self._on_index_changed)
+
+        layout = QHBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.addWidget(self._combo)
+
+    def _on_index_changed(self, _index: int) -> None:
+        member = self._combo.currentData()
+        if member is None:
+            return
+        self._write_to_node(member)
+        self.value_changed.emit(member)
+
+    @override
+    def set_value(self, value: object) -> None:
+        member = self._coerce(value)
+        idx = self._combo.findData(member)
+        if idx >= 0:
+            self._combo.setCurrentIndex(idx)
+
+    @override
+    def get_value(self) -> object:
+        return self._combo.currentData()
+
+    # ── Helpers ────────────────────────────────────────────────────────────
+
+    def _coerce(self, value: object) -> Enum:
+        """Return *value* as an instance of ``self._enum_cls``.
+
+        Accepts the enum member itself, its ``value`` (int/str), or its
+        ``name``. Falls back to the first declared member on failure so
+        the combo always has a defined current row.
+        """
+        if isinstance(value, self._enum_cls):
+            return value
+        try:
+            return self._enum_cls(value)
+        except (ValueError, KeyError):
+            pass
+        if isinstance(value, str):
+            try:
+                return self._enum_cls[value]
+            except KeyError:
+                pass
+        return next(iter(self._enum_cls))
+
+    @staticmethod
+    def _label_for(member: Enum) -> str:
+        """Humanise an enum member's ``SHOUTY_SNAKE`` name for display."""
+        return member.name.replace("_", " ").title()
+
+
 class FilePathParamWidget(ParamWidgetBase):
     """Line-edit + browse-button editor for :attr:`NodeParamType.FILE_PATH` parameters."""
 
@@ -200,6 +289,7 @@ _PARAM_WIDGET_CLASSES: dict[NodeParamType, type[ParamWidgetBase]] = {
     NodeParamType.FILE_PATH: FilePathParamWidget,
     NodeParamType.INT:       IntParamWidget,
     NodeParamType.BOOL:      BoolParamWidget,
+    NodeParamType.ENUM:      EnumParamWidget,
 }
 
 
@@ -207,10 +297,19 @@ def build_param_widget(node: NodeBase, param: NodeParam) -> ParamWidgetBase | No
     """Return a :class:`ParamWidgetBase` that edits *param* on *node*.
 
     Returns ``None`` for unsupported param types, so callers can render a
-    placeholder label instead of crashing.
+    placeholder label instead of crashing.  Also returns ``None`` (with
+    a log) when a widget constructor raises — misconfigured metadata
+    should not bring the node editor down.
     """
     cls = _PARAM_WIDGET_CLASSES.get(param.param_type)
     if cls is None:
         logger.warning("No widget class registered for param type %s", param.param_type)
         return None
-    return cls(node, param)
+    try:
+        return cls(node, param)
+    except Exception:
+        logger.exception(
+            "Failed to build %s widget for %s.%s",
+            cls.__name__, type(node).__name__, param.name,
+        )
+        return None


### PR DESCRIPTION
Fixes #51.

## Summary
- New `NodeParamType.ENUM` and `EnumParamWidget` (QComboBox populated from the declared `Enum` class, labels prettified from member names).
- `Dither.method` migrated from raw `INT` to `ENUM` (`{"enum": DitherMethod, "default": DitherMethod.STUCKI}`); its internal storage now holds the `DitherMethod` member and the setter accepts either an int or the enum.
- `flow_io._jsonable` serialises any `Enum` as its `.value`, so saved flows stay human-readable and existing files like `flow/test_dither.flowjs` (`"method": 6`) keep loading unchanged.
- `build_param_widget` now logs and returns `None` if a widget constructor raises (misconfigured metadata cannot crash the node editor).

## Test plan
- [ ] Drop a Dither node on the canvas → `method` renders as a combo box with every `DitherMethod` label in order.
- [ ] Pick `Noise` / `Floyd Steinberg` → preview updates (reactive ImageSource) and matches the selected algorithm.
- [ ] Save, reopen → selection survives the round-trip.
- [ ] Open `flow/test_dither.flowjs` (method=6) → combo shows `Stucki`.