### PR TITLE
Fix #54: add Recently Used Files submenu to the File menu

### DIFF
--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -20,6 +20,7 @@ from core.flow import Flow
 from core.node_registry import NodeRegistry
 from ui.node_editor_page import NodeEditorPage
 from ui.page import PageBase
+from ui.recent_flows import RecentFlowsManager
 from ui.start_page import StartPage
 
 if TYPE_CHECKING:
@@ -61,12 +62,16 @@ class MainWindow(QMainWindow):
             logger.warning("User node scan: %s", err)
         logger.info("Registry: %d node(s) loaded", len(self._registry))
 
+        # ── Recent flows MRU (persistent across sessions) ──
+        self._recent_flows = RecentFlowsManager(self)
+        self._recent_flows.changed.connect(self._rebuild_recent_menu)
+
         # ── Page stack ──
         self._pages = QStackedWidget()
         self.setCentralWidget(self._pages)
 
         self._start_page  = StartPage()
-        self._editor_page = NodeEditorPage(self._registry)
+        self._editor_page = NodeEditorPage(self._registry, self._recent_flows)
         # Seed the editor with an empty flow so the user can switch to it
         # via the page-selector radio group at any time without first
         # visiting the start page to create one.
@@ -212,8 +217,14 @@ class MainWindow(QMainWindow):
     # ── Menus ──────────────────────────────────────────────────────────────────
 
     def _build_app_menu(self) -> QMenu:
-        """Always-visible application menu (Quit, About)."""
+        """Always-visible application menu (Recently Used Files, Quit)."""
         menu = self._menu_bar.addMenu("&File")
+
+        # MRU submenu: rebuilt on every RecentFlowsManager.changed emission
+        # so the labels reflect the latest state without any per-open hook.
+        self._recent_menu = menu.addMenu("Recently Used Files")
+        self._rebuild_recent_menu()
+        menu.addSeparator()
 
         quit_action = QAction("&Quit", self)
         quit_action.setShortcut(QKeySequence.StandardKey.Quit)
@@ -221,6 +232,45 @@ class MainWindow(QMainWindow):
         menu.addAction(quit_action)
 
         return menu
+
+    def _rebuild_recent_menu(self) -> None:
+        """Repopulate the Recently Used Files submenu from the MRU list.
+
+        Called once at startup and on every :attr:`RecentFlowsManager.changed`
+        emission. Disabled placeholder ("(none)") shown when the list is
+        empty; a trailing "Clear Recent Files" action lets the user wipe
+        the MRU from the UI without editing the JSON file by hand.
+        """
+        self._recent_menu.clear()
+        paths = self._recent_flows.paths
+        if not paths:
+            empty = QAction("(none)", self)
+            empty.setEnabled(False)
+            self._recent_menu.addAction(empty)
+            return
+        for index, path in enumerate(paths, start=1):
+            # Leading "&N " gives Alt-N mnemonics for the first 9 entries.
+            label = f"&{index} {path.name}" if index < 10 else path.name
+            action = QAction(label, self)
+            action.setToolTip(str(path))
+            action.triggered.connect(lambda _checked=False, p=path: self._on_open_recent(p))
+            self._recent_menu.addAction(action)
+        self._recent_menu.addSeparator()
+        clear = QAction("Clear Recent Files", self)
+        clear.triggered.connect(self._recent_flows.clear)
+        self._recent_menu.addAction(clear)
+
+    def _on_open_recent(self, path: Path) -> None:
+        """Load ``path`` in the editor and switch to the editor page.
+
+        On failure the editor page already shows a status message and the
+        path is dropped from the MRU so the user doesn't keep seeing a
+        stale entry.
+        """
+        if self._editor_page.load_flow(path):
+            self._activate_page(self._editor_page)
+        else:
+            self._recent_flows.remove(path)
 
     # ── Navigation callbacks ───────────────────────────────────────────────────
 

--- a/src/ui/node_editor_page.py
+++ b/src/ui/node_editor_page.py
@@ -30,6 +30,7 @@ from typing_extensions import override
 
 from ui.page import PageBase, ToolbarSection
 from ui.node_list import NodeList
+from ui.recent_flows import RecentFlowsManager
 from ui.theme import STATUS_FAIL_COLOR, STATUS_MUTED_COLOR, STATUS_OK_COLOR
 from ui.viewer_panel import ViewerPanel
 
@@ -54,9 +55,14 @@ class NodeEditorPage(PageBase):
     flow name changes.
     """
 
-    def __init__(self, registry: NodeRegistry) -> None:
+    def __init__(
+        self,
+        registry: NodeRegistry,
+        recent_flows: RecentFlowsManager | None = None,
+    ) -> None:
         super().__init__()
         self._registry = registry
+        self._recent_flows = recent_flows
         self._flow: Flow | None = None
 
         outer = QVBoxLayout(self)
@@ -197,6 +203,8 @@ class NodeEditorPage(PageBase):
             f"Loaded {_display_path(path)} at {datetime.now().strftime('%H:%M:%S')}",
             kind="ok",
         )
+        if self._recent_flows is not None:
+            self._recent_flows.add(path)
         return True
 
     # ── Actions ────────────────────────────────────────────────────────────────
@@ -298,6 +306,8 @@ class NodeEditorPage(PageBase):
             f"Saved to {_display_path(path)} at {datetime.now().strftime('%H:%M:%S')}",
             kind="ok",
         )
+        if self._recent_flows is not None:
+            self._recent_flows.add(path)
 
     def _on_save_as_clicked(self) -> None:
         if self._flow is None:
@@ -334,6 +344,8 @@ class NodeEditorPage(PageBase):
             f"Saved to {_display_path(path)} at {datetime.now().strftime('%H:%M:%S')}",
             kind="ok",
         )
+        if self._recent_flows is not None:
+            self._recent_flows.add(path)
 
     def _on_open_clicked(self) -> None:
         FLOW_DIR.mkdir(parents=True, exist_ok=True)

--- a/src/ui/recent_flows.py
+++ b/src/ui/recent_flows.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+from PySide6.QtCore import QObject, Signal
+
+from constants import USER_CONFIG_DIR
+
+logger = logging.getLogger(__name__)
+
+#: JSON file that persists the MRU list between sessions. Lives in the
+#: same user-config directory as user-defined nodes.
+_RECENT_FLOWS_FILE: Path = USER_CONFIG_DIR / "recent_flows.json"
+
+#: Maximum number of recent paths kept in the list. The issue specifies 5.
+MAX_RECENT_FLOWS: int = 5
+
+
+class RecentFlowsManager(QObject):
+    """Persistent most-recently-used list of flow files.
+
+    Stores up to :data:`MAX_RECENT_FLOWS` absolute paths in
+    ``~/.image-inquest/recent_flows.json``.  Emits :attr:`changed`
+    whenever the list is mutated so menus can rebuild themselves.
+
+    The list is ordered newest-first.  Re-adding an existing path moves
+    it to the top instead of creating a duplicate.
+    """
+
+    changed = Signal()
+
+    def __init__(self, parent: QObject | None = None) -> None:
+        super().__init__(parent)
+        self._paths: list[Path] = []
+        self._load()
+
+    # ── Access ────────────────────────────────────────────────────────────────
+
+    @property
+    def paths(self) -> list[Path]:
+        """Return a snapshot of the current MRU list (newest first)."""
+        return list(self._paths)
+
+    def __len__(self) -> int:
+        return len(self._paths)
+
+    # ── Mutation ──────────────────────────────────────────────────────────────
+
+    def add(self, path: Path) -> None:
+        """Insert ``path`` at the top of the list (deduplicated, trimmed).
+
+        Paths are resolved so the same file opened via different relative
+        prefixes collapses to a single entry. Trimming keeps the list at
+        :data:`MAX_RECENT_FLOWS` items.
+        """
+        resolved = _safe_resolve(path)
+        self._paths = [p for p in self._paths if p != resolved]
+        self._paths.insert(0, resolved)
+        del self._paths[MAX_RECENT_FLOWS:]
+        self._save()
+        self.changed.emit()
+
+    def remove(self, path: Path) -> None:
+        """Drop ``path`` from the list if present (no-op otherwise)."""
+        resolved = _safe_resolve(path)
+        before = len(self._paths)
+        self._paths = [p for p in self._paths if p != resolved]
+        if len(self._paths) != before:
+            self._save()
+            self.changed.emit()
+
+    def clear(self) -> None:
+        if not self._paths:
+            return
+        self._paths = []
+        self._save()
+        self.changed.emit()
+
+    # ── Persistence ───────────────────────────────────────────────────────────
+
+    def _load(self) -> None:
+        if not _RECENT_FLOWS_FILE.exists():
+            return
+        try:
+            raw = _RECENT_FLOWS_FILE.read_text(encoding="utf-8")
+            data = json.loads(raw)
+        except (OSError, json.JSONDecodeError):
+            logger.exception("Failed to load %s; starting with empty MRU", _RECENT_FLOWS_FILE)
+            return
+        if not isinstance(data, list):
+            logger.warning(
+                "%s: expected JSON list, got %s; ignoring",
+                _RECENT_FLOWS_FILE, type(data).__name__,
+            )
+            return
+        self._paths = [Path(item) for item in data if isinstance(item, str)][:MAX_RECENT_FLOWS]
+
+    def _save(self) -> None:
+        try:
+            _RECENT_FLOWS_FILE.parent.mkdir(parents=True, exist_ok=True)
+            _RECENT_FLOWS_FILE.write_text(
+                json.dumps([str(p) for p in self._paths], indent=2),
+                encoding="utf-8",
+            )
+        except OSError:
+            logger.exception("Failed to save %s", _RECENT_FLOWS_FILE)
+
+
+def _safe_resolve(path: Path) -> Path:
+    """Return ``path.resolve()`` but fall back to ``path`` on filesystem errors.
+
+    ``Path.resolve()`` touches the filesystem, which can raise on broken
+    symlinks or permission issues.  The MRU list still wants a stable
+    key in those cases.
+    """
+    try:
+        return path.resolve()
+    except OSError:
+        return path


### PR DESCRIPTION
Fixes #54.

## Summary
Adds a persistent MRU list of up to 5 flow paths shown as a **Recently Used Files** submenu under the top-level File menu.

- **`RecentFlowsManager`** (`src/ui/recent_flows.py`): `QObject` that loads, mutates, and persists the MRU list to `~/.image-inquest/recent_flows.json`. Newest-first, dedup-and-promote on re-add, automatic trim to 5 entries. Emits a `changed` signal so menus rebuild themselves without per-open plumbing.
- **`NodeEditorPage`**: accepts an optional `RecentFlowsManager`. `load_flow`, `_on_save_clicked`, and `_on_save_as_clicked` now call `add(path)` so every open and save is recorded. This covers:
  - Opening via the editor's **Open** action
  - Opening via the StartPage's **Open** action (funnels through `load_flow`)
  - Opening via the `--flow` CLI flag
  - Saving via **Save** or **Save As…**
- **`MainWindow`**: owns the shared `RecentFlowsManager`, passes it to the editor page, and populates a **Recently Used Files** submenu of **File**. Each entry renders as `&N filename` for Alt-N mnemonics (first 9), full path in the tooltip. A trailing **Clear Recent Files** wipes the MRU. An empty list shows a disabled `(none)` placeholder. Selecting an entry loads it via the editor page and switches to the editor; failed loads are removed from the MRU so stale entries don't linger.

## Test plan
- [ ] Launch app → File → Recently Used Files shows `(none)` on a fresh `~/.image-inquest`
- [ ] Open or save a flow → reopen the menu → that flow appears at the top
- [ ] Open 6 different flows → the menu shows exactly the 5 most recent, newest first
- [ ] Re-open an earlier entry → it moves back to the top (no duplicate)
- [ ] Restart the app → the MRU is preserved
- [ ] Choose **Clear Recent Files** → list empties; `recent_flows.json` becomes `[]`
- [ ] Delete a flow file on disk, then click its MRU entry → status shows the open failure and the entry is dropped from the MRU

https://claude.ai/code/session_01HaHBGxxdCW3g4tr7agijTh