### PR TITLE
Draw node border on top so header doesn't chew the selection marker

### DIFF
--- a/src/ui/node_item.py
+++ b/src/ui/node_item.py
@@ -226,8 +226,14 @@ class NodeItem(QGraphicsItem):
             2 if self.isSelected() else 1,
         )
 
-        # ── body ──
-        painter.setPen(border_pen)
+        # Draw fill, header, and border in three passes so that the
+        # selection border is always rendered LAST — otherwise the header
+        # path (which covers the full node width) overpaints the inside
+        # half of the border along the top edges and the yellow selection
+        # marker appears chewed at the top-left / top-right.
+
+        # ── body fill ──
+        painter.setPen(Qt.NoPen)
         painter.setBrush(QBrush(NODE_BODY_COLOR))
         painter.drawRoundedRect(body_rect, self.CORNER_RADIUS, self.CORNER_RADIUS)
 
@@ -235,6 +241,11 @@ class NodeItem(QGraphicsItem):
         painter.setPen(Qt.NoPen)
         painter.setBrush(QBrush(self._header_color()))
         painter.drawPath(self._header_path())
+
+        # ── border (stroked on top so nothing covers it) ──
+        painter.setPen(border_pen)
+        painter.setBrush(Qt.NoBrush)
+        painter.drawRoundedRect(body_rect, self.CORNER_RADIUS, self.CORNER_RADIUS)
 
         # ── title text ──
         painter.setPen(QPen(NODE_TITLE_TEXT_COLOR))


### PR DESCRIPTION
## Summary
- `NodeItem.paint` drew the body fill + border in one `drawRoundedRect` call, then laid the header path on top. Because the header spans the full node width, its fill overpainted the inside half of the border along the top edges — visibly chewing the yellow selection marker at the top-left and top-right corners.
- Fix: split the body pass into three calls — **fill → header → border stroke** — so the border is always rendered last and remains unbroken across the full perimeter.

## Test plan
- [x] `pytest` suite passes (28/28).
- [ ] Manually verify:
  - [ ] Select a node: the yellow outline is continuous across the top corners, including where the header meets the body.
  - [ ] Unselected border (1 px) is also unbroken.
  - [ ] No change in node geometry or hit-testing.

https://claude.ai/code/session_011SeuaREwuB4aa874XHPi3J