### PR TITLE
Add close button to node headers and remove node context menu

### DIFF
--- a/src/ui/flow_scene.py
+++ b/src/ui/flow_scene.py
@@ -35,7 +35,8 @@ class FlowScene(QGraphicsScene):
         registering it with the active Flow.
       - drag-between-ports → creating both the visual LinkItem and the
         underlying ``Flow.connect`` edge.
-      - right-click context menus on nodes (Delete) and links (Delete).
+      - right-click context menu on links (Delete). Nodes are deleted
+        via the ``X`` button in their header or the Delete key.
 
     Emits :attr:`selected_node_changed` whenever the user's selection
     settles on a different single node (None when nothing or multiple
@@ -222,24 +223,14 @@ class FlowScene(QGraphicsScene):
         views = self.views()
         xform = views[0].transform() if views else QTransform()
         item = self.itemAt(event.scenePos(), xform)
-        # Walk up to a NodeItem / LinkItem if a port or label was clicked.
-        while item is not None and not isinstance(item, (NodeItem, LinkItem)):
+        # Walk up to a LinkItem if a label was clicked.
+        while item is not None and not isinstance(item, LinkItem):
             item = item.parentItem()
 
-        if isinstance(item, NodeItem):
-            self._node_context_menu(item, event)
-            return
         if isinstance(item, LinkItem):
             self._link_context_menu(item, event)
             return
         super().contextMenuEvent(event)
-
-    def _node_context_menu(self, item: NodeItem, event: QGraphicsSceneContextMenuEvent) -> None:
-        menu = QMenu()
-        delete = QAction("Delete Node", menu)
-        delete.triggered.connect(lambda: self.remove_node_item(item))
-        menu.addAction(delete)
-        menu.exec(event.screenPos())
 
     def _link_context_menu(self, link: LinkItem, event: QGraphicsSceneContextMenuEvent) -> None:
         menu = QMenu()

--- a/src/ui/node_item.py
+++ b/src/ui/node_item.py
@@ -3,9 +3,10 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING
 
-from PySide6.QtCore import QObject, QPointF, QRectF, Qt, Signal
+from PySide6.QtCore import QObject, QPointF, QRectF, Qt, QTimer, Signal
 from PySide6.QtGui import (
     QBrush,
+    QColor,
     QPainter,
     QPainterPath,
     QPen,
@@ -53,6 +54,77 @@ class _NodeSignals(QObject):
     param_changed = Signal()
 
 
+class _CloseButtonItem(QGraphicsItem):
+    """Small ``X`` button rendered on the right of a node header.
+
+    Clicking it asks the owning scene to delete the node. Kept as a child
+    ``QGraphicsItem`` of the node so it moves and z-orders with the header.
+    """
+
+    SIZE: float = 14.0
+    Z_VALUE = 2
+
+    def __init__(self, node_item: "NodeItem") -> None:
+        super().__init__(parent=node_item)
+        self._node_item = node_item
+        self._hovered = False
+        self._pressed = False
+        self.setZValue(self.Z_VALUE)
+        self.setAcceptHoverEvents(True)
+        self.setAcceptedMouseButtons(Qt.MouseButton.LeftButton)
+        self.setCursor(Qt.CursorShape.ArrowCursor)
+
+    def boundingRect(self) -> QRectF:  # type: ignore[override]
+        return QRectF(0, 0, self.SIZE, self.SIZE)
+
+    def paint(self, painter: QPainter, option, widget=None) -> None:  # type: ignore[override]
+        painter.setRenderHint(QPainter.RenderHint.Antialiasing, True)
+        if self._hovered or self._pressed:
+            painter.setPen(Qt.NoPen)
+            painter.setBrush(QBrush(QColor(255, 255, 255, 70)))
+            painter.drawRoundedRect(self.boundingRect(), 2, 2)
+        pen = QPen(NODE_TITLE_TEXT_COLOR, 1.6)
+        pen.setCapStyle(Qt.PenCapStyle.RoundCap)
+        painter.setPen(pen)
+        m = 4.0
+        s = self.SIZE
+        painter.drawLine(QPointF(m, m), QPointF(s - m, s - m))
+        painter.drawLine(QPointF(s - m, m), QPointF(m, s - m))
+
+    def hoverEnterEvent(self, event) -> None:  # type: ignore[override]
+        self._hovered = True
+        self.update()
+        super().hoverEnterEvent(event)
+
+    def hoverLeaveEvent(self, event) -> None:  # type: ignore[override]
+        self._hovered = False
+        self.update()
+        super().hoverLeaveEvent(event)
+
+    def mousePressEvent(self, event) -> None:  # type: ignore[override]
+        if event.button() == Qt.MouseButton.LeftButton:
+            self._pressed = True
+            self.update()
+            event.accept()
+            return
+        super().mousePressEvent(event)
+
+    def mouseReleaseEvent(self, event) -> None:  # type: ignore[override]
+        if event.button() == Qt.MouseButton.LeftButton and self._pressed:
+            self._pressed = False
+            self.update()
+            if self.boundingRect().contains(event.pos()):
+                scene = self.scene()
+                node_item = self._node_item
+                if scene is not None and hasattr(scene, "remove_node_item"):
+                    # Defer so we don't delete ourselves while still inside
+                    # our own event handler.
+                    QTimer.singleShot(0, lambda: scene.remove_node_item(node_item))
+            event.accept()
+            return
+        super().mouseReleaseEvent(event)
+
+
 class NodeItem(QGraphicsItem):
     """A single node drawn on the flow canvas.
 
@@ -78,6 +150,7 @@ class NodeItem(QGraphicsItem):
     CORNER_RADIUS: float = 5.0
     PADDING: float = 8.0
     PARAM_GAP: float = 4.0
+    CLOSE_BUTTON_SIZE: float = 14.0
 
     Z_VALUE = 1
 
@@ -96,6 +169,12 @@ class NodeItem(QGraphicsItem):
         self.setFlag(QGraphicsItem.GraphicsItemFlag.ItemIsMovable, True)
         self.setFlag(QGraphicsItem.GraphicsItemFlag.ItemIsSelectable, True)
         self.setFlag(QGraphicsItem.GraphicsItemFlag.ItemSendsScenePositionChanges, True)
+
+        self._close_button = _CloseButtonItem(self)
+        self._close_button.setPos(
+            self.WIDTH - self.PADDING - self.CLOSE_BUTTON_SIZE,
+            (self.HEADER_HEIGHT - self.CLOSE_BUTTON_SIZE) / 2,
+        )
 
         self._build_params_widget()
         self._build_ports()
@@ -159,8 +238,14 @@ class NodeItem(QGraphicsItem):
 
         # ── title text ──
         painter.setPen(QPen(NODE_TITLE_TEXT_COLOR))
+        title_right_reserve = self.CLOSE_BUTTON_SIZE + self.PADDING
         painter.drawText(
-            QRectF(self.PADDING, 0, self.WIDTH - 2 * self.PADDING, self.HEADER_HEIGHT),
+            QRectF(
+                self.PADDING,
+                0,
+                self.WIDTH - 2 * self.PADDING - title_right_reserve,
+                self.HEADER_HEIGHT,
+            ),
             Qt.AlignmentFlag.AlignVCenter | Qt.AlignmentFlag.AlignLeft,
             self._node.display_name,
         )


### PR DESCRIPTION
## Summary
This PR adds a clickable close button (X) to node headers as an alternative way to delete nodes, and removes the right-click context menu for nodes. Node deletion is now primarily handled via the header button or the Delete key.

## Key Changes
- **New `_CloseButtonItem` class**: A small graphical button rendered on the right side of node headers that deletes the node when clicked
  - Displays as a rounded rectangle with an X icon on hover/press
  - Uses `QTimer.singleShot()` to defer node deletion, avoiding deletion during event handling
  - Properly handles hover and mouse press/release events with visual feedback
  
- **Updated `NodeItem`**: 
  - Instantiates and positions the close button in the header
  - Adjusts title text layout to reserve space for the close button
  
- **Simplified `FlowScene`**:
  - Removed `_node_context_menu()` method and its associated right-click handling
  - Context menu now only handles link deletion
  - Updated docstring to reflect that nodes are deleted via header button or Delete key

## Implementation Details
- The close button is a child `QGraphicsItem` of the node, so it moves and z-orders with the header automatically
- Button size is 14x14 pixels with 4-pixel margins for the X icon
- Visual feedback includes a semi-transparent white background on hover/press
- Node deletion is deferred via `QTimer.singleShot(0, ...)` to prevent issues with deleting the node while still processing its own event

https://claude.ai/code/session_011SeuaREwuB4aa874XHPi3J