### PR TITLE
Fix #63: update README and add CHANGELOG reflecting recent work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,79 @@
+# Changelog
+
+All notable changes to Sparklehoof (repo: `image-inquest`) are tracked
+in this file.
+
+The format loosely follows [Keep a
+Changelog](https://keepachangelog.com/en/1.1.0/) and the project aims
+to adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
+once a first tagged release is cut.
+
+## [Unreleased]
+
+### Added
+- **Enum-typed node parameters.** `NodeParamType.ENUM` + an
+  `EnumParamWidget` that renders a combo box populated from a declared
+  `Enum` class, with pretty member labels. Dither uses it for its
+  `method` parameter; `flow_io` serialises `Enum` values via their
+  underlying `.value` so saved flows stay human-readable and
+  backward-compatible (#51).
+- **Live-coding auto-run.** Image-backed source nodes trigger a 300 ms
+  debounced re-run of the flow on any parameter change so the viewer
+  reflects edits in near real time.
+- **Image Source / Video Source** nodes, in addition to the existing
+  generic File Source.
+- **Numba-JIT error-diffusion dither** (Floyd–Steinberg, Stucki,
+  Atkinson, Burkes, Sierra, simple-X, simple-XY). Kernels are JIT-
+  compiled once and cached to `__pycache__` for interactive-speed
+  dithering.
+- **Bayer ordered-dither** matrices (2×2, 4×4, 8×8), alongside a
+  white-noise threshold method.
+- **Adaptive Gaussian Threshold**, **Median**, **Normalize** filters;
+  **Scale**, **Shift** transforms; **RGB Split**, **RGB Join**,
+  **Grayscale** colour-space nodes.
+- **Fit to window** and **Reset zoom** toolbar actions in the node
+  editor.
+- **Page-selector radio group** in the main toolbar: each page
+  (Start, Editor) contributes its own menus and a named
+  `ToolbarSection` group that MainWindow installs next to the
+  selector.
+- **Material-Icons**-based toolbar icons, rendered from the bundled
+  TTF via a custom `QIconEngine` so they stay crisp at any size.
+- **Dark theme** applied globally via a Qt style sheet + palette.
+- **Splash screen** with monitor-aware placement so the main window
+  opens on the same display.
+- **CLI `--flow FILE`** to open a flow at startup.
+- **Per-node status bar** messages (OK / fail / muted) with full-
+  text tooltip for long error traces.
+- **Rotating file log** at `~/.image-inquest/logs/image-inquest.log`
+  (5 × 1 MB chunks).
+
+### Changed
+- The **node palette** was restructured: nodes now declare their own
+  palette section via `super().__init__(..., section="…")` instead of
+  being grouped by their base-class category. Built-in sections are
+  Sources, Sinks, Color Spaces, Transform, Processing; user plugins
+  can introduce new sections (#52).
+- The **palette widget** was renamed from `PaletteWidget` to
+  `NodeList` and its dock is now titled "Node List" (#52).
+- The start page has a single primary **Create** action sized to
+  match the main toolbar, with a material "add" icon; the duplicate
+  client-area **Open** button has been removed since the toolbar
+  already exposes one (#53).
+
+### Fixed
+- File-dialog browse button showing `.` instead of `…` on nodes
+  with a file-path field.
+- Node selection after the `QGraphicsObject` → `QGraphicsItem` +
+  signal-helper refactor.
+- Viewer showing nothing after a run because the end-of-stream frame
+  was overwriting the cached output.
+- Window-title duplication caused by Qt's automatic
+  `applicationDisplayName` prefix.
+- Node file-path field overlapping the browse button.
+
+## [0.1.0] — initial development snapshot
+
+Initial working prototype: start page, node editor with dockable
+palette and viewer, flow save/load, and a minimal built-in node set
+(File Source, Grayscale, File Sink).

--- a/README.md
+++ b/README.md
@@ -4,19 +4,52 @@
 
 # Sparklehoof
 
-A Python desktop application for building image- and video-processing workflows using a node-based visual editor.
+A Python desktop application for building image- and video-processing
+workflows using a node-based visual editor.
 
-> The repo is still named `image-inquest` while the rebrand to **Sparklehoof** lands piece by piece. `APP_NAME` in `src/constants.py` remains `Image-Inquest` for now so log paths and the user config dir (`~/.image-inquest/`) stay stable.
+> The repo is still named `image-inquest` while the rebrand to
+> **Sparklehoof** lands piece by piece. `APP_NAME` in
+> `src/constants.py` remains `Image-Inquest` for now so log paths and
+> the user config dir (`~/.image-inquest/`) stay stable.
 
 ## Status
 
-Early-stage development. The application provides a two-page UI — a start page and a node editor — with dynamic node creation, linking, flow save/load (`*.flowjs`), and a working **Run** action that executes the active flow. Built-in nodes today: a file source, a grayscale filter, and a file sink.
+Early-stage development.  The application ships:
+
+- A **page-based UI**: a start page, a node editor, and (coming soon,
+  see [CHANGELOG](CHANGELOG.md)) a read-only Log page.
+- A **node-based flow editor** with a dockable node palette, a canvas
+  with a zoom-and-pan graphics view, a selectable viewer dock, and a
+  status bar.
+- **Dynamic node discovery** — built-in nodes under `src/nodes/` and
+  user nodes under `~/.image-inquest/user_nodes/` are scanned at
+  startup via the Python AST (no import needed to appear in the
+  palette).
+- **Flow persistence** — `*.flowjs` JSON files under `flow/`.
+- **Live coding** — image-backed source nodes auto-re-run the flow
+  300 ms after any parameter change so changes are reflected in the
+  viewer in near real time.
+- **Numba-JIT dither kernels** for interactive-speed error diffusion.
+
+### Built-in nodes
+
+Organised by palette section:
+
+| Section | Nodes |
+|---|---|
+| Sources | File Source, Image Source, Video Source |
+| Sinks | File Sink |
+| Color Spaces | Grayscale, RGB Split, RGB Join |
+| Transform | Scale, Shift |
+| Processing | Adaptive Gaussian Threshold, Dither, Median, Normalize |
+
+See [`CHANGELOG.md`](CHANGELOG.md) for a running list of notable changes.
 
 ## Requirements
 
 - Python 3.10+
 - [PySide6](https://doc.qt.io/qtforpython-6/)
-- NumPy, OpenCV, rawpy
+- NumPy, OpenCV, numba, rawpy
 
 ```bash
 pip install -r requirements.txt
@@ -38,10 +71,40 @@ Optional arguments:
 ## Usage
 
 1. The app opens on the **start page**.
-2. Enter a name and click **Create** to open the node editor with a new empty flow, or click **Open** to load an existing `*.flowjs` file.
-3. In the editor, drag nodes from the **Palette** dock onto the canvas.
-4. Drag between node ports to create links; drag an existing link to remove it.
-5. Click **Run** to execute the flow, or **Save** to persist it to `flow/`.
+2. Enter a name and click **Create** to open the node editor with a
+   new empty flow, or click **Open** to load an existing `*.flowjs`
+   file.
+3. In the editor, drag nodes from the **palette** onto the canvas.
+4. Drag between node ports to create links; drag an existing link to
+   remove it.
+5. Click **Run** to execute the flow, or **Save** to persist it to
+   `flow/`.  Reactive sources (still-image inputs) re-run the flow
+   automatically as you edit parameters.
+
+## Project layout
+
+```
+src/
+  main.py               Entry point + CLI parsing + splash screen
+  constants.py          Paths (FLOW_DIR, USER_CONFIG_DIR, …) and app metadata
+  log.py                Rotating-file logging setup
+  core/                 Non-UI: node base classes, ports, data, registry
+  nodes/                Built-in nodes (sources, sinks, filters)
+  ui/                   PySide6 views, pages, widgets
+tests/                  Pytest suite
+flow/                   Sample + saved flows (*.flowjs)
+assets/                 Splash image and bundled fonts
+```
+
+User-specific state (logs, recent flows, user-defined nodes) lives
+under `~/.image-inquest/`.
+
+## Development
+
+```bash
+pip install -r requirements-dev.txt
+pytest
+```
 
 ## License
 


### PR DESCRIPTION
Fixes #63.

## Summary
- **README** now documents the actual current feature surface: the page-based UI, dynamic AST-driven node discovery, flow persistence, live-coding auto-run, numba-JIT dither, the full built-in node list grouped by palette section, the CLI flags, and a Project layout + Development section.
- **New `CHANGELOG.md`** follows the [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format. The `[Unreleased]` section groups recent work into **Added / Changed / Fixed** (enum-typed node parameters, live-coding auto-run, the new source/filter/transform/colour-space/processing nodes, Material Icons, dark theme, splash screen, `--flow`, palette section restructure, `PaletteWidget → NodeList` rename, start-page polish, and a batch of bug fixes). `[0.1.0]` anchors the initial prototype.

## Test plan
- [ ] Render the README on GitHub — tables and links resolve correctly; `[CHANGELOG](CHANGELOG.md)` link works.
- [ ] Render the CHANGELOG on GitHub — Added/Changed/Fixed headers, issue links (`#51`, `#52`, `#53`) resolve.

https://claude.ai/code/session_01HaHBGxxdCW3g4tr7agijTh