### PR TITLE
Add Debug "Throw Exception" node

### DIFF
--- a/flow/debug_error.flowjs
+++ b/flow/debug_error.flowjs
@@ -1,0 +1,54 @@
+{
+  "version": 1,
+  "name": "Untitled_flow",
+  "nodes": [
+    {
+      "id": 0,
+      "module": "nodes.sources.image_source",
+      "class": "ImageSource",
+      "position": [
+        -1311.0,
+        -747.0
+      ],
+      "params": {
+        "file_path": "/home/user/Dokumente/GitHub/image-inquest/input/ship.jpg"
+      }
+    },
+    {
+      "id": 1,
+      "module": "nodes.filters.throw_exception",
+      "class": "ThrowException",
+      "position": [
+        -973.0,
+        -703.0
+      ],
+      "params": {}
+    },
+    {
+      "id": 2,
+      "module": "nodes.sinks.file_sink",
+      "class": "FileSink",
+      "position": [
+        -631.0,
+        -652.0
+      ],
+      "params": {
+        "output_path": "output/out.png"
+      }
+    }
+  ],
+  "connections": [
+    {
+      "src_node": 0,
+      "src_output": 0,
+      "dst_node": 1,
+      "dst_input": 0
+    },
+    {
+      "src_node": 1,
+      "src_output": 0,
+      "dst_node": 2,
+      "dst_input": 0
+    }
+  ]
+}

--- a/src/nodes/filters/throw_exception.py
+++ b/src/nodes/filters/throw_exception.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from typing_extensions import override
+
+from core.io_data import IoDataType
+from core.node_base import NodeBase, NodeParam
+from core.port import InputPort, OutputPort
+
+
+class ThrowException(NodeBase):
+    """Debug node that raises a RuntimeError whenever it processes.
+
+    Its only purpose is to surface the pipeline's exception handling path
+    (status bar message, log entry, run abort) during development. The node
+    declares one image input and one image output so it can be wired into a
+    flow like any filter; the output is never produced because ``process``
+    always raises before sending.
+    """
+
+    def __init__(self) -> None:
+        super().__init__("Throw Exception", section="Debug")
+        self._add_input(InputPort("image", {IoDataType.IMAGE}))
+        self._add_output(OutputPort("image", {IoDataType.IMAGE}))
+
+    @property
+    @override
+    def params(self) -> list[NodeParam]:
+        return []
+
+    @override
+    def process(self) -> None:
+        raise RuntimeError("Throw Exception node: intentional failure")

--- a/src/nodes/filters/throw_exception.py
+++ b/src/nodes/filters/throw_exception.py
@@ -29,4 +29,13 @@ class ThrowException(NodeBase):
 
     @override
     def process(self) -> None:
-        raise RuntimeError("Throw Exception node: intentional failure")
+        raise RuntimeError(
+            "Throw Exception node: intentional failure triggered to exercise "
+            "the pipeline's exception-handling path.\n"
+            "This is line two of the message, long enough to make sure the "
+            "status bar truncates it and the tooltip shows the full text.\n"
+            "Line three carries more filler so the log entry wraps across "
+            "several lines and proves that multi-line messages render correctly.\n"
+            "Line four: if you are reading this in the UI, the Throw Exception "
+            "node is working exactly as intended — there is no bug to fix here."
+        )


### PR DESCRIPTION
## Summary
- Adds a new `ThrowException` node under a new "Debug" palette section.
- `process()` unconditionally raises `RuntimeError` so the flow's exception-handling path (status bar, log, run abort) can be exercised without contriving a failing input.
- One image input and one image output so it can be wired into any flow like a filter.

## Test plan
- [x] Registry AST scan picks it up: `NodeEntry(class_name='ThrowException', display_name='Throw Exception', category='Filters', section='Debug', ...)`.
- [x] `pytest` suite passes (28/28).
- [ ] Manually verify in the app:
  - [ ] Node palette shows a "Debug" section containing "Throw Exception".
  - [ ] Wiring Image Source → Throw Exception and clicking Run shows a red status line and a traceback in the log.

https://claude.ai/code/session_011SeuaREwuB4aa874XHPi3J