### PR TITLE
Rename Viewer to Output Inspector; dock left with 50/50 split

### DIFF
--- a/src/ui/node_editor_page.py
+++ b/src/ui/node_editor_page.py
@@ -44,12 +44,14 @@ _FLOW_FILE_FILTER    = "Flow (*.flowjs);;All files (*)"
 
 
 class NodeEditorPage(PageBase):
-    """The editor. Central canvas + palette dock (left) + viewer dock (bottom).
+    """The editor. Central canvas + palette dock (left) + Output Inspector (left).
 
     Dockable panels are hosted on an inner QMainWindow so the palette and
-    viewer can be dragged around, floated, or closed by the user. Toolbar
-    actions are exposed via :meth:`page_toolbar_actions` so MainWindow can
-    render them in the global toolbar next to the page-selector radio group.
+    Output Inspector can be dragged around, floated, or closed by the user.
+    By default the Node List and Output Inspector share the left dock area
+    with an equal 50/50 vertical split. Toolbar actions are exposed via
+    :meth:`page_toolbar_actions` so MainWindow can render them in the
+    global toolbar next to the page-selector radio group.
 
     Signal :attr:`title_changed` fires up to MainWindow whenever the active
     flow name changes.
@@ -89,13 +91,18 @@ class NodeEditorPage(PageBase):
         self._node_list_dock.setAllowedAreas(Qt.DockWidgetArea.AllDockWidgetAreas)
         self._inner.addDockWidget(Qt.DockWidgetArea.LeftDockWidgetArea, self._node_list_dock)
 
-        # Viewer dock (bottom).
+        # Output Inspector dock — also on the left, stacked under the Node
+        # List with a 50/50 vertical split applied after the widget is shown.
         self._viewer = ViewerPanel()
-        self._viewer_dock = QDockWidget("Viewer", self._inner)
-        self._viewer_dock.setObjectName("ViewerDock")
+        self._viewer_dock = QDockWidget("Output Inspector", self._inner)
+        self._viewer_dock.setObjectName("OutputInspectorDock")
         self._viewer_dock.setWidget(self._viewer)
         self._viewer_dock.setAllowedAreas(Qt.DockWidgetArea.AllDockWidgetAreas)
-        self._inner.addDockWidget(Qt.DockWidgetArea.BottomDockWidgetArea, self._viewer_dock)
+        self._inner.addDockWidget(Qt.DockWidgetArea.LeftDockWidgetArea, self._viewer_dock)
+        self._inner.splitDockWidget(
+            self._node_list_dock, self._viewer_dock, Qt.Orientation.Vertical,
+        )
+        self._initial_split_applied = False
 
         # Actions: reused by both the page menu and the main toolbar.
         self._actions = self._build_actions()
@@ -176,6 +183,24 @@ class NodeEditorPage(PageBase):
         # currently selected (nothing, typically).
         self.title_changed.emit(self.page_title())
         self._viewer.refresh()
+
+    def showEvent(self, event) -> None:  # type: ignore[override]
+        super().showEvent(event)
+        # Qt only honours resizeDocks after the main window has real geometry,
+        # so defer the 50/50 split until the first show.
+        if not self._initial_split_applied:
+            self._initial_split_applied = True
+            QTimer.singleShot(0, self._equalize_left_docks)
+
+    def _equalize_left_docks(self) -> None:
+        """Give the Node List and Output Inspector equal height in the left area."""
+        h = max(self._inner.height(), 2)
+        half = h // 2
+        self._inner.resizeDocks(
+            [self._node_list_dock, self._viewer_dock],
+            [half, h - half],
+            Qt.Orientation.Vertical,
+        )
 
     # ── Public API (called by MainWindow) ──────────────────────────────────────
 

--- a/src/ui/viewer_panel.py
+++ b/src/ui/viewer_panel.py
@@ -4,7 +4,7 @@ import logging
 
 import cv2
 import numpy as np
-from PySide6.QtCore import Qt
+from PySide6.QtCore import QEvent, QObject, Qt
 from PySide6.QtGui import QImage, QPixmap
 from PySide6.QtWidgets import (
     QLabel,
@@ -26,18 +26,25 @@ _MAX_DIM: int = 1024
 
 
 class ViewerPanel(QWidget):
-    """Scrollable panel that renders every image output of a node.
+    """Scrollable panel ("Output Inspector") that renders every image output of a node.
 
     ``show(node)`` wipes the panel and re-populates it with one labelled
     :class:`QLabel` + :class:`QPixmap` pair per ``IoDataType.IMAGE``
     output port that has cached data. Non-image outputs and empty ports
     are represented by a muted placeholder label so the layout always
     reflects the node's output topology.
+
+    Each image is always scaled to the current viewport width so the
+    inspector never needs horizontal scrolling. Resize events re-scale
+    the cached pixmaps in place.
     """
 
     def __init__(self, parent: QWidget | None = None) -> None:
         super().__init__(parent)
         self._current_node: NodeBase | None = None
+        # (label, original-pixmap) pairs kept so we can rescale on resize
+        # without re-running the node pipeline.
+        self._image_labels: list[tuple[QLabel, QPixmap]] = []
 
         outer = QVBoxLayout(self)
         outer.setContentsMargins(0, 0, 0, 0)
@@ -45,7 +52,7 @@ class ViewerPanel(QWidget):
 
         self._scroll = QScrollArea()
         self._scroll.setWidgetResizable(True)
-        self._scroll.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAsNeeded)
+        self._scroll.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
         self._scroll.setVerticalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAsNeeded)
         outer.addWidget(self._scroll)
 
@@ -55,6 +62,11 @@ class ViewerPanel(QWidget):
         self._content_layout.setSpacing(8)
         self._content_layout.addStretch(1)
         self._scroll.setWidget(self._content)
+
+        # Viewport width drives the image scale, so react to its resize events
+        # (the scrollbar appearing/disappearing changes the viewport width
+        # without resizing this outer widget).
+        self._scroll.viewport().installEventFilter(self)
 
         self._placeholder("(select a node to view its output)", muted=True)
 
@@ -108,7 +120,29 @@ class ViewerPanel(QWidget):
             if widget is not None:
                 widget.setParent(None)
                 widget.deleteLater()
+        self._image_labels.clear()
         self._content_layout.addStretch(1)
+
+    def eventFilter(self, obj: QObject, event: QEvent) -> bool:  # type: ignore[override]
+        if obj is self._scroll.viewport() and event.type() == QEvent.Type.Resize:
+            self._rescale_images()
+        return super().eventFilter(obj, event)
+
+    def _available_width(self) -> int:
+        """Width available to an image inside the scroll viewport."""
+        vp = self._scroll.viewport().width()
+        m = self._content_layout.contentsMargins()
+        return max(1, vp - m.left() - m.right())
+
+    def _scaled_pixmap(self, original: QPixmap) -> QPixmap:
+        w = self._available_width()
+        if w <= 0 or original.isNull() or original.width() == 0:
+            return original
+        return original.scaledToWidth(w, Qt.TransformationMode.SmoothTransformation)
+
+    def _rescale_images(self) -> None:
+        for label, original in self._image_labels:
+            label.setPixmap(self._scaled_pixmap(original))
 
     def _placeholder(self, text: str, *, muted: bool = False, error: bool = False) -> None:
         label = QLabel(text)
@@ -146,9 +180,10 @@ class ViewerPanel(QWidget):
         self._content_layout.insertWidget(self._content_layout.count() - 1, title)
 
         image_label = QLabel()
-        image_label.setPixmap(pixmap)
         image_label.setAlignment(Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignTop)
-        image_label.setSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
+        image_label.setSizePolicy(QSizePolicy.Policy.Ignored, QSizePolicy.Policy.Fixed)
+        image_label.setPixmap(self._scaled_pixmap(pixmap))
+        self._image_labels.append((image_label, pixmap))
         self._content_layout.insertWidget(self._content_layout.count() - 1, image_label)
 
     @staticmethod


### PR DESCRIPTION
## Summary
- Rename the bottom "Viewer" dock to "Output Inspector" and move it to the left dock area, stacked vertically under the Node List with a 50/50 height split on first show.
- Scale each rendered image to the current viewport width of the Output Inspector; re-scale cached pixmaps on viewport resize so the panel never needs horizontal scrolling.
- Dock object name changed to `OutputInspectorDock` (note: any persisted layout state keyed on the old `ViewerDock` name would reset — this codebase does not currently persist dock state).

## Test plan
- [x] Existing `pytest` suite still passes (28/28).
- [ ] Manually verify in the app:
  - [ ] On launch, Node List and Output Inspector share the left side with roughly equal height.
  - [ ] The dock title reads "Output Inspector".
  - [ ] Selecting a node and clicking Run renders its image outputs, each exactly the inspector's width.
  - [ ] Resizing the dock (wider/narrower, splitter drag, floating) re-scales images live with no horizontal scrollbar.

https://claude.ai/code/session_011SeuaREwuB4aa874XHPi3J