### PR TITLE
Live-tail the log file on the Log page

### DIFF
--- a/src/constants.py
+++ b/src/constants.py
@@ -26,3 +26,5 @@ FLOW_DIR:   Path = Path(__file__).parent.parent / "flow"
 # User-defined nodes (~/.image-inquest/user_nodes/)
 USER_CONFIG_DIR: Path = Path.home() / ".image-inquest"
 USER_NODES_DIR:  Path = USER_CONFIG_DIR / "user_nodes"
+LOG_DIR:  Path = USER_CONFIG_DIR / "logs"
+LOG_FILE: Path = LOG_DIR / "image-inquest.log"

--- a/src/log.py
+++ b/src/log.py
@@ -34,11 +34,6 @@ def setup_logging(log_dir: Path, level: int = logging.DEBUG) -> None:
     log_dir.mkdir(parents=True, exist_ok=True)
     log_file = log_dir / "image-inquest.log"
 
-    # Stamp a session header directly into the file (bypassing the
-    # logger) so the ASCII banner only hits disk, not the console.
-    with log_file.open("a", encoding="utf-8") as fh:
-        fh.write(_STARTUP_BANNER)
-
     fmt = logging.Formatter(
         fmt="%(asctime)s  %(levelname)-8s  %(name)s  %(message)s",
         datefmt="%Y-%m-%d %H:%M:%S",
@@ -60,5 +55,14 @@ def setup_logging(log_dir: Path, level: int = logging.DEBUG) -> None:
     root.setLevel(level)
     root.addHandler(file_handler)
     root.addHandler(console_handler)
+
+    # Emit the session banner through the standard formatter so every
+    # line carries a timestamp and keeps the log format consistent.
+    # INFO is below the console handler's threshold, so the banner
+    # only lands in the file.
+    banner = logging.getLogger("banner")
+    for line in _STARTUP_BANNER.splitlines():
+        if line:
+            banner.info(line)
 
     logging.getLogger(__name__).info("Logging initialised → %s", log_file)

--- a/src/log.py
+++ b/src/log.py
@@ -14,6 +14,16 @@ import logging.handlers
 from pathlib import Path
 
 
+_STARTUP_BANNER = r"""
+  _________                   __   .__         .__                   _____
+ /   _____/__________ _______|  | _|  |   ____ |  |__   ____   _____/ ____\
+ \_____  \\____ \__  \\_  __ \  |/ /  | _/ __ \|  |  \ /  _ \ /  _ \   __\
+ /        \  |_> > __ \|  | \/    <|  |_\  ___/|   Y  (  <_> |  <_> )  |
+/_______  /   __(____  /__|  |__|_ \____/\___  >___|  /\____/ \____/|__|
+        \/|__|       \/           \/         \/     \/
+"""
+
+
 def setup_logging(log_dir: Path, level: int = logging.DEBUG) -> None:
     """Configure the root logger.
 
@@ -23,6 +33,11 @@ def setup_logging(log_dir: Path, level: int = logging.DEBUG) -> None:
     """
     log_dir.mkdir(parents=True, exist_ok=True)
     log_file = log_dir / "image-inquest.log"
+
+    # Stamp a session header directly into the file (bypassing the
+    # logger) so the ASCII banner only hits disk, not the console.
+    with log_file.open("a", encoding="utf-8") as fh:
+        fh.write(_STARTUP_BANNER)
 
     fmt = logging.Formatter(
         fmt="%(asctime)s  %(levelname)-8s  %(name)s  %(message)s",

--- a/src/log.py
+++ b/src/log.py
@@ -24,6 +24,32 @@ _STARTUP_BANNER = r"""
 """
 
 
+# Width of the logger-name column. Names longer than this are truncated
+# with an ellipsis so the message column always starts at the same
+# offset.
+_NAME_WIDTH = 24
+
+
+class _FixedWidthFormatter(logging.Formatter):
+    """Formatter that pads/truncates ``record.name`` to ``_NAME_WIDTH``.
+
+    Every field before the message (``asctime`` → 19 chars,
+    ``levelname`` → 8, ``name`` → 24) has a fixed width, so the message
+    column lines up regardless of which module logged the record.
+    """
+
+    def format(self, record: logging.LogRecord) -> str:
+        name = record.name
+        if len(name) > _NAME_WIDTH:
+            name = name[: _NAME_WIDTH - 1] + "…"
+        else:
+            name = name.ljust(_NAME_WIDTH)
+        # Copy so other handlers still see the original unpadded name.
+        rec = logging.makeLogRecord(record.__dict__)
+        rec.name = name
+        return super().format(rec)
+
+
 def setup_logging(log_dir: Path, level: int = logging.DEBUG) -> None:
     """Configure the root logger.
 
@@ -34,7 +60,7 @@ def setup_logging(log_dir: Path, level: int = logging.DEBUG) -> None:
     log_dir.mkdir(parents=True, exist_ok=True)
     log_file = log_dir / "image-inquest.log"
 
-    fmt = logging.Formatter(
+    fmt = _FixedWidthFormatter(
         fmt="%(asctime)s  %(levelname)-8s  %(name)s  %(message)s",
         datefmt="%Y-%m-%d %H:%M:%S",
     )

--- a/src/log.py
+++ b/src/log.py
@@ -14,16 +14,6 @@ import logging.handlers
 from pathlib import Path
 
 
-_STARTUP_BANNER = r"""
-  _________                   __   .__         .__                   _____
- /   _____/__________ _______|  | _|  |   ____ |  |__   ____   _____/ ____\
- \_____  \\____ \__  \\_  __ \  |/ /  | _/ __ \|  |  \ /  _ \ /  _ \   __\
- /        \  |_> > __ \|  | \/    <|  |_\  ___/|   Y  (  <_> |  <_> )  |
-/_______  /   __(____  /__|  |__|_ \____/\___  >___|  /\____/ \____/|__|
-        \/|__|       \/           \/         \/     \/
-"""
-
-
 def setup_logging(log_dir: Path, level: int = logging.DEBUG) -> None:
     """Configure the root logger.
 
@@ -56,13 +46,19 @@ def setup_logging(log_dir: Path, level: int = logging.DEBUG) -> None:
     root.addHandler(file_handler)
     root.addHandler(console_handler)
 
-    # Emit the session banner through the standard formatter so every
-    # line carries a timestamp and keeps the log format consistent.
-    # INFO is below the console handler's threshold, so the banner
-    # only lands in the file.
-    banner = logging.getLogger("banner")
-    for line in _STARTUP_BANNER.splitlines():
+    logger = logging.getLogger(__name__)
+    # Each banner line goes through the standard formatter so the log
+    # format stays consistent. INFO is below the console handler's
+    # threshold, so the banner lands in the file only.
+    for line in r"""
+  _________                   __   .__         .__                   _____
+ /   _____/__________ _______|  | _|  |   ____ |  |__   ____   _____/ ____\
+ \_____  \\____ \__  \\_  __ \  |/ /  | _/ __ \|  |  \ /  _ \ /  _ \   __\
+ /        \  |_> > __ \|  | \/    <|  |_\  ___/|   Y  (  <_> |  <_> )  |
+/_______  /   __(____  /__|  |__|_ \____/\___  >___|  /\____/ \____/|__|
+        \/|__|       \/           \/         \/     \/
+""".splitlines():
         if line:
-            banner.info(line)
+            logger.info(line)
 
-    logging.getLogger(__name__).info("Logging initialised → %s", log_file)
+    logger.info("Logging initialised → %s", log_file)

--- a/src/log.py
+++ b/src/log.py
@@ -14,6 +14,16 @@ import logging.handlers
 from pathlib import Path
 
 
+_STARTUP_BANNER = r"""
+  _________                   __   .__         .__                   _____
+ /   _____/__________ _______|  | _|  |   ____ |  |__   ____   _____/ ____\
+ \_____  \\____ \__  \\_  __ \  |/ /  | _/ __ \|  |  \ /  _ \ /  _ \   __\
+ /        \  |_> > __ \|  | \/    <|  |_\  ___/|   Y  (  <_> |  <_> )  |
+/_______  /   __(____  /__|  |__|_ \____/\___  >___|  /\____/ \____/|__|
+        \/|__|       \/           \/         \/     \/
+"""
+
+
 def setup_logging(log_dir: Path, level: int = logging.DEBUG) -> None:
     """Configure the root logger.
 
@@ -50,14 +60,7 @@ def setup_logging(log_dir: Path, level: int = logging.DEBUG) -> None:
     # Each banner line goes through the standard formatter so the log
     # format stays consistent. INFO is below the console handler's
     # threshold, so the banner lands in the file only.
-    for line in r"""
-  _________                   __   .__         .__                   _____
- /   _____/__________ _______|  | _|  |   ____ |  |__   ____   _____/ ____\
- \_____  \\____ \__  \\_  __ \  |/ /  | _/ __ \|  |  \ /  _ \ /  _ \   __\
- /        \  |_> > __ \|  | \/    <|  |_\  ___/|   Y  (  <_> |  <_> )  |
-/_______  /   __(____  /__|  |__|_ \____/\___  >___|  /\____/ \____/|__|
-        \/|__|       \/           \/         \/     \/
-""".splitlines():
+    for line in _STARTUP_BANNER.splitlines():
         if line:
             logger.info(line)
 

--- a/src/main.py
+++ b/src/main.py
@@ -13,9 +13,9 @@ from constants import (
     APP_NAME,
     APP_VERSION,
     FLOW_DIR,
+    LOG_DIR,
     SPLASH_DURATION_MS,
     SPLASH_IMAGE_PATH,
-    USER_CONFIG_DIR,
 )
 from log import setup_logging
 from ui.main_window import MainWindow
@@ -103,7 +103,7 @@ def main(argv: list[str]) -> int:
     )
     args, qt_args = parser.parse_known_args(argv)
 
-    setup_logging(USER_CONFIG_DIR / "logs")
+    setup_logging(LOG_DIR)
     logger.info("Starting %s v%s", APP_NAME, APP_VERSION)
 
     initial_flow_path: Path | None = None

--- a/src/ui/log_page.py
+++ b/src/ui/log_page.py
@@ -2,11 +2,11 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from PySide6.QtGui import QIcon
-from PySide6.QtWidgets import (
-    QWidget,
-)
+from PySide6.QtCore import QFileSystemWatcher
+from PySide6.QtGui import QFont, QIcon, QTextCursor
+from PySide6.QtWidgets import QPlainTextEdit, QVBoxLayout, QWidget
 
+from constants import LOG_FILE
 from ui.icons import material_icon
 from typing_extensions import override
 
@@ -16,18 +16,60 @@ if TYPE_CHECKING:
     pass
 
 
+# Upper bound on lines retained in the view. The full history stays on
+# disk; older lines scroll off once this cap is reached so memory use
+# stays bounded no matter how long the app runs.
+_MAX_BLOCKS = 20_000
+
+# Largest tail we seed the view with on first load or after rotation,
+# so opening the page never blocks on a multi-megabyte read.
+_TAIL_BYTES = 256 * 1024
+
+
 class LogPage(PageBase):
-    """Page for displaying the log file
+    """Live-tail view of the application log file.
+
+    Reads the file incrementally — only the bytes appended since the
+    previous update are pulled in and inserted at the end. A
+    :class:`QFileSystemWatcher` on both the file and its parent
+    directory drives refreshes; watching the directory too lets us
+    notice rotation, which renames the file out from under a per-file
+    watch.
     """
 
     def __init__(self, parent: QWidget | None = None) -> None:
         super().__init__(parent)
 
+        self._offset: int = 0
+
+        root = QVBoxLayout(self)
+        root.setContentsMargins(0, 0, 0, 0)
+        root.setSpacing(0)
+
+        self._view = QPlainTextEdit(self)
+        self._view.setReadOnly(True)
+        self._view.setLineWrapMode(QPlainTextEdit.LineWrapMode.NoWrap)
+        self._view.setMaximumBlockCount(_MAX_BLOCKS)
+        mono = QFont()
+        mono.setStyleHint(QFont.StyleHint.TypeWriter)
+        mono.setFamily("Monospace")
+        self._view.setFont(mono)
+        root.addWidget(self._view)
+
+        self._watcher = QFileSystemWatcher(self)
+        self._watcher.fileChanged.connect(self._on_path_changed)
+        self._watcher.directoryChanged.connect(self._on_path_changed)
+        if LOG_FILE.parent.exists():
+            self._watcher.addPath(str(LOG_FILE.parent))
+
+        self._load_tail()
+        self._install_file_watch()
 
     # ── Page hooks ─────────────────────────────────────────────────────────────
 
+    @override
     def page_title(self) -> str:
-        return ""  # MainWindow shows the bare app name on the start page
+        return "Log"
 
     @override
     def page_selector_label(self) -> str:
@@ -37,10 +79,84 @@ class LogPage(PageBase):
     def page_selector_icon(self) -> QIcon:
         return material_icon("description")
 
+    @override
     def page_toolbar_sections(self) -> list[ToolbarSection]:
         return []
 
+    @override
     def on_activated(self) -> None:
-        pass
+        # Pick up anything that arrived while the page was hidden.
+        self._refresh()
 
+    # ── Internals ──────────────────────────────────────────────────────────────
 
+    def _install_file_watch(self) -> None:
+        if not LOG_FILE.exists():
+            return
+        path = str(LOG_FILE)
+        if path not in self._watcher.files():
+            self._watcher.addPath(path)
+
+    def _load_tail(self) -> None:
+        if not LOG_FILE.exists():
+            self._offset = 0
+            return
+        try:
+            size = LOG_FILE.stat().st_size
+            with LOG_FILE.open("rb") as fh:
+                if size > _TAIL_BYTES:
+                    fh.seek(size - _TAIL_BYTES)
+                    # Drop the partial first line so we start at a boundary.
+                    fh.readline()
+                chunk = fh.read()
+                self._offset = fh.tell()
+        except OSError:
+            return
+        self._append_bytes(chunk)
+
+    def _on_path_changed(self, _path: str) -> None:
+        self._refresh()
+
+    def _refresh(self) -> None:
+        if not LOG_FILE.exists():
+            self._offset = 0
+            return
+        try:
+            size = LOG_FILE.stat().st_size
+        except OSError:
+            return
+
+        if size < self._offset:
+            # File shrank → rotated or truncated. Start over.
+            self._view.clear()
+            self._offset = 0
+
+        if size > self._offset:
+            try:
+                with LOG_FILE.open("rb") as fh:
+                    fh.seek(self._offset)
+                    chunk = fh.read()
+                    self._offset = fh.tell()
+            except OSError:
+                return
+            self._append_bytes(chunk)
+
+        # Rotation drops the per-file watch (the inode was renamed);
+        # re-add it so we keep receiving fileChanged signals.
+        self._install_file_watch()
+
+    def _append_bytes(self, data: bytes) -> None:
+        if not data:
+            return
+        text = data.decode("utf-8", errors="replace")
+        at_bottom = self._is_at_bottom()
+        cursor = self._view.textCursor()
+        cursor.movePosition(QTextCursor.MoveOperation.End)
+        cursor.insertText(text)
+        if at_bottom:
+            bar = self._view.verticalScrollBar()
+            bar.setValue(bar.maximum())
+
+    def _is_at_bottom(self) -> bool:
+        bar = self._view.verticalScrollBar()
+        return bar.value() >= bar.maximum() - 4

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -73,17 +73,26 @@ class MainWindow(QMainWindow):
 
         self._start_page  = StartPage()
         self._editor_page = NodeEditorPage(self._registry, self._recent_flows)
-        self._log_page = LogPage()
+        self._log_page    = LogPage()
 
-        self._pages.addWidget(self._start_page)
-        self._pages.addWidget(self._editor_page)
-        self._pages.addWidget(self._log_page)
+        # Single source of truth for the set of pages. Adding a new page
+        # means: construct it, append it here, and every loop below —
+        # stack registration, signal wiring, page-selector actions —
+        # picks it up automatically.
+        self._pages_list: list[PageBase] = [
+            self._start_page,
+            self._editor_page,
+            self._log_page,
+        ]
 
-        # Wire page signals.
+        for page in self._pages_list:
+            self._pages.addWidget(page)
+            page.title_changed.connect(self._update_window_title)
+
+        # Per-page signals that only make sense on one page live outside
+        # the iteration above.
         self._start_page.create_flow_requested.connect(self._on_create_flow)
         self._start_page.open_flow_requested.connect(self._on_open_flow_from_start)
-        for page in (self._start_page, self._editor_page):
-            page.title_changed.connect(self._update_window_title)
 
         # ── Menu bar ──
         self._menu_bar: QMenuBar = self.menuBar()
@@ -98,7 +107,7 @@ class MainWindow(QMainWindow):
         self._page_selector_group = QActionGroup(self)
         self._page_selector_group.setExclusive(True)
         self._page_selector_actions: dict[PageBase, QAction] = {}
-        for page in (self._start_page, self._editor_page, self._log_page):
+        for page in self._pages_list:
             self._add_page_selector_action(page)
 
         # Separator between the page-selector radio group and the


### PR DESCRIPTION
## Summary
- Replace the empty Log page stub with a live view of `~/.image-inquest/logs/image-inquest.log`.
- Drive refreshes with a `QFileSystemWatcher` on both the file and its parent directory; the directory watch is what catches rotation, since `RotatingFileHandler` renames the inode out from under a per-file watch.
- Read incrementally: track a byte offset and only pull in bytes appended since the last refresh.
- Detect rotation / truncation via file-size shrink — clear the view, reset the offset, and re-install the per-file watch.
- Render with `QPlainTextEdit` (no-wrap, monospace) and a bounded `setMaximumBlockCount(20_000)` so long sessions don't grow unboundedly in memory.
- Auto-scroll to the bottom only when the user was already there, so scrolling up to inspect older lines isn't yanked back down.
- Seed with the last 256 KB (aligned to a line boundary) so opening the page never blocks on a huge rotated file.
- Extract `LOG_DIR` / `LOG_FILE` into `constants.py` so `main.py` and `log_page.py` share one source of truth.

## Test plan
- [ ] Open the Log page — recent log lines appear, view scrolled to bottom.
- [ ] Trigger any action that logs (e.g. load a flow, raise an error) — new lines appear live without reopening the page.
- [ ] Scroll up; new log lines should NOT snap the view back down.
- [ ] Force a log rotation (produce >1 MB of log output) — the view handles the rollover cleanly and keeps tailing the new file.
- [ ] Switch away and back to the page — any lines written while hidden are present (on_activated catch-up).

https://claude.ai/code/session_01CVgTbeXq9n6WvrHp4VsgQp