### PR TITLE
Make _display_path symlink-safe

### DIFF
--- a/src/ui/node_editor_page.py
+++ b/src/ui/node_editor_page.py
@@ -430,8 +430,13 @@ class NodeEditorPage(PageBase):
 # ── Helpers ────────────────────────────────────────────────────────────────────
 
 def _display_path(path: Path) -> str:
-    """Return ``path`` relative to cwd when possible, otherwise absolute."""
+    """Return ``path`` relative to cwd when possible, otherwise absolute.
+
+    Resolves symlinks on both sides so a path that differs from cwd only
+    via a symlink (e.g. ``~/Desktop/repo`` → ``~/Code/repo``) is still
+    shown in the shorter relative form.
+    """
     try:
-        return str(path.relative_to(Path.cwd()))
-    except ValueError:
+        return str(path.resolve().relative_to(Path.cwd().resolve()))
+    except (OSError, ValueError):
         return str(path)


### PR DESCRIPTION
## Summary
`Path.relative_to` is a string-only operation. When you reach the project through a symlink (cwd = `~/Dokumente/image-inquest`, file dialog returns `~/Schreibtisch/image-inquest/flow/foo.flowjs`) the two prefixes differ even though they refer to the same directory — `relative_to` raises `ValueError`. It's caught by the existing `except`, but VS Code's debugger breaks on the raised exception, and the user never sees the short form.

Fix: call `.resolve()` on both sides before comparing so symlinks canonicalise. Keep the `str(path)` fallback when the path is genuinely outside cwd. Also widen the caught exception set to `(OSError, ValueError)` since `resolve()` can raise `OSError` on missing paths in older Python.

## Note about the ImageSource side
`ImageSource.file_path`'s setter already does `p.resolve().relative_to(INPUT_DIR.resolve())`, so the same symlink setup does **not** affect path-normalisation in the node — only this display helper.

## Test plan
- [x] `pytest` suite passes (28/28).
- [ ] Manually verify:
  - [ ] Run the app from the Dokumente path and open a flow via the Schreibtisch symlink: status line shows `flow/rgb_split.flowjs`, no debugger break.
  - [ ] Open a flow truly outside cwd: status line shows the absolute path, no crash.

https://claude.ai/code/session_011SeuaREwuB4aa874XHPi3J