### PR TITLE
Fix #70: pass section to NodeEntry in FlowView drop handler

### DIFF
--- a/src/ui/flow_view.py
+++ b/src/ui/flow_view.py
@@ -151,6 +151,10 @@ class FlowView(QGraphicsView):
         entry = NodeEntry(
             display_name=data.get("display_name", ""),
             category=data.get("category", ""),
+            # NodeList started carrying ``section`` in its drag payload in
+            # #52; default to the category so drops from stale payloads
+            # still instantiate cleanly instead of raising TypeError.
+            section=data.get("section", data.get("category", "")),
             module=data["module"],
             class_name=data["class_name"],
         )


### PR DESCRIPTION
Fixes #70.

## Summary
#52 added a required `section` field to `NodeEntry` and updated `NodeList` to carry it in the drag payload, but the matching read-back in `FlowView.dropEvent` was missed. Dropping any node on the canvas therefore raised:

```
TypeError: NodeEntry.__init__() missing 1 required positional argument: 'section'
```

Read `section` back out of the MIME payload; fall back to `category` when the payload predates #52 so stale clipboard data can't crash the editor either.

## Test plan
- [ ] Drag a node from the Node List dock onto the canvas → node instantiates without a TypeError
- [ ] Drag a node from any section (Sources, Color Spaces, Transform, Processing, Sinks) → all drop successfully

https://claude.ai/code/session_01HaHBGxxdCW3g4tr7agijTh