### PR TITLE
Auto-fit view to contents after loading a flow

### DIFF
--- a/src/ui/node_editor_page.py
+++ b/src/ui/node_editor_page.py
@@ -230,6 +230,10 @@ class NodeEditorPage(PageBase):
         self._flow = flow
         self._viewer.show_node(None)
         self.title_changed.emit(self.page_title())
+        # Fit the freshly-loaded graph into the view. Deferred so it runs
+        # after pending layout events settle — viewport geometry isn't
+        # final yet when load_flow runs during the first paint.
+        QTimer.singleShot(0, self._view.fit_to_contents)
         self._set_status(
             f"Loaded {_display_path(path)} at {datetime.now().strftime('%H:%M:%S')}",
             kind="ok",


### PR DESCRIPTION
## Summary
- After `NodeEditorPage.load_flow` succeeds, call `FlowView.fit_to_contents` so the freshly-loaded graph is framed in the viewport automatically.
- Call is deferred via `QTimer.singleShot(0, …)` so it runs after pending layout events settle — the viewport geometry isn't final yet when `load_flow` fires during the initial paint (e.g. opening a recent flow on startup).

## Test plan
- [x] `pytest` suite passes (28/28).
- [ ] Manually verify:
  - [ ] File → Open a saved flow: the nodes are centred and zoomed to fit.
  - [ ] Recent Flows → open on startup: the flow is fit after the window shows (no stale zoom).
  - [ ] Loading an empty flow file: no crash, view stays at whatever zoom it had (fit_to_contents is a no-op on an empty scene).

https://claude.ai/code/session_011SeuaREwuB4aa874XHPi3J