### PR TITLE
Surface connect_ports errors in the error banner

### DIFF
--- a/src/ui/flow_io.py
+++ b/src/ui/flow_io.py
@@ -117,7 +117,13 @@ def load_flow_into(path: Path, scene: FlowScene) -> Flow:
         except (IndexError, KeyError):
             logger.warning("Skipping connection with out-of-range port index: %s", conn)
             continue
-        scene.connect_ports(src_port, dst_port)
+        try:
+            scene.connect_ports(src_port, dst_port)
+        except TypeError as err:
+            # Incompatible port types (e.g. a saved flow routing IMAGE_GREY
+            # into an IMAGE-only port). Log and continue so the rest of the
+            # flow still loads rather than aborting the whole file.
+            logger.warning("Skipping incompatible connection %s: %s", conn, err)
 
     return flow
 

--- a/src/ui/flow_scene.py
+++ b/src/ui/flow_scene.py
@@ -46,6 +46,10 @@ class FlowScene(QGraphicsScene):
     selected_node_changed = Signal(object)   # NodeBase | None
     #: Emitted when any parameter widget on any node in the scene changes value.
     param_changed = Signal()
+    #: Emitted when an interactive connection attempt raises a user-actionable
+    #: error (e.g. incompatible port types). Carries the exception's message so
+    #: the host page can surface it in the error banner.
+    connection_error = Signal(str)
 
     def __init__(self) -> None:
         super().__init__()
@@ -127,8 +131,16 @@ class FlowScene(QGraphicsScene):
     # ── Link operations ────────────────────────────────────────────────────────
 
     def connect_ports(self, src: PortItem, dst: PortItem) -> LinkItem | None:
-        """Create a link from ``src`` (output) to ``dst`` (input) if the
-        port types are compatible and the link does not already exist."""
+        """Create a link from ``src`` (output) to ``dst`` (input).
+
+        Returns ``None`` for trivial rejections (wrong direction, self-loop,
+        duplicate) and raises :class:`TypeError` when the underlying
+        :meth:`Flow.connect` rejects the edge as type-incompatible. Callers
+        are expected to surface that error to the user (the interactive
+        drag path in :meth:`mouseReleaseEvent` emits
+        :attr:`connection_error`; the flow-loader in ``flow_io`` logs and
+        skips the edge).
+        """
         if src.kind != "output" or dst.kind != "input":
             return None
         if src.node_item is dst.node_item:
@@ -139,13 +151,7 @@ class FlowScene(QGraphicsScene):
         src_node = src.node_item.node
         dst_node = dst.node_item.node
         if self._flow is not None:
-            try:
-                self._flow.connect(src_node, src.index, dst_node, dst.index)
-            except TypeError:
-                logger.info("Rejected incompatible connection: %s.%s -> %s.%s",
-                            type(src_node).__name__, src.name,
-                            type(dst_node).__name__, dst.name)
-                return None
+            self._flow.connect(src_node, src.index, dst_node, dst.index)
 
         link = LinkItem(src, dst)
         self.addItem(link)
@@ -202,10 +208,15 @@ class FlowScene(QGraphicsScene):
 
             if target is not None and target is not src:
                 # Allow drag from either direction (output→input or input→output).
-                if src.kind == "output" and target.kind == "input":
-                    self.connect_ports(src, target)
-                elif src.kind == "input" and target.kind == "output":
-                    self.connect_ports(target, src)
+                try:
+                    if src.kind == "output" and target.kind == "input":
+                        self.connect_ports(src, target)
+                    elif src.kind == "input" and target.kind == "output":
+                        self.connect_ports(target, src)
+                except TypeError as err:
+                    # Surface incompatible-port errors through the UI so
+                    # the user sees why the edge was rejected.
+                    self.connection_error.emit(str(err))
             event.accept()
             return
         super().mouseReleaseEvent(event)

--- a/src/ui/node_editor_page.py
+++ b/src/ui/node_editor_page.py
@@ -121,6 +121,9 @@ class NodeEditorPage(PageBase):
 
         # Wire scene → viewer.
         self._scene.selected_node_changed.connect(self._viewer.show_node)
+        # Surface interactive-connection errors (type mismatches) in the
+        # error banner instead of swallowing them inside FlowScene.
+        self._scene.connection_error.connect(self._on_connection_error)
 
         # Debounce timer for reactive (auto-run) flows.  A 300 ms single-shot
         # timer is restarted on every param change; it fires _on_run_clicked
@@ -403,6 +406,12 @@ class NodeEditorPage(PageBase):
         # Start from a fresh Flow with the same name so Save still targets
         # the same file. The scene clears via set_flow.
         self.set_flow(Flow(name=self._flow.name))
+
+    # ── Scene error handlers ───────────────────────────────────────────────────
+
+    def _on_connection_error(self, message: str) -> None:
+        """Surface a FlowScene connection rejection in the error banner."""
+        self._set_status(message, kind="fail")
 
     # ── Status line ────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
`FlowScene.connect_ports` used to swallow the `TypeError` that `Flow.connect` raises when port types are incompatible, log an info message, and return `None`. The user was left without feedback — the dragged link just disappeared.

- Removed the `try/except TypeError` in `connect_ports` so the exception propagates.
- Added a `FlowScene.connection_error = Signal(str)` for user-actionable rejections.
- `mouseReleaseEvent` catches around its `connect_ports` calls and emits the signal with the exception message.
- `NodeEditorPage` routes that signal to `_set_status(..., kind="fail")`, which shows the floating error banner.
- Flow loader (`flow_io.load_flow_into`) catches the same `TypeError` around its own `connect_ports` call and logs a warning — skipping that edge so the rest of a saved flow still loads.

## Test plan
- [x] `pytest` passes (28/28).
- [ ] Manually verify:
  - [ ] Drag an incompatible connection (e.g. File Sink's input → non-image output if one existed): the error banner shows `Cannot connect output '…' to input '…'`.
  - [ ] Load a saved flow that contains one incompatible edge: the flow opens with the remaining edges, warning in the log, no crash.

https://claude.ai/code/session_011SeuaREwuB4aa874XHPi3J