### PR TITLE
Fix #56: add Log page showing the last 1000 lines of the log file

### DIFF
--- a/src/constants.py
+++ b/src/constants.py
@@ -26,3 +26,7 @@ FLOW_DIR:   Path = Path(__file__).parent.parent / "flow"
 # User-defined nodes (~/.image-inquest/user_nodes/)
 USER_CONFIG_DIR: Path = Path.home() / ".image-inquest"
 USER_NODES_DIR:  Path = USER_CONFIG_DIR / "user_nodes"
+
+# Application log directory and active log file (rotated by log.setup_logging).
+USER_LOG_DIR:    Path = USER_CONFIG_DIR / "logs"
+LOG_FILE_PATH:   Path = USER_LOG_DIR / "image-inquest.log"

--- a/src/main.py
+++ b/src/main.py
@@ -15,7 +15,7 @@ from constants import (
     FLOW_DIR,
     SPLASH_DURATION_MS,
     SPLASH_IMAGE_PATH,
-    USER_CONFIG_DIR,
+    USER_LOG_DIR,
 )
 from log import setup_logging
 from ui.main_window import MainWindow
@@ -103,7 +103,7 @@ def main(argv: list[str]) -> int:
     )
     args, qt_args = parser.parse_known_args(argv)
 
-    setup_logging(USER_CONFIG_DIR / "logs")
+    setup_logging(USER_LOG_DIR)
     logger.info("Starting %s v%s", APP_NAME, APP_VERSION)
 
     initial_flow_path: Path | None = None

--- a/src/ui/icons.py
+++ b/src/ui/icons.py
@@ -42,6 +42,8 @@ _CODEPOINTS: Final[dict[str, str]] = {
     "delete":       "e872",
     "zoom_out_map": "e56b",
     "fullscreen_exit": "e5d1",
+    "article":      "ef42",
+    "refresh":      "e5d5",
 }
 
 

--- a/src/ui/log_page.py
+++ b/src/ui/log_page.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+import logging
+from collections import deque
+from pathlib import Path
+
+from PySide6.QtCore import Qt
+from PySide6.QtGui import QAction, QFont, QIcon
+from PySide6.QtWidgets import QMenu, QPlainTextEdit, QVBoxLayout
+from typing_extensions import override
+
+from constants import LOG_FILE_PATH
+from ui.icons import material_icon
+from ui.page import PageBase, ToolbarSection
+
+logger = logging.getLogger(__name__)
+
+#: Maximum number of trailing log lines shown in the page.
+MAX_LOG_LINES: int = 1000
+
+
+class LogPage(PageBase):
+    """Read-only viewer that shows the last :data:`MAX_LOG_LINES` lines
+    of the application log file.
+
+    The log is re-read on every activation and whenever the user triggers
+    the Refresh action.  The text view uses a monospaced font so column-
+    aligned log records stay aligned.  Missing or unreadable log files
+    are surfaced inline so users can tell the page apart from an empty
+    log at a glance.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(8, 8, 8, 8)
+        layout.setSpacing(4)
+
+        self._text = QPlainTextEdit()
+        self._text.setReadOnly(True)
+        self._text.setLineWrapMode(QPlainTextEdit.LineWrapMode.NoWrap)
+        # Fixed-width font so the "timestamp  LEVEL  logger  message"
+        # columns produced by log.setup_logging line up.
+        mono = QFont("Monospace")
+        mono.setStyleHint(QFont.StyleHint.TypeWriter)
+        self._text.setFont(mono)
+        layout.addWidget(self._text, 1)
+
+        self._refresh_action = QAction(material_icon("refresh"), "Refresh", self)
+        self._refresh_action.setToolTip("Re-read the log file from disk")
+        self._refresh_action.triggered.connect(self.refresh)
+
+    # ── Page hooks ─────────────────────────────────────────────────────────────
+
+    @override
+    def page_selector_label(self) -> str:
+        return "Log"
+
+    @override
+    def page_selector_icon(self) -> QIcon:
+        return material_icon("article")
+
+    @override
+    def page_title(self) -> str:
+        return ""
+
+    @override
+    def page_toolbar_sections(self) -> list[ToolbarSection]:
+        return [ToolbarSection("Log", [self._refresh_action])]
+
+    @override
+    def page_menus(self) -> list[QMenu]:
+        menu = QMenu("Log")
+        menu.addAction(self._refresh_action)
+        return [menu]
+
+    @override
+    def on_activated(self) -> None:
+        # Always show fresh content when the user switches to this page.
+        self.refresh()
+
+    # ── Public API ─────────────────────────────────────────────────────────────
+
+    def refresh(self) -> None:
+        """Reload the log file and display its last :data:`MAX_LOG_LINES` lines."""
+        text = _read_tail(LOG_FILE_PATH, MAX_LOG_LINES)
+        self._text.setPlainText(text)
+        # Scroll to the end so the newest entry is immediately visible.
+        cursor = self._text.textCursor()
+        cursor.movePosition(cursor.MoveOperation.End)
+        self._text.setTextCursor(cursor)
+        # Also nudge the vertical scrollbar to the bottom in case the
+        # cursor-based scroll lags on very large contents.
+        bar = self._text.verticalScrollBar()
+        bar.setValue(bar.maximum())
+
+
+def _read_tail(path: Path, max_lines: int) -> str:
+    """Return the last ``max_lines`` of the file at ``path``.
+
+    Missing file → returns a short explanatory placeholder so the page
+    isn't blank (a fresh install with no logs yet is common). Read
+    errors are logged and surfaced in the view as well.
+    """
+    if not path.exists():
+        return f"(no log file at {path})"
+    try:
+        with path.open("r", encoding="utf-8", errors="replace") as fp:
+            # Bounded buffer: keep the most recent ``max_lines`` without
+            # loading the whole file into memory at once. At the
+            # configured 1 MB rotation limit this is also safe to read
+            # directly, but the deque approach is future-proof.
+            buf: deque[str] = deque(maxlen=max_lines)
+            for line in fp:
+                buf.append(line)
+    except OSError as err:
+        logger.exception("Failed to read log file %s", path)
+        return f"(failed to read {path}: {err})"
+
+    if not buf:
+        return "(log file is empty)"
+    # Lines already include their trailing newlines; strip the very last
+    # one so the QPlainTextEdit doesn't render a dangling empty row.
+    return "".join(buf).rstrip("\n")

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -18,6 +18,7 @@ from PySide6.QtWidgets import (
 from constants import APP_DISPLAY_NAME, BUILTIN_NODES_DIR, USER_NODES_DIR
 from core.flow import Flow
 from core.node_registry import NodeRegistry
+from ui.log_page import LogPage
 from ui.node_editor_page import NodeEditorPage
 from ui.page import PageBase
 from ui.start_page import StartPage
@@ -67,6 +68,7 @@ class MainWindow(QMainWindow):
 
         self._start_page  = StartPage()
         self._editor_page = NodeEditorPage(self._registry)
+        self._log_page    = LogPage()
         # Seed the editor with an empty flow so the user can switch to it
         # via the page-selector radio group at any time without first
         # visiting the start page to create one.
@@ -74,11 +76,12 @@ class MainWindow(QMainWindow):
 
         self._pages.addWidget(self._start_page)
         self._pages.addWidget(self._editor_page)
+        self._pages.addWidget(self._log_page)
 
         # Wire page signals.
         self._start_page.create_flow_requested.connect(self._on_create_flow)
         self._start_page.open_flow_requested.connect(self._on_open_flow_from_start)
-        for page in (self._start_page, self._editor_page):
+        for page in (self._start_page, self._editor_page, self._log_page):
             page.title_changed.connect(self._update_window_title)
 
         # ── Menu bar ──
@@ -94,7 +97,7 @@ class MainWindow(QMainWindow):
         self._page_selector_group = QActionGroup(self)
         self._page_selector_group.setExclusive(True)
         self._page_selector_actions: dict[PageBase, QAction] = {}
-        for page in (self._start_page, self._editor_page):
+        for page in (self._start_page, self._editor_page, self._log_page):
             self._add_page_selector_action(page)
         # Separator between the page-selector radio group and the
         # page-specific toolbar actions.


### PR DESCRIPTION
Fixes #56.

## Summary
Adds a third top-level page, reachable from the main toolbar's page-selector radio group, that displays the tail of the application log file.

- **`constants.py`** gains `USER_LOG_DIR` and `LOG_FILE_PATH`, so the log file location is declared alongside other app paths rather than being implicit inside `main.py` and `log.py`. `main.py` now calls `setup_logging(USER_LOG_DIR)` via the constant.
- **`ui/log_page.py` (new)**: `LogPage` extending `PageBase`. A read-only `QPlainTextEdit` with a monospaced font renders the last `MAX_LOG_LINES` (= 1000) lines of `LOG_FILE_PATH`. The tail is collected via a bounded `deque`, so the page stays memory-cheap even if the log later exceeds the 1 MB rotation threshold. Missing / unreadable files surface inline (e.g. `(no log file at …)`) rather than leaving the view blank. A **Refresh** toolbar action re-reads on demand; `on_activated()` also refreshes so tab-switching always shows current data. After reload the view scrolls to the bottom so the most recent entry is visible without hunting for it.
- **`ui/icons.py`** registers the Material Icons codepoints for `article` (page-selector icon) and `refresh` (toolbar action icon).
- **`ui/main_window.py`**: instantiates `LogPage`, stacks it after the editor page, and adds it to both the page-selector and the title subscription list.

## Test plan
- [ ] Launch the app → toolbar shows **Start / Editor / Log** selectors; clicking **Log** switches to the new page.
- [ ] With no log file yet → page shows `(no log file at …)`.
- [ ] Perform a few actions → click **Log** → most recent log records visible; scrolled to the bottom.
- [ ] With a log file longer than 1000 lines → exactly the last 1000 lines are shown.
- [ ] Click **Refresh** after triggering a new log record → new record appears without restarting the app.
- [ ] Switch back to **Editor**, do something that logs, switch to **Log** → refreshes automatically.

https://claude.ai/code/session_01HaHBGxxdCW3g4tr7agijTh