### PR TITLE
Implement IMAGE_GREY as a first-class IoData type

### DIFF
--- a/src/core/io_data.py
+++ b/src/core/io_data.py
@@ -11,6 +11,12 @@ class IoDataType(Enum):
     END_OF_STREAM = "EndOfStream"
 
 
+#: Set of :class:`IoDataType` values that carry image payloads. Useful for
+#: declaring input/output ports that accept colour or greyscale images
+#: interchangeably, e.g. filters like Median and Scale that work on either.
+IMAGE_TYPES: frozenset[IoDataType] = frozenset({IoDataType.IMAGE, IoDataType.IMAGE_GREY})
+
+
 class IoData:
     """Envelope that carries data between nodes in a flow.
 
@@ -30,7 +36,17 @@ class IoData:
 
     @classmethod
     def from_image(cls, image: np.ndarray) -> IoData:
+        """Wrap a (potentially multi-channel) image as :data:`IoDataType.IMAGE`."""
         return cls(IoDataType.IMAGE, image=image)
+
+    @classmethod
+    def from_greyscale(cls, image: np.ndarray) -> IoData:
+        """Wrap a single-channel image as :data:`IoDataType.IMAGE_GREY`.
+
+        The image is expected to be a 2-D ``uint8`` array. No shape check is
+        enforced — callers are responsible for producing the right shape.
+        """
+        return cls(IoDataType.IMAGE_GREY, image=image)
 
     @classmethod
     def end_of_stream(cls) -> IoData:
@@ -44,7 +60,7 @@ class IoData:
 
     @property
     def image(self) -> np.ndarray:
-        if self._type != IoDataType.IMAGE:
+        if self._type not in IMAGE_TYPES:
             raise TypeError(f"IoData does not carry an image (type={self._type})")
         assert self._image is not None
         return self._image
@@ -52,8 +68,23 @@ class IoData:
     def is_end_of_stream(self) -> bool:
         return self._type == IoDataType.END_OF_STREAM
 
+    def is_image(self) -> bool:
+        """Return True if this carries an image payload (colour or greyscale)."""
+        return self._type in IMAGE_TYPES
+
+    def with_image(self, image: np.ndarray) -> IoData:
+        """Return a new :class:`IoData` with the same type and a new payload.
+
+        Use this in pass-through filters so the output type (IMAGE vs
+        IMAGE_GREY) matches the input without the filter having to branch on
+        it explicitly.
+        """
+        if not self.is_image():
+            raise TypeError(f"with_image only valid on image payloads (type={self._type})")
+        return IoData(self._type, image=image)
+
     def __repr__(self) -> str:
-        if self._type == IoDataType.IMAGE:
+        if self.is_image():
             shape = self._image.shape if self._image is not None else "?"
-            return f"IoData(IMAGE, shape={shape})"
+            return f"IoData({self._type.name}, shape={shape})"
         return f"IoData({self._type.value})"

--- a/src/nodes/filters/adaptive_gaussian_threshold.py
+++ b/src/nodes/filters/adaptive_gaussian_threshold.py
@@ -4,7 +4,7 @@ import cv2
 import numpy as np
 from typing_extensions import override
 
-from core.io_data import IoData, IoDataType
+from core.io_data import IMAGE_TYPES, IoData, IoDataType
 from core.node_base import NodeBase, NodeParam, NodeParamType
 from core.port import InputPort, OutputPort
 
@@ -18,9 +18,9 @@ class AdaptiveGaussianThreshold(NodeBase):
     weighted mean. Ported from the original OCVL
     ``AdaptiveGuaussianThresholdProcessor`` [sic].
 
-    3-channel inputs are converted to grayscale first and the binary
-    result is re-broadcast to BGR so downstream nodes get the expected
-    3-channel format.
+    Accepts colour or greyscale inputs; 3-channel inputs are internally
+    converted to greyscale first. The output is always a single-channel
+    binary :data:`IoDataType.IMAGE_GREY` payload.
     """
 
     def __init__(self) -> None:
@@ -28,8 +28,8 @@ class AdaptiveGaussianThreshold(NodeBase):
         self._block_size: int = 101
         self._c: int = -32
 
-        self._add_input(InputPort("image", {IoDataType.IMAGE}))
-        self._add_output(OutputPort("image", {IoDataType.IMAGE}))
+        self._add_input(InputPort("image", set(IMAGE_TYPES)))
+        self._add_output(OutputPort("image", {IoDataType.IMAGE_GREY}))
 
         self._apply_default_params()
 
@@ -86,5 +86,4 @@ class AdaptiveGaussianThreshold(NodeBase):
             self._block_size,
             self._c,
         )
-        out = cv2.cvtColor(th, cv2.COLOR_GRAY2BGR)
-        self.outputs[0].send(IoData.from_image(out))
+        self.outputs[0].send(IoData.from_greyscale(th))

--- a/src/nodes/filters/dither.py
+++ b/src/nodes/filters/dither.py
@@ -8,7 +8,7 @@ import numba
 import numpy as np
 from typing_extensions import override
 
-from core.io_data import IoData, IoDataType
+from core.io_data import IMAGE_TYPES, IoData, IoDataType
 from core.node_base import NodeBase, NodeParam, NodeParamType
 from core.port import InputPort, OutputPort
 
@@ -103,8 +103,8 @@ class Dither(NodeBase):
 
     Reduces an image to two levels (0 / 255) using one of the classic
     ordered or error-diffusion schemes. Colour inputs are converted to
-    grayscale first; the binary result is broadcast back to BGR so
-    downstream nodes receive the expected 3-channel format.
+    greyscale first; the output is always a single-channel
+    :data:`IoDataType.IMAGE_GREY` payload.
 
     The error-diffusion inner loop is JIT-compiled by numba on first use
     (``@njit(cache=True)``), making it comparable in speed to the
@@ -115,8 +115,8 @@ class Dither(NodeBase):
         super().__init__("Dither", section="Processing")
         self._method: DitherMethod = DitherMethod.STUCKI
 
-        self._add_input(InputPort("image", {IoDataType.IMAGE}))
-        self._add_output(OutputPort("image", {IoDataType.IMAGE}))
+        self._add_input(InputPort("image", set(IMAGE_TYPES)))
+        self._add_output(OutputPort("image", {IoDataType.IMAGE_GREY}))
 
         self._apply_default_params()
 
@@ -167,8 +167,7 @@ class Dither(NodeBase):
         else:
             out = _dither_diffusion(gray, _DIFFUSION_KERNELS[method])
 
-        out_bgr = cv2.cvtColor(out, cv2.COLOR_GRAY2BGR)
-        self.outputs[0].send(IoData.from_image(out_bgr))
+        self.outputs[0].send(IoData.from_greyscale(out))
 
 
 # ── Dithering kernels ─────────────────────────────────────────────────────────

--- a/src/nodes/filters/grayscale.py
+++ b/src/nodes/filters/grayscale.py
@@ -10,16 +10,17 @@ from core.port import InputPort, OutputPort
 
 
 class Grayscale(NodeBase):
-    """Converts a colour image to grayscale.
+    """Converts a colour image to greyscale.
 
-    The output is a 3-channel BGR image (all three channels identical) so that
-    downstream nodes receive a consistent format regardless of whether the
-    input was colour or already grayscale.
+    Emits a single-channel (H×W) :data:`IoDataType.IMAGE_GREY` payload.
+    Downstream nodes that accept ``IMAGE_GREY`` (including the viewer and
+    file sink) can consume the output directly; use an :class:`RgbJoin`
+    upstream of colour-only consumers.
     """
 
     def __init__(self) -> None:
         super().__init__("Grayscale", section="Color Spaces")
-        self._add_input(InputPort("image",  {IoDataType.IMAGE}))
+        self._add_input(InputPort("image", {IoDataType.IMAGE}))
         self._add_output(OutputPort("image", {IoDataType.IMAGE_GREY}))
 
     @property
@@ -29,12 +30,6 @@ class Grayscale(NodeBase):
 
     @override
     def process(self) -> None:
-        if self.inputs[0].data.type != IoDataType.IMAGE:
-            raise TypeError(f"Expected IMAGE input but got {self.inputs[0].data.type}")
-            
         image: np.ndarray = self.inputs[0].data.image
         gray = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)
-        
-        # Convert back to 3-channel BGR so downstream nodes get a consistent format
-        gray_bgr = cv2.cvtColor(gray, cv2.COLOR_GRAY2BGR)
-        self.outputs[0].send(IoData.from_image(gray_bgr))
+        self.outputs[0].send(IoData.from_greyscale(gray))

--- a/src/nodes/filters/median.py
+++ b/src/nodes/filters/median.py
@@ -4,7 +4,7 @@ import cv2
 import numpy as np
 from typing_extensions import override
 
-from core.io_data import IoData, IoDataType
+from core.io_data import IMAGE_TYPES
 from core.node_base import NodeBase, NodeParam, NodeParamType
 from core.port import InputPort, OutputPort
 
@@ -13,15 +13,17 @@ class Median(NodeBase):
     """Apply a median blur with a square kernel.
 
     Wraps ``cv2.medianBlur``; the kernel ``size`` must be odd and ≥ 1.
-    Ported from the original OCVL ``MedianProcessor``.
+    Accepts both colour (``IMAGE``) and greyscale (``IMAGE_GREY``) inputs
+    and emits the same type on the output. Ported from the original OCVL
+    ``MedianProcessor``.
     """
 
     def __init__(self) -> None:
         super().__init__("Median", section="Processing")
         self._size: int = 3
 
-        self._add_input(InputPort("image", {IoDataType.IMAGE}))
-        self._add_output(OutputPort("image", {IoDataType.IMAGE}))
+        self._add_input(InputPort("image", set(IMAGE_TYPES)))
+        self._add_output(OutputPort("image", set(IMAGE_TYPES)))
 
         self._apply_default_params()
 
@@ -54,6 +56,6 @@ class Median(NodeBase):
 
     @override
     def process(self) -> None:
-        image: np.ndarray = self.inputs[0].data.image
-        blurred = cv2.medianBlur(image, self._size)
-        self.outputs[0].send(IoData.from_image(blurred))
+        in_data = self.inputs[0].data
+        blurred = cv2.medianBlur(in_data.image, self._size)
+        self.outputs[0].send(in_data.with_image(blurred))

--- a/src/nodes/filters/normalize.py
+++ b/src/nodes/filters/normalize.py
@@ -4,7 +4,7 @@ import cv2
 import numpy as np
 from typing_extensions import override
 
-from core.io_data import IoData, IoDataType
+from core.io_data import IMAGE_TYPES
 from core.node_base import NodeBase, NodeParam
 from core.port import InputPort, OutputPort
 
@@ -13,15 +13,16 @@ class Normalize(NodeBase):
     """Equalise the histogram of an image.
 
     Applies ``cv2.equalizeHist`` — a per-channel operation on 8-bit
-    single-channel data. For BGR inputs each channel is equalised
-    independently (matching how downstream nodes expect a 3-channel
-    image). Ported from the original OCVL ``NormalizeProcessor``.
+    single-channel data. Accepts both colour (``IMAGE``) and greyscale
+    (``IMAGE_GREY``) inputs and emits the same type on the output. For
+    colour inputs each channel is equalised independently. Ported from
+    the original OCVL ``NormalizeProcessor``.
     """
 
     def __init__(self) -> None:
         super().__init__("Normalize", section="Processing")
-        self._add_input(InputPort("image", {IoDataType.IMAGE}))
-        self._add_output(OutputPort("image", {IoDataType.IMAGE}))
+        self._add_input(InputPort("image", set(IMAGE_TYPES)))
+        self._add_output(OutputPort("image", set(IMAGE_TYPES)))
 
     @property
     @override
@@ -30,7 +31,8 @@ class Normalize(NodeBase):
 
     @override
     def process(self) -> None:
-        image: np.ndarray = self.inputs[0].data.image
+        in_data = self.inputs[0].data
+        image = in_data.image
 
         if image.ndim == 2:
             result = cv2.equalizeHist(image)
@@ -41,4 +43,4 @@ class Normalize(NodeBase):
             equalised = [cv2.equalizeHist(c) for c in channels]
             result = cv2.merge(equalised)
 
-        self.outputs[0].send(IoData.from_image(result))
+        self.outputs[0].send(in_data.with_image(result))

--- a/src/nodes/filters/rgb_join.py
+++ b/src/nodes/filters/rgb_join.py
@@ -22,9 +22,9 @@ class RgbJoin(NodeBase):
         super().__init__("RGB Join", section="Color Spaces")
         self._three_color: bool = False
 
-        self._add_input(InputPort("B", {IoDataType.IMAGE}))
-        self._add_input(InputPort("G", {IoDataType.IMAGE}))
-        self._add_input(InputPort("R", {IoDataType.IMAGE}))
+        self._add_input(InputPort("B", {IoDataType.IMAGE_GREY}))
+        self._add_input(InputPort("G", {IoDataType.IMAGE_GREY}))
+        self._add_input(InputPort("R", {IoDataType.IMAGE_GREY}))
         self._add_output(OutputPort("image", {IoDataType.IMAGE}))
 
         # Sync attributes with declared NodeParam defaults; see

--- a/src/nodes/filters/rgb_split.py
+++ b/src/nodes/filters/rgb_split.py
@@ -12,17 +12,17 @@ from core.port import InputPort, OutputPort
 class RgbSplit(NodeBase):
     """Split a BGR image into its three channels.
 
-    Emits three single-channel (H×W) images on the ``B``, ``G`` and ``R``
-    output ports — matching ``cv2.split``'s channel order. Ported from the
-    original OCVL ``RgbSplitProcessor``.
+    Emits three single-channel (H×W) :data:`IoDataType.IMAGE_GREY` payloads
+    on the ``B``, ``G`` and ``R`` output ports — matching ``cv2.split``'s
+    channel order. Ported from the original OCVL ``RgbSplitProcessor``.
     """
 
     def __init__(self) -> None:
         super().__init__("RGB Split", section="Color Spaces")
         self._add_input(InputPort("image", {IoDataType.IMAGE}))
-        self._add_output(OutputPort("B", {IoDataType.IMAGE}))
-        self._add_output(OutputPort("G", {IoDataType.IMAGE}))
-        self._add_output(OutputPort("R", {IoDataType.IMAGE}))
+        self._add_output(OutputPort("B", {IoDataType.IMAGE_GREY}))
+        self._add_output(OutputPort("G", {IoDataType.IMAGE_GREY}))
+        self._add_output(OutputPort("R", {IoDataType.IMAGE_GREY}))
 
     @property
     @override
@@ -33,6 +33,6 @@ class RgbSplit(NodeBase):
     def process(self) -> None:
         image: np.ndarray = self.inputs[0].data.image
         b, g, r = cv2.split(image)
-        self.outputs[0].send(IoData.from_image(b))
-        self.outputs[1].send(IoData.from_image(g))
-        self.outputs[2].send(IoData.from_image(r))
+        self.outputs[0].send(IoData.from_greyscale(b))
+        self.outputs[1].send(IoData.from_greyscale(g))
+        self.outputs[2].send(IoData.from_greyscale(r))

--- a/src/nodes/filters/scale.py
+++ b/src/nodes/filters/scale.py
@@ -4,7 +4,7 @@ import cv2
 import numpy as np
 from typing_extensions import override
 
-from core.io_data import IoData, IoDataType
+from core.io_data import IMAGE_TYPES
 from core.node_base import NodeBase, NodeParam, NodeParamType
 from core.port import InputPort, OutputPort
 
@@ -33,8 +33,8 @@ class Scale(NodeBase):
         self._scale_percent: int = 100
         self._interpolation: int = 1  # Linear
 
-        self._add_input(InputPort("image", {IoDataType.IMAGE}))
-        self._add_output(OutputPort("image", {IoDataType.IMAGE}))
+        self._add_input(InputPort("image", set(IMAGE_TYPES)))
+        self._add_output(OutputPort("image", set(IMAGE_TYPES)))
 
         self._apply_default_params()
 
@@ -79,7 +79,8 @@ class Scale(NodeBase):
 
     @override
     def process(self) -> None:
-        image: np.ndarray = self.inputs[0].data.image
+        in_data = self.inputs[0].data
+        image: np.ndarray = in_data.image
         h, w = image.shape[:2]
         factor = self._scale_percent / 100.0
         new_w = max(1, int(round(w * factor)))
@@ -90,4 +91,4 @@ class Scale(NodeBase):
             (new_w, new_h),
             interpolation=_INTERPOLATIONS[self._interpolation],
         )
-        self.outputs[0].send(IoData.from_image(resized))
+        self.outputs[0].send(in_data.with_image(resized))

--- a/src/nodes/filters/shift.py
+++ b/src/nodes/filters/shift.py
@@ -4,7 +4,7 @@ import cv2
 import numpy as np
 from typing_extensions import override
 
-from core.io_data import IoData, IoDataType
+from core.io_data import IMAGE_TYPES
 from core.node_base import NodeBase, NodeParam, NodeParamType
 from core.port import InputPort, OutputPort
 
@@ -24,8 +24,8 @@ class Shift(NodeBase):
         self._offset_x: int = 0
         self._offset_y: int = 0
 
-        self._add_input(InputPort("image", {IoDataType.IMAGE}))
-        self._add_output(OutputPort("image", {IoDataType.IMAGE}))
+        self._add_input(InputPort("image", set(IMAGE_TYPES)))
+        self._add_output(OutputPort("image", set(IMAGE_TYPES)))
 
         self._apply_default_params()
 
@@ -61,9 +61,10 @@ class Shift(NodeBase):
 
     @override
     def process(self) -> None:
-        image: np.ndarray = self.inputs[0].data.image
+        in_data = self.inputs[0].data
+        image: np.ndarray = in_data.image
         h, w = image.shape[:2]
         matrix = np.float32([[1, 0, self._offset_x],
                              [0, 1, self._offset_y]])
         shifted = cv2.warpAffine(image, matrix, (w, h))
-        self.outputs[0].send(IoData.from_image(shifted))
+        self.outputs[0].send(in_data.with_image(shifted))

--- a/src/nodes/sinks/file_sink.py
+++ b/src/nodes/sinks/file_sink.py
@@ -6,7 +6,7 @@ from enum import Enum
 import cv2
 from typing_extensions import override
 
-from core.io_data import IoDataType
+from core.io_data import IMAGE_TYPES
 from core.node_base import SinkNodeBase, NodeParam, NodeParamType
 from core.port import InputPort
 
@@ -23,7 +23,7 @@ class FileSink(SinkNodeBase):
         self._output_path: str = "output/out.png"
         self._output_format: OutputFormat = OutputFormat.SAME_AS_INPUT
 
-        self._add_input(InputPort("image", {IoDataType.IMAGE}))
+        self._add_input(InputPort("image", set(IMAGE_TYPES)))
         # Sync attributes with declared NodeParam defaults; see
         # NodeBase._apply_default_params for rationale.
         self._apply_default_params()

--- a/src/ui/node_editor_page.py
+++ b/src/ui/node_editor_page.py
@@ -20,7 +20,7 @@ from PySide6.QtWidgets import (
 
 from constants import FLOW_DIR
 from core.flow import Flow, is_valid_flow_name
-from core.io_data import IoDataType
+from core.io_data import IMAGE_TYPES
 from core.node_base import SinkNodeBase, SourceNodeBase
 from ui.flow_io import FlowIoError, load_flow_into, save_flow_to
 from ui.flow_scene import FlowScene
@@ -300,7 +300,7 @@ class NodeEditorPage(PageBase):
             if isinstance(node, SinkNodeBase):
                 continue
             for port in node.outputs:
-                if IoDataType.IMAGE in port.emits and port.last_emitted is not None:
+                if (port.emits & IMAGE_TYPES) and port.last_emitted is not None:
                     return node
         return None
 

--- a/src/ui/viewer_panel.py
+++ b/src/ui/viewer_panel.py
@@ -14,7 +14,7 @@ from PySide6.QtWidgets import (
     QWidget,
 )
 
-from core.io_data import IoDataType
+from core.io_data import IMAGE_TYPES
 from core.node_base import NodeBase
 from ui.theme import STATUS_FAIL_COLOR, STATUS_MUTED_COLOR
 
@@ -85,12 +85,12 @@ class ViewerPanel(QWidget):
             return
 
         for port in node.outputs:
-            if IoDataType.IMAGE not in port.emits:
+            if not (port.emits & IMAGE_TYPES):
                 self._placeholder(f"{port.name}: (non-image output)", muted=True)
                 continue
 
             data = port.last_emitted
-            if data is None or data.type != IoDataType.IMAGE:
+            if data is None or data.type not in IMAGE_TYPES:
                 self._placeholder(f"{port.name}: (no data — click Run)", muted=True)
                 continue
 

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -134,20 +134,16 @@ def test_normalize_passes_through_grayscale_input() -> None:
 
 # ── AdaptiveGaussianThreshold ─────────────────────────────────────────────────
 
-def test_agauss_threshold_produces_bgr_binary_output() -> None:
+def test_agauss_threshold_produces_greyscale_binary_output() -> None:
     rng = np.random.default_rng(2)
     image = rng.integers(0, 256, size=(128, 128, 3), dtype=np.uint8)
 
     node = AdaptiveGaussianThreshold()
     out = _run(node, image)
 
-    assert out.shape == (128, 128, 3)
-    # Binary output: every channel is either 0 or 255, and all three
-    # channels are equal (GRAY2BGR).
-    unique = np.unique(out)
-    assert set(unique.tolist()).issubset({0, 255})
-    np.testing.assert_array_equal(out[..., 0], out[..., 1])
-    np.testing.assert_array_equal(out[..., 1], out[..., 2])
+    # Now a single-channel IMAGE_GREY payload.
+    assert out.shape == (128, 128)
+    assert set(np.unique(out).tolist()).issubset({0, 255})
 
 
 def test_agauss_threshold_coerces_even_block_size() -> None:
@@ -165,21 +161,20 @@ def test_agauss_threshold_rejects_tiny_block_size() -> None:
 # ── Dither ────────────────────────────────────────────────────────────────────
 
 @pytest.mark.parametrize("method", list(DitherMethod))
-def test_dither_produces_bgr_binary_output(method: DitherMethod) -> None:
+def test_dither_produces_greyscale_binary_output(method: DitherMethod) -> None:
     image = _gradient(h=8, w=8)
 
     node = Dither()
     node.method = int(method)
     out = _run(node, image)
 
-    assert out.shape == (8, 8, 3)
+    # Dither emits a single-channel IMAGE_GREY payload.
+    assert out.shape == (8, 8)
     assert set(np.unique(out).tolist()).issubset({0, 255})
-    np.testing.assert_array_equal(out[..., 0], out[..., 1])
-    np.testing.assert_array_equal(out[..., 1], out[..., 2])
 
 
 def test_dither_accepts_bgr_input() -> None:
-    # Gradient broadcast to 3 channels — the node should grayscale it.
+    # Gradient broadcast to 3 channels — the node should greyscale it.
     gray = _gradient(h=8, w=8)
     bgr = cv2.cvtColor(gray, cv2.COLOR_GRAY2BGR)
 
@@ -187,7 +182,7 @@ def test_dither_accepts_bgr_input() -> None:
     node.method = int(DitherMethod.BAYER4)
     out = _run(node, bgr)
 
-    assert out.shape == (8, 8, 3)
+    assert out.shape == (8, 8)
     assert set(np.unique(out).tolist()).issubset({0, 255})
 
 


### PR DESCRIPTION
## Summary
Makes `IoDataType.IMAGE_GREY` a first-class payload type so nodes can advertise and consume single-channel images without the round-trip through a 3-channel BGR broadcast.

### `IoData`
- `from_greyscale(image)` factory for single-channel payloads.
- `image` property now accepts `IMAGE` **and** `IMAGE_GREY` (both are image payloads).
- `with_image(image)` helper returns a new IoData with the same discriminator — lets pass-through filters forward the type without branching.
- `IMAGE_TYPES = {IMAGE, IMAGE_GREY}` module constant for ports that accept either.

### Filters
| Filter | Input | Output |
| --- | --- | --- |
| Grayscale | `IMAGE` | `IMAGE_GREY` (single-channel, no more GRAY2BGR broadcast) |
| RGB Split | `IMAGE` | 3× `IMAGE_GREY` |
| RGB Join | 3× `IMAGE_GREY` | `IMAGE` |
| Adaptive Gaussian Threshold | `IMAGE_TYPES` | `IMAGE_GREY` |
| Dither | `IMAGE_TYPES` | `IMAGE_GREY` |
| Median / Normalize / Scale / Shift | `IMAGE_TYPES` | same type as input (via `with_image`) |

### Sinks / UI
- `FileSink` input accepts `IMAGE_TYPES` (`cv2.imwrite` handles greyscale fine).
- `ViewerPanel` and `_best_viewer_node` check against `IMAGE_TYPES` instead of hard-coding `IMAGE`; the existing `_to_rgba` already converts 2-D arrays via `COLOR_GRAY2RGBA`.

### Tests
- Updated `AdaptiveGaussianThreshold` and `Dither` assertions to expect a 2-D single-channel output (renamed from `…_produces_bgr_binary_output` → `…_produces_greyscale_binary_output`).

## Compatibility
Saved flows that route a Grayscale / RGB Split / Dither / Adaptive-Threshold output into a node that still declares only `IMAGE` will fail to connect on load. The built-in filters and the File Sink all accept `IMAGE_GREY`, so any flow whose edges only touch those is safe.

## Test plan
- [x] `pytest` passes (28/28).
- [x] Registry scans cleanly; every node class instantiates.
- [x] Integration smoke test: Grayscale → Median preserves `IMAGE_GREY`; RGB Split → RGB Join round-trip connects.
- [ ] Manually verify in the app:
  - [ ] Image Source → Grayscale → File Sink: sink writes a single-channel PNG.
  - [ ] Select the Grayscale node in the Output Inspector: renders the greyscale image.
  - [ ] RGB Split → RGB Join → viewer: colour round-trips.

https://claude.ai/code/session_011SeuaREwuB4aa874XHPi3J