### PR TITLE
Show errors in a floating top-right banner instead of the status bar

### DIFF
--- a/flow/Untitled_flow.flowjs
+++ b/flow/Untitled_flow.flowjs
@@ -1,0 +1,54 @@
+{
+  "version": 1,
+  "name": "Untitled_flow",
+  "nodes": [
+    {
+      "id": 0,
+      "module": "nodes.sources.image_source",
+      "class": "ImageSource",
+      "position": [
+        -1404.0,
+        -755.0
+      ],
+      "params": {
+        "file_path": "/home/user/Dokumente/GitHub/image-inquest/input/ship.jpg"
+      }
+    },
+    {
+      "id": 1,
+      "module": "nodes.filters.throw_exception",
+      "class": "ThrowException",
+      "position": [
+        -1086.0,
+        -704.0
+      ],
+      "params": {}
+    },
+    {
+      "id": 2,
+      "module": "nodes.sinks.file_sink",
+      "class": "FileSink",
+      "position": [
+        -779.0,
+        -758.0
+      ],
+      "params": {
+        "output_path": "output/out.png"
+      }
+    }
+  ],
+  "connections": [
+    {
+      "src_node": 0,
+      "src_output": 0,
+      "dst_node": 1,
+      "dst_input": 0
+    },
+    {
+      "src_node": 1,
+      "src_output": 0,
+      "dst_node": 2,
+      "dst_input": 0
+    }
+  ]
+}

--- a/src/ui/error_banner.py
+++ b/src/ui/error_banner.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from PySide6.QtCore import QEvent, QObject, Qt
 from PySide6.QtWidgets import (
     QFrame,
+    QGraphicsOpacityEffect,
     QHBoxLayout,
     QLabel,
     QScrollArea,
@@ -27,12 +28,19 @@ class ErrorBanner(QFrame):
     MAX_HEIGHT_FRACTION: float = 0.6
     MIN_WIDTH: int = 240
     MIN_HEIGHT: int = 120
+    OPACITY: float = 0.85
 
     def __init__(self, parent: QWidget) -> None:
         super().__init__(parent)
         self.setObjectName("ErrorBanner")
         self.setAttribute(Qt.WidgetAttribute.WA_StyledBackground, True)
         self.setFocusPolicy(Qt.FocusPolicy.NoFocus)
+        # Let the red backdrop blend slightly with whatever is underneath
+        # (canvas, docks) so the banner reads as an overlay rather than an
+        # opaque panel.
+        opacity = QGraphicsOpacityEffect(self)
+        opacity.setOpacity(self.OPACITY)
+        self.setGraphicsEffect(opacity)
         self.setStyleSheet(
             """
             QFrame#ErrorBanner {

--- a/src/ui/error_banner.py
+++ b/src/ui/error_banner.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+from PySide6.QtCore import QEvent, QObject, Qt
+from PySide6.QtWidgets import (
+    QFrame,
+    QHBoxLayout,
+    QLabel,
+    QScrollArea,
+    QToolButton,
+    QVBoxLayout,
+    QWidget,
+)
+
+
+class ErrorBanner(QFrame):
+    """Floating error toast anchored to the top-right of a parent widget.
+
+    Used to surface multi-line error messages that do not fit into the
+    single-line status bar. The banner stays visible until the user clicks
+    its close button; a subsequent :meth:`show_error` replaces the text in
+    place. A parent-resize event filter keeps the banner glued to the
+    upper-right corner of the client area.
+    """
+
+    MARGIN: int = 12
+    MAX_WIDTH: int = 480
+    MAX_HEIGHT_FRACTION: float = 0.6
+    MIN_WIDTH: int = 240
+    MIN_HEIGHT: int = 120
+
+    def __init__(self, parent: QWidget) -> None:
+        super().__init__(parent)
+        self.setObjectName("ErrorBanner")
+        self.setAttribute(Qt.WidgetAttribute.WA_StyledBackground, True)
+        self.setFocusPolicy(Qt.FocusPolicy.NoFocus)
+        self.setStyleSheet(
+            """
+            QFrame#ErrorBanner {
+                background: #5a1e22;
+                border: 1px solid #e05050;
+                border-radius: 4px;
+            }
+            QLabel#ErrorBannerTitle {
+                color: #ffdcdc;
+                font-weight: bold;
+                background: transparent;
+            }
+            QLabel#ErrorBannerMessage {
+                color: #ffeaea;
+                background: transparent;
+            }
+            QToolButton#ErrorBannerClose {
+                color: #ffdcdc;
+                background: transparent;
+                border: none;
+                padding: 0 6px;
+                font-size: 14px;
+            }
+            QToolButton#ErrorBannerClose:hover {
+                color: #ffffff;
+            }
+            QScrollArea#ErrorBannerScroll {
+                background: transparent;
+                border: none;
+            }
+            QScrollArea#ErrorBannerScroll > QWidget > QWidget {
+                background: transparent;
+            }
+            """
+        )
+
+        self._title = QLabel("Error")
+        self._title.setObjectName("ErrorBannerTitle")
+
+        self._close = QToolButton()
+        self._close.setObjectName("ErrorBannerClose")
+        self._close.setText("\u2715")
+        self._close.setToolTip("Dismiss")
+        self._close.setCursor(Qt.CursorShape.PointingHandCursor)
+        self._close.clicked.connect(self.hide)
+
+        header = QHBoxLayout()
+        header.setContentsMargins(0, 0, 0, 0)
+        header.setSpacing(8)
+        header.addWidget(self._title)
+        header.addStretch(1)
+        header.addWidget(self._close)
+
+        self._message = QLabel("")
+        self._message.setObjectName("ErrorBannerMessage")
+        self._message.setWordWrap(True)
+        self._message.setAlignment(Qt.AlignmentFlag.AlignTop | Qt.AlignmentFlag.AlignLeft)
+        self._message.setTextInteractionFlags(
+            Qt.TextInteractionFlag.TextSelectableByMouse
+        )
+
+        self._scroll = QScrollArea()
+        self._scroll.setObjectName("ErrorBannerScroll")
+        self._scroll.setWidgetResizable(True)
+        self._scroll.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
+        self._scroll.setVerticalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAsNeeded)
+        self._scroll.setFrameShape(QFrame.Shape.NoFrame)
+        self._scroll.setWidget(self._message)
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(12, 10, 12, 12)
+        layout.setSpacing(6)
+        layout.addLayout(header)
+        layout.addWidget(self._scroll)
+
+        parent.installEventFilter(self)
+        self.hide()
+
+    # ── Public API ─────────────────────────────────────────────────────────────
+
+    def show_error(self, message: str, *, title: str = "Error") -> None:
+        """Display ``message`` in the banner and bring it to the front."""
+        self._title.setText(title)
+        self._message.setText(message)
+        self._reposition()
+        self.show()
+        self.raise_()
+
+    # ── Parent resize tracking ─────────────────────────────────────────────────
+
+    def eventFilter(self, obj: QObject, event: QEvent) -> bool:  # type: ignore[override]
+        if obj is self.parent() and event.type() == QEvent.Type.Resize and self.isVisible():
+            self._reposition()
+        return super().eventFilter(obj, event)
+
+    def _reposition(self) -> None:
+        parent = self.parentWidget()
+        if parent is None:
+            return
+        margin = self.MARGIN
+        max_w = min(self.MAX_WIDTH, max(self.MIN_WIDTH, parent.width() - 2 * margin))
+        max_h = max(self.MIN_HEIGHT, int(parent.height() * self.MAX_HEIGHT_FRACTION))
+        self.setFixedWidth(max_w)
+        self.setMaximumHeight(max_h)
+        # adjustSize lets the banner shrink-to-fit short messages and keeps
+        # the scroll area kicking in only when the message would exceed max_h.
+        self.adjustSize()
+        x = parent.width() - self.width() - margin
+        y = margin
+        self.move(max(margin, x), y)

--- a/src/ui/node_editor_page.py
+++ b/src/ui/node_editor_page.py
@@ -31,7 +31,8 @@ from typing_extensions import override
 from ui.page import PageBase, ToolbarSection
 from ui.node_list import NodeList
 from ui.recent_flows import RecentFlowsManager
-from ui.theme import STATUS_FAIL_COLOR, STATUS_MUTED_COLOR, STATUS_OK_COLOR
+from ui.error_banner import ErrorBanner
+from ui.theme import STATUS_MUTED_COLOR, STATUS_OK_COLOR
 from ui.viewer_panel import ViewerPanel
 
 if TYPE_CHECKING:
@@ -112,6 +113,11 @@ class NodeEditorPage(PageBase):
         self._status_label = QLabel("")
         self._status_bar.addWidget(self._status_label, 1)
         self._inner.setStatusBar(self._status_bar)
+
+        # Floating error banner anchored to the top-right of the page's
+        # client area. Used instead of the status bar for failures because
+        # error messages can be long and multi-line.
+        self._error_banner = ErrorBanner(self._inner)
 
         # Wire scene → viewer.
         self._scene.selected_node_changed.connect(self._viewer.show_node)
@@ -397,18 +403,24 @@ class NodeEditorPage(PageBase):
     # ── Status line ────────────────────────────────────────────────────────────
 
     def _set_status(self, message: str, *, kind: str) -> None:
+        # Failures go to the floating error banner so long / multi-line
+        # messages are readable. The status bar keeps the last success or
+        # informational message so the user can still glance at it.
+        if kind == "fail":
+            self._error_banner.show_error(message)
+            return
         color = {
             "ok":    STATUS_OK_COLOR,
-            "fail":  STATUS_FAIL_COLOR,
             "muted": STATUS_MUTED_COLOR,
         }.get(kind, STATUS_MUTED_COLOR)
         self._status_label.setText(message)
-        # Show the full message in a tooltip so long exception text isn't
-        # lost when the status bar truncates the label.
         self._status_label.setToolTip(message)
         self._status_label.setStyleSheet(
             f"color: rgb({color.red()},{color.green()},{color.blue()});"
         )
+        # A successful action implicitly clears any stale error.
+        if kind == "ok":
+            self._error_banner.hide()
 
 
 # ── Helpers ────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- New `ErrorBanner` widget (`src/ui/error_banner.py`): a floating red toast anchored to the top-right of a parent widget. Word-wraps long text, scrolls vertically when a message exceeds a fraction of the client height, has a close (`✕`) button, and repositions itself whenever the parent resizes.
- `NodeEditorPage._set_status` now routes `kind="fail"` to the banner instead of the status bar (status bar keeps `ok`/`muted`). A subsequent `ok` auto-hides the banner.

## Why
Errors like the Throw Exception node's multi-line message get truncated in the status bar to a single line, with the rest only visible via tooltip. The banner surfaces the full text immediately.

## Test plan
- [x] `pytest` suite passes (28/28).
- [ ] Manually verify:
  - [ ] Drag Image Source → Throw Exception → File Sink, click Run: the banner appears in the upper-right, shows all four lines, can be dismissed with `✕`.
  - [ ] Resize the window: the banner stays glued to the top-right corner.
  - [ ] A subsequent successful Save / Run hides the banner.
  - [ ] Very long messages scroll inside the banner rather than overflowing off-screen.

https://claude.ai/code/session_011SeuaREwuB4aa874XHPi3J