### PR TITLE
Fix #52: rename PaletteWidget → NodeList; group by per-node section

### DIFF
--- a/src/core/node_base.py
+++ b/src/core/node_base.py
@@ -49,8 +49,15 @@ class NodeBase(ABC):
         outputs so the signal propagates to the end of the graph.
     """
 
-    def __init__(self, display_name: str) -> None:
+    #: Default palette section for this class. Subclasses may override to
+    #: keep the ``section`` parameter optional for tests / ad-hoc nodes;
+    #: production nodes should pass ``section=...`` explicitly so the
+    #: NodeList palette picks it up via AST scanning.
+    DEFAULT_SECTION: str = "Filters"
+
+    def __init__(self, display_name: str, section: str | None = None) -> None:
         self._display_name = display_name
+        self._section = section if section is not None else self.DEFAULT_SECTION
         self._inputs: list[InputPort] = []
         self._outputs: list[OutputPort] = []
 
@@ -107,6 +114,11 @@ class NodeBase(ABC):
     @property
     def display_name(self) -> str:
         return self._display_name
+
+    @property
+    def section(self) -> str:
+        """Palette section this node belongs to (e.g. ``"Processing"``)."""
+        return self._section
 
     @property
     def inputs(self) -> list[InputPort]:
@@ -168,6 +180,8 @@ class SourceNodeBase(NodeBase, ABC):
     live-coding feel.
     """
 
+    DEFAULT_SECTION: str = "Sources"
+
     @property
     def is_reactive(self) -> bool:
         """Return True if this source should trigger an auto-run on any param change.
@@ -201,6 +215,8 @@ class SinkNodeBase(NodeBase, ABC):
     A sink has inputs only — it consumes data as a side effect (writing to
     a file, displaying to screen, etc.) and does not propagate data further.
     """
+
+    DEFAULT_SECTION: str = "Sinks"
 
     @abstractmethod
     @override

--- a/src/core/node_registry.py
+++ b/src/core/node_registry.py
@@ -19,7 +19,8 @@ class NodeEntry:
     """Metadata about a discovered node class."""
     class_name:   str   # Python class name, e.g. "FileSource"
     display_name: str   # Human-readable name, e.g. "File Source"
-    category:     str   # "Sources" | "Filters" | "Sinks"
+    category:     str   # "Sources" | "Filters" | "Sinks" (from base class)
+    section:      str   # Palette section (from the node's own __init__)
     module:       str   # Importable dotted path, e.g. "nodes.sources.file_source"
 
 
@@ -72,7 +73,7 @@ class NodeRegistry:
             module = ".".join(path.relative_to(src_root).with_suffix("").parts)
             found, file_errors = _parse_node_file(path)
             errors.extend(file_errors)
-            for class_name, display_name, category in found:
+            for class_name, display_name, category, section in found:
                 if reject_conflicts and class_name in self._nodes:
                     errors.append(ScanError(
                         file=path,
@@ -86,6 +87,7 @@ class NodeRegistry:
                         class_name=class_name,
                         display_name=display_name,
                         category=category,
+                        section=section,
                         module=module,
                     )
         return errors
@@ -97,6 +99,21 @@ class NodeRegistry:
         result: dict[str, list[NodeEntry]] = {"Sources": [], "Filters": [], "Sinks": []}
         for entry in self._nodes.values():
             result.setdefault(entry.category, []).append(entry)
+        for entries in result.values():
+            entries.sort(key=lambda e: e.display_name)
+        return result
+
+    def nodes_by_section(self) -> dict[str, list[NodeEntry]]:
+        """Return entries grouped by palette section.
+
+        Sections are user-facing labels each node picks in its constructor
+        (see :class:`NodeBase.__init__`'s ``section`` parameter). The key
+        order reflects the order sections are first seen, so the NodeList
+        palette can establish an order without hard-coding section names.
+        """
+        result: dict[str, list[NodeEntry]] = {}
+        for entry in self._nodes.values():
+            result.setdefault(entry.section, []).append(entry)
         for entries in result.values():
             entries.sort(key=lambda e: e.display_name)
         return result
@@ -130,11 +147,21 @@ _CATEGORY_MAP: dict[str, str] = {
     "SinkNodeBase":   "Sinks",
 }
 
+# Default section used when a node omits ``section=...`` in its
+# super().__init__() call. Falls back to the category-derived label so
+# legacy / third-party nodes still appear in the palette under a
+# sensible heading.
+_DEFAULT_SECTION_FOR_CATEGORY: dict[str, str] = {
+    "Sources": "Sources",
+    "Sinks":   "Sinks",
+    "Filters": "Filters",
+}
+
 
 def _parse_node_file(
     path: Path,
-) -> tuple[list[tuple[str, str, str]], list[ScanError]]:
-    """Return ([(class_name, display_name, category), ...], [errors]) for a file."""
+) -> tuple[list[tuple[str, str, str, str]], list[ScanError]]:
+    """Return ([(class_name, display_name, category, section), ...], [errors]) for a file."""
     try:
         source = path.read_text(encoding="utf-8")
         tree = ast.parse(source, filename=str(path))
@@ -143,7 +170,7 @@ def _parse_node_file(
     except OSError as e:
         return [], [ScanError(file=path, message=f"Could not read file: {e}")]
 
-    results: list[tuple[str, str, str]] = []
+    results: list[tuple[str, str, str, str]] = []
     errors: list[ScanError] = []
     for node in ast.walk(tree):
         if isinstance(node, ast.ClassDef):
@@ -161,8 +188,8 @@ def _parse_node_file(
 
 def _extract_node_entry(
     class_node: ast.ClassDef,
-) -> tuple[str, str, str] | None:
-    """Return (class_name, display_name, category) if the class is a node, else None."""
+) -> tuple[str, str, str, str] | None:
+    """Return (class_name, display_name, category, section) if the class is a node, else None."""
     init = _find_init(class_node)
     if init is None or not _has_super_init(init):
         return None
@@ -170,7 +197,11 @@ def _extract_node_entry(
         return None
     display_name = _extract_super_init_name(init) or class_node.name
     category = _detect_category(class_node)
-    return class_node.name, display_name, category
+    section = (
+        _extract_super_init_section(init)
+        or _DEFAULT_SECTION_FOR_CATEGORY.get(category, "Filters")
+    )
+    return class_node.name, display_name, category, section
 
 
 def _detect_category(class_node: ast.ClassDef) -> str:
@@ -248,6 +279,28 @@ def _extract_super_init_name(init_node: ast.FunctionDef) -> str | None:
             continue
         if node.args and isinstance(node.args[0], ast.Constant) and isinstance(node.args[0].value, str):
             return node.args[0].value
+    return None
+
+
+def _extract_super_init_section(init_node: ast.FunctionDef) -> str | None:
+    """Return the string value of the ``section`` argument to super().__init__(),
+    if any.  Supports both positional (second arg) and keyword form.
+    """
+    for node in ast.walk(init_node):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if not (isinstance(func, ast.Attribute) and func.attr == "__init__"):
+            continue
+        if not (isinstance(func.value, ast.Call) and isinstance(func.value.func, ast.Name) and func.value.func.id == "super"):
+            continue
+        # Keyword form: super().__init__("Foo", section="Processing")
+        for kw in node.keywords:
+            if kw.arg == "section" and isinstance(kw.value, ast.Constant) and isinstance(kw.value.value, str):
+                return kw.value.value
+        # Positional form: super().__init__("Foo", "Processing")
+        if len(node.args) >= 2 and isinstance(node.args[1], ast.Constant) and isinstance(node.args[1].value, str):
+            return node.args[1].value
     return None
 
 

--- a/src/nodes/filters/adaptive_gaussian_threshold.py
+++ b/src/nodes/filters/adaptive_gaussian_threshold.py
@@ -24,7 +24,7 @@ class AdaptiveGaussianThreshold(NodeBase):
     """
 
     def __init__(self) -> None:
-        super().__init__("Adaptive Gaussian Threshold")
+        super().__init__("Adaptive Gaussian Threshold", section="Processing")
         self._block_size: int = 101
         self._c: int = -32
 

--- a/src/nodes/filters/dither.py
+++ b/src/nodes/filters/dither.py
@@ -112,7 +112,7 @@ class Dither(NodeBase):
     """
 
     def __init__(self) -> None:
-        super().__init__("Dither")
+        super().__init__("Dither", section="Processing")
         self._method: DitherMethod = DitherMethod.STUCKI
 
         self._add_input(InputPort("image", {IoDataType.IMAGE}))

--- a/src/nodes/filters/grayscale.py
+++ b/src/nodes/filters/grayscale.py
@@ -18,7 +18,7 @@ class Grayscale(NodeBase):
     """
 
     def __init__(self) -> None:
-        super().__init__("Grayscale")
+        super().__init__("Grayscale", section="Color Spaces")
         self._add_input(InputPort("image",  {IoDataType.IMAGE}))
         self._add_output(OutputPort("image", {IoDataType.IMAGE}))
 

--- a/src/nodes/filters/median.py
+++ b/src/nodes/filters/median.py
@@ -17,7 +17,7 @@ class Median(NodeBase):
     """
 
     def __init__(self) -> None:
-        super().__init__("Median")
+        super().__init__("Median", section="Processing")
         self._size: int = 3
 
         self._add_input(InputPort("image", {IoDataType.IMAGE}))

--- a/src/nodes/filters/normalize.py
+++ b/src/nodes/filters/normalize.py
@@ -19,7 +19,7 @@ class Normalize(NodeBase):
     """
 
     def __init__(self) -> None:
-        super().__init__("Normalize")
+        super().__init__("Normalize", section="Processing")
         self._add_input(InputPort("image", {IoDataType.IMAGE}))
         self._add_output(OutputPort("image", {IoDataType.IMAGE}))
 

--- a/src/nodes/filters/rgb_join.py
+++ b/src/nodes/filters/rgb_join.py
@@ -19,7 +19,7 @@ class RgbJoin(NodeBase):
     """
 
     def __init__(self) -> None:
-        super().__init__("RGB Join")
+        super().__init__("RGB Join", section="Color Spaces")
         self._three_color: bool = False
 
         self._add_input(InputPort("B", {IoDataType.IMAGE}))

--- a/src/nodes/filters/rgb_split.py
+++ b/src/nodes/filters/rgb_split.py
@@ -18,7 +18,7 @@ class RgbSplit(NodeBase):
     """
 
     def __init__(self) -> None:
-        super().__init__("RGB Split")
+        super().__init__("RGB Split", section="Color Spaces")
         self._add_input(InputPort("image", {IoDataType.IMAGE}))
         self._add_output(OutputPort("B", {IoDataType.IMAGE}))
         self._add_output(OutputPort("G", {IoDataType.IMAGE}))

--- a/src/nodes/filters/scale.py
+++ b/src/nodes/filters/scale.py
@@ -29,7 +29,7 @@ class Scale(NodeBase):
     """
 
     def __init__(self) -> None:
-        super().__init__("Scale")
+        super().__init__("Scale", section="Transform")
         self._scale_percent: int = 100
         self._interpolation: int = 1  # Linear
 

--- a/src/nodes/filters/shift.py
+++ b/src/nodes/filters/shift.py
@@ -20,7 +20,7 @@ class Shift(NodeBase):
     """
 
     def __init__(self) -> None:
-        super().__init__("Shift")
+        super().__init__("Shift", section="Transform")
         self._offset_x: int = 0
         self._offset_y: int = 0
 

--- a/src/nodes/sinks/file_sink.py
+++ b/src/nodes/sinks/file_sink.py
@@ -18,7 +18,7 @@ class OutputFormat(Enum):
 
 class FileSink(SinkNodeBase):
     def __init__(self):
-        super().__init__("File Sink")
+        super().__init__("File Sink", section="Sinks")
 
         self._output_path: str = "output/out.png"
         self._output_format: OutputFormat = OutputFormat.SAME_AS_INPUT

--- a/src/nodes/sources/file_source.py
+++ b/src/nodes/sources/file_source.py
@@ -30,7 +30,7 @@ class FileSource(SourceNodeBase):
     """
 
     def __init__(self) -> None:
-        super().__init__("File Source")
+        super().__init__("File Source", section="Sources")
         self._file_path: Path = Path()
         self._max_num_frames: int = -1
         self._add_output(OutputPort("image", {IoDataType.IMAGE}))

--- a/src/nodes/sources/image_source.py
+++ b/src/nodes/sources/image_source.py
@@ -28,7 +28,7 @@ class ImageSource(SourceNodeBase):
     """
 
     def __init__(self) -> None:
-        super().__init__("Image Source")
+        super().__init__("Image Source", section="Sources")
         self._file_path: Path = Path()
         self._add_output(OutputPort("image", {IoDataType.IMAGE}))
         self._apply_default_params()

--- a/src/nodes/sources/video_source.py
+++ b/src/nodes/sources/video_source.py
@@ -27,7 +27,7 @@ class VideoSource(SourceNodeBase):
     """
 
     def __init__(self) -> None:
-        super().__init__("Video Source")
+        super().__init__("Video Source", section="Sources")
         self._file_path: Path = Path()
         self._max_num_frames: int = -1
         self._add_output(OutputPort("image", {IoDataType.IMAGE}))

--- a/src/ui/flow_view.py
+++ b/src/ui/flow_view.py
@@ -8,7 +8,7 @@ from PySide6.QtCore import QMarginsF, QPoint, Qt
 from PySide6.QtGui import QPainter, QPen
 from PySide6.QtWidgets import QGraphicsView
 
-from ui.palette_widget import NODE_LIST_MIME_TYPE
+from ui.node_list import NODE_LIST_MIME_TYPE
 from ui.theme import CANVAS_BACKGROUND_COLOR, CANVAS_GRID_COLOR
 
 if TYPE_CHECKING:

--- a/src/ui/node_editor_page.py
+++ b/src/ui/node_editor_page.py
@@ -29,7 +29,7 @@ from ui.icons import material_icon
 from typing_extensions import override
 
 from ui.page import PageBase, ToolbarSection
-from ui.palette_widget import PaletteWidget
+from ui.node_list import NodeList
 from ui.theme import STATUS_FAIL_COLOR, STATUS_MUTED_COLOR, STATUS_OK_COLOR
 from ui.viewer_panel import ViewerPanel
 
@@ -75,13 +75,13 @@ class NodeEditorPage(PageBase):
         self._view  = FlowView(self._scene)
         self._inner.setCentralWidget(self._view)
 
-        # Palette dock (left).
-        self._palette = PaletteWidget(registry)
-        self._palette_dock = QDockWidget("Palette", self._inner)
-        self._palette_dock.setObjectName("PaletteDock")
-        self._palette_dock.setWidget(self._palette)
-        self._palette_dock.setAllowedAreas(Qt.DockWidgetArea.AllDockWidgetAreas)
-        self._inner.addDockWidget(Qt.DockWidgetArea.LeftDockWidgetArea, self._palette_dock)
+        # Node list dock (left, formerly "Palette").
+        self._node_list = NodeList(registry)
+        self._node_list_dock = QDockWidget("Node List", self._inner)
+        self._node_list_dock.setObjectName("NodeListDock")
+        self._node_list_dock.setWidget(self._node_list)
+        self._node_list_dock.setAllowedAreas(Qt.DockWidgetArea.AllDockWidgetAreas)
+        self._inner.addDockWidget(Qt.DockWidgetArea.LeftDockWidgetArea, self._node_list_dock)
 
         # Viewer dock (bottom).
         self._viewer = ViewerPanel()
@@ -160,7 +160,7 @@ class NodeEditorPage(PageBase):
         menu.addSeparator()
 
         view_menu = menu.addMenu("View")
-        view_menu.addAction(self._palette_dock.toggleViewAction())
+        view_menu.addAction(self._node_list_dock.toggleViewAction())
         view_menu.addAction(self._viewer_dock.toggleViewAction())
         return [menu]
 

--- a/src/ui/node_list.py
+++ b/src/ui/node_list.py
@@ -20,20 +20,30 @@ if TYPE_CHECKING:
 #: Custom MIME type carrying a JSON-encoded NodeEntry descriptor.
 NODE_LIST_MIME_TYPE: str = "application/x-image-inquest-node"
 
+#: Canonical display order for the well-known palette sections. Any
+#: section not listed here (e.g. defined by a user-provided plugin node)
+#: is appended after these in the order the registry reports them.
+_SECTION_ORDER: tuple[str, ...] = (
+    "Sources",
+    "Sinks",
+    "Color Spaces",
+    "Transform",
+    "Processing",
+)
 
-class PaletteWidget(QWidget):
-    """Palette listing every registered node by category.
+
+class NodeList(QWidget):
+    """Palette listing every registered node grouped by the ``section``
+    string each node declares in its constructor.
 
     Each entry is a :class:`QListWidgetItem` that emits a drag with the
     :data:`NODE_LIST_MIME_TYPE` MIME type carrying a JSON descriptor of
-    the node (module, class_name, display_name, category). The flow
-    canvas reads that payload on drop and instantiates the node.
+    the node (module, class_name, display_name, category, section). The
+    flow canvas reads that payload on drop and instantiates the node.
 
     A search box filters the list live; matching falls back to case-
     insensitive ``in`` on display names.
     """
-
-    _CATEGORIES: tuple[str, ...] = ("Sources", "Filters", "Sinks")
 
     def __init__(self, registry: NodeRegistry, parent: QWidget | None = None) -> None:
         super().__init__(parent)
@@ -55,11 +65,24 @@ class PaletteWidget(QWidget):
     # ── Internals ──────────────────────────────────────────────────────────────
 
     def _populate(self, registry: NodeRegistry) -> None:
-        categorized = registry.nodes_by_category()
-        for category in self._CATEGORIES:
-            entries = categorized.get(category, [])
-            # Category header is a non-selectable, non-draggable item.
-            header = QListWidgetItem(f"{category}  ({len(entries)})")
+        grouped = registry.nodes_by_section()
+        # Render well-known sections first in canonical order, then any
+        # novel sections (e.g. from user plugins) in registry order.
+        seen: set[str] = set()
+        ordered_sections: list[str] = []
+        for name in _SECTION_ORDER:
+            if name in grouped:
+                ordered_sections.append(name)
+                seen.add(name)
+        for name in grouped.keys():
+            if name not in seen:
+                ordered_sections.append(name)
+                seen.add(name)
+
+        for section in ordered_sections:
+            entries = grouped.get(section, [])
+            # Section header is a non-selectable, non-draggable item.
+            header = QListWidgetItem(f"{section}  ({len(entries)})")
             font = header.font()
             font.setBold(True)
             header.setFont(font)
@@ -81,6 +104,7 @@ class PaletteWidget(QWidget):
                     "class_name":   entry.class_name,
                     "display_name": entry.display_name,
                     "category":     entry.category,
+                    "section":      entry.section,
                 })
                 item.setData(Qt.ItemDataRole.UserRole, payload)
                 item.setToolTip(f"{entry.module}.{entry.class_name}")
@@ -90,7 +114,7 @@ class PaletteWidget(QWidget):
         query = text.strip().lower()
         for i in range(self._list.count()):
             item = self._list.item(i)
-            # Never hide category headers — context matters.
+            # Never hide section headers — context matters.
             if item.flags() == Qt.ItemFlag.NoItemFlags:
                 item.setHidden(False)
                 continue


### PR DESCRIPTION
Fixes #52.

## Summary
- The palette previously grouped nodes by their base-class category (Sources / Filters / Sinks). This is too coarse — most built-in nodes end up lumped under "Filters". Replace it with a user-controlled grouping where each node declares its own palette section.
- **`NodeBase.__init__`** gains a `section` kwarg (defaulting to a `DEFAULT_SECTION` class attribute: `"Sources"` / `"Sinks"` / `"Filters"`), exposed as a `section` property.
- **`NodeRegistry`**: AST scanner parses the `section=` argument (keyword or positional) of `super().__init__(...)`; `NodeEntry` now carries both `category` (from base class — still used for node header colour) and `section` (user-set — used for palette grouping). New `nodes_by_section()` returns the grouping used by the palette.
- **`palette_widget.py` → `node_list.py`; `PaletteWidget` → `NodeList`**. The list renders well-known sections (`"Sources"`, `"Sinks"`, `"Color Spaces"`, `"Transform"`, `"Processing"`) in canonical order, then any additional sections declared by user plugins. The drag JSON payload now carries the section.
- **`node_editor_page.py` + `flow_view.py`** updated for the new import and dock title ("Node List" instead of "Palette").
- **All built-in nodes** annotated with their section:
  - Sources: File Source, Image Source, Video Source
  - Sinks: File Sink
  - Color Spaces: Grayscale, RGB Split, RGB Join
  - Transform: Scale, Shift
  - Processing: Adaptive Gaussian Threshold, Dither, Median, Normalize

## Test plan
- [ ] Launch the app → left dock is titled "Node List" with sections Sources / Sinks / Color Spaces / Transform / Processing in that order
- [ ] Every built-in node appears exactly once, under the expected section
- [ ] Drag a node onto the canvas → it instantiates correctly
- [ ] Save + reopen a flow with each of the relocated nodes (Grayscale, Scale, Dither, …) → loads unchanged
- [ ] Add a user plugin node that passes a novel `section=` value → it appears in its own group below the built-in sections

https://claude.ai/code/session_01HaHBGxxdCW3g4tr7agijTh