### PR TITLE
Allow the floating Output Inspector to be maximised / fullscreened

### DIFF
--- a/flow/rgb_dither.flowjs
+++ b/flow/rgb_dither.flowjs
@@ -1,0 +1,138 @@
+{
+  "version": 1,
+  "name": "rgb_split",
+  "nodes": [
+    {
+      "id": 0,
+      "module": "nodes.filters.rgb_split",
+      "class": "RgbSplit",
+      "position": [
+        -1509.4279939393775,
+        -639.4775833967562
+      ],
+      "params": {}
+    },
+    {
+      "id": 1,
+      "module": "nodes.filters.rgb_join",
+      "class": "RgbJoin",
+      "position": [
+        -893.9002165396971,
+        -637.5054134924299
+      ],
+      "params": {
+        "three_color": false
+      }
+    },
+    {
+      "id": 2,
+      "module": "nodes.sinks.file_sink",
+      "class": "FileSink",
+      "position": [
+        -613.0,
+        -600.0
+      ],
+      "params": {
+        "output_path": "output/out.png"
+      }
+    },
+    {
+      "id": 3,
+      "module": "nodes.sources.image_source",
+      "class": "ImageSource",
+      "position": [
+        -1788.9559912621874,
+        -669.0594064681123
+      ],
+      "params": {
+        "file_path": "ship.jpg"
+      }
+    },
+    {
+      "id": 4,
+      "module": "nodes.filters.dither",
+      "class": "Dither",
+      "position": [
+        -1196.0567957802757,
+        -781.5990196600775
+      ],
+      "params": {
+        "method": 6
+      }
+    },
+    {
+      "id": 5,
+      "module": "nodes.filters.dither",
+      "class": "Dither",
+      "position": [
+        -1194.256362700881,
+        -648.6988031203803
+      ],
+      "params": {
+        "method": 6
+      }
+    },
+    {
+      "id": 6,
+      "module": "nodes.filters.dither",
+      "class": "Dither",
+      "position": [
+        -1196.0567957802757,
+        -517.5990196600775
+      ],
+      "params": {
+        "method": 6
+      }
+    }
+  ],
+  "connections": [
+    {
+      "src_node": 1,
+      "src_output": 0,
+      "dst_node": 2,
+      "dst_input": 0
+    },
+    {
+      "src_node": 3,
+      "src_output": 0,
+      "dst_node": 0,
+      "dst_input": 0
+    },
+    {
+      "src_node": 0,
+      "src_output": 0,
+      "dst_node": 4,
+      "dst_input": 0
+    },
+    {
+      "src_node": 4,
+      "src_output": 0,
+      "dst_node": 1,
+      "dst_input": 0
+    },
+    {
+      "src_node": 0,
+      "src_output": 1,
+      "dst_node": 5,
+      "dst_input": 0
+    },
+    {
+      "src_node": 0,
+      "src_output": 2,
+      "dst_node": 6,
+      "dst_input": 0
+    },
+    {
+      "src_node": 6,
+      "src_output": 0,
+      "dst_node": 1,
+      "dst_input": 2
+    },
+    {
+      "src_node": 5,
+      "src_output": 0,
+      "dst_node": 1,
+      "dst_input": 1
+    }
+  ]
+}

--- a/src/ui/node_editor_page.py
+++ b/src/ui/node_editor_page.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from PySide6.QtCore import Qt, QTimer
-from PySide6.QtGui import QAction, QIcon
+from PySide6.QtGui import QAction, QIcon, QKeySequence, QShortcut
 from PySide6.QtWidgets import (
     QDockWidget,
     QFileDialog,
@@ -104,6 +104,19 @@ class NodeEditorPage(PageBase):
             self._node_list_dock, self._viewer_dock, Qt.Orientation.Vertical,
         )
         self._initial_split_applied = False
+        # A floating QDockWidget defaults to a Qt.Tool window, which on most
+        # desktop environments lacks maximise / fullscreen affordances.
+        # Promote it to a regular top-level window when it floats so the
+        # user can inspect large outputs in full screen; F11 toggles
+        # fullscreen while the dock is detached.
+        self._viewer_dock.topLevelChanged.connect(self._on_viewer_top_level_changed)
+        self._viewer_fullscreen_shortcut = QShortcut(
+            QKeySequence(Qt.Key.Key_F11), self._viewer_dock
+        )
+        self._viewer_fullscreen_shortcut.setContext(Qt.ShortcutContext.WidgetWithChildrenShortcut)
+        self._viewer_fullscreen_shortcut.activated.connect(
+            self._toggle_viewer_fullscreen
+        )
 
         # Actions: reused by both the page menu and the main toolbar.
         self._actions = self._build_actions()
@@ -284,6 +297,32 @@ class NodeEditorPage(PageBase):
     def _on_stack_vertical_clicked(self) -> None:
         """Align selected nodes on a shared X axis and stack them vertically."""
         self._scene.stack_selected_vertically()
+
+    def _on_viewer_top_level_changed(self, floating: bool) -> None:
+        """Promote the floating Output Inspector to a real top-level window.
+
+        QDockWidget's default floating style is Qt.Tool, which most window
+        managers render without maximise / fullscreen controls. Re-flag the
+        window so the OS chrome offers those affordances, then re-show it
+        (Qt hides a widget whenever its window flags change).
+        """
+        if not floating:
+            return
+        self._viewer_dock.setWindowFlags(
+            Qt.WindowType.Window
+            | Qt.WindowType.WindowMinMaxButtonsHint
+            | Qt.WindowType.WindowCloseButtonHint
+        )
+        self._viewer_dock.show()
+
+    def _toggle_viewer_fullscreen(self) -> None:
+        """F11 handler: toggle fullscreen on the floating Output Inspector."""
+        if not self._viewer_dock.isFloating():
+            return
+        if self._viewer_dock.isFullScreen():
+            self._viewer_dock.showNormal()
+        else:
+            self._viewer_dock.showFullScreen()
 
     def _on_run_clicked(self) -> None:
         if self._flow is None:


### PR DESCRIPTION
## Summary
QDockWidget's floating style is `Qt.Tool`, which most desktop environments render without maximise / fullscreen controls. That meant the Output Inspector couldn't be made truly large without manual resizing.

- On `topLevelChanged(True)`, re-flag the floating `_viewer_dock` as a regular top-level window (`Qt.Window | Qt.WindowMinMaxButtonsHint | Qt.WindowCloseButtonHint`) and re-show it. Qt hides a widget when its window flags change, so the re-show is required. Qt restores the normal docked flags automatically on re-dock.
- Bind `F11` (via `QShortcut` with `WidgetWithChildrenShortcut` context) to toggle fullscreen while the dock is floating — docked, the shortcut is a no-op.

## Test plan
- [x] `pytest` suite passes (28/28).
- [ ] Manually verify:
  - [ ] Undock the Output Inspector → the floating window now has maximise / close buttons in its title bar.
  - [ ] Click maximise: the window fills the screen minus the taskbar.
  - [ ] Press F11: the window enters fullscreen; F11 again restores it.
  - [ ] Dock the window back into the editor: it snaps back into the left area as before.

https://claude.ai/code/session_011SeuaREwuB4aa874XHPi3J