### PR TITLE
Enforce at most one upstream per input port

### DIFF
--- a/src/core/port.py
+++ b/src/core/port.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
-from typing import Callable
+from typing import Callable, TYPE_CHECKING
 
 from core.io_data import IoData, IoDataType
+
+if TYPE_CHECKING:
+    pass
 
 
 class InputPort:
@@ -14,6 +17,11 @@ class InputPort:
 
     on_data_received is a zero-argument callback invoked each time new data
     arrives; nodes use it to trigger their processing logic.
+
+    An input port can be fed by **at most one** upstream OutputPort —
+    fan-in is not supported. The binding is maintained by
+    :meth:`OutputPort.connect` / :meth:`OutputPort.disconnect` and
+    exposed read-only through :attr:`upstream`.
     """
 
     def __init__(
@@ -26,6 +34,7 @@ class InputPort:
         self.accepted_types: frozenset[IoDataType] = frozenset(accepted_types)
         self._on_data_received = on_data_received
         self._data: IoData | None = None
+        self._upstream: "OutputPort | None" = None
 
     @property
     def has_data(self) -> bool:
@@ -36,6 +45,11 @@ class InputPort:
         if self._data is None:
             raise RuntimeError(f"Input port '{self.name}' has no data yet")
         return self._data
+
+    @property
+    def upstream(self) -> "OutputPort | None":
+        """The OutputPort currently feeding this input, if any."""
+        return self._upstream
 
     def receive(self, data: IoData) -> None:
         if not data.is_end_of_stream() and data.type not in self.accepted_types:
@@ -66,6 +80,10 @@ class OutputPort:
     Flow use this to validate connections before they are made: a connection
     is only allowed if the output's emits set and the input's accepted_types
     set have at least one type in common.
+
+    Fan-out is allowed — one output can drive any number of inputs — but
+    each input may have at most one upstream output (enforced by
+    :meth:`connect`).
     """
 
     def __init__(self, name: str, emits: set[IoDataType]) -> None:
@@ -80,23 +98,39 @@ class OutputPort:
     # ── Connection management ──────────────────────────────────────────────────
 
     def can_connect(self, input_port: InputPort) -> bool:
-        """Return True if type sets are compatible."""
-        return bool(self.emits & input_port.accepted_types)
+        """Return True if type sets are compatible and the input is free
+        (not already fed by another output)."""
+        if not (self.emits & input_port.accepted_types):
+            return False
+        if input_port.upstream is not None and input_port.upstream is not self:
+            return False
+        return True
 
     def connect(self, input_port: InputPort) -> None:
-        if not self.can_connect(input_port):
+        if not (self.emits & input_port.accepted_types):
             raise TypeError(
                 f"Cannot connect output '{self.name}' (emits {set(self.emits)}) "
                 f"to input '{input_port.name}' (accepts {set(input_port.accepted_types)})"
             )
+        if input_port.upstream is not None and input_port.upstream is not self:
+            raise TypeError(
+                f"Input '{input_port.name}' is already connected to "
+                f"'{input_port.upstream.name}'. Disconnect it first."
+            )
         if input_port not in self._connections:
             self._connections.append(input_port)
+            input_port._upstream = self
 
     def disconnect(self, input_port: InputPort) -> None:
         if input_port in self._connections:
             self._connections.remove(input_port)
+            if input_port.upstream is self:
+                input_port._upstream = None
 
     def disconnect_all(self) -> None:
+        for input_port in self._connections:
+            if input_port.upstream is self:
+                input_port._upstream = None
         self._connections.clear()
 
     @property

--- a/tests/test_port_connections.py
+++ b/tests/test_port_connections.py
@@ -1,0 +1,86 @@
+"""Unit tests for port connection semantics."""
+from __future__ import annotations
+
+import pytest
+
+from core.io_data import IoDataType
+from core.port import InputPort, OutputPort
+
+
+def _image_input(name: str = "in") -> InputPort:
+    return InputPort(name, {IoDataType.IMAGE})
+
+
+def _image_output(name: str = "out") -> OutputPort:
+    return OutputPort(name, {IoDataType.IMAGE})
+
+
+def test_output_can_fan_out_to_multiple_inputs() -> None:
+    """One output may feed many inputs — fan-out is allowed."""
+    out = _image_output()
+    in1 = _image_input("in1")
+    in2 = _image_input("in2")
+
+    out.connect(in1)
+    out.connect(in2)
+
+    assert in1.upstream is out
+    assert in2.upstream is out
+    assert len(out.connections) == 2
+
+
+def test_input_rejects_second_upstream() -> None:
+    """An input already connected to one output cannot accept another."""
+    out_a = _image_output("a")
+    out_b = _image_output("b")
+    target = _image_input()
+
+    out_a.connect(target)
+    with pytest.raises(TypeError, match="already connected"):
+        out_b.connect(target)
+    assert target.upstream is out_a
+    assert target not in out_b.connections
+
+
+def test_reconnecting_same_output_is_idempotent() -> None:
+    """Connecting the same (output, input) pair twice is a no-op, not an error."""
+    out = _image_output()
+    target = _image_input()
+    out.connect(target)
+    out.connect(target)
+    assert len(out.connections) == 1
+    assert target.upstream is out
+
+
+def test_disconnect_clears_upstream() -> None:
+    out = _image_output()
+    target = _image_input()
+    out.connect(target)
+    out.disconnect(target)
+    assert target.upstream is None
+    assert target not in out.connections
+
+
+def test_disconnect_all_clears_every_upstream() -> None:
+    out = _image_output()
+    in1 = _image_input("in1")
+    in2 = _image_input("in2")
+    out.connect(in1)
+    out.connect(in2)
+    out.disconnect_all()
+    assert in1.upstream is None
+    assert in2.upstream is None
+    assert out.connections == []
+
+
+def test_input_reusable_after_disconnect() -> None:
+    """After disconnecting, the input can accept a different output."""
+    out_a = _image_output("a")
+    out_b = _image_output("b")
+    target = _image_input()
+
+    out_a.connect(target)
+    out_a.disconnect(target)
+    out_b.connect(target)
+
+    assert target.upstream is out_b


### PR DESCRIPTION
## Summary
Enforce "each input port has at most one upstream output" at the port level. Fan-out is unchanged — one output can still feed any number of inputs — but a second output can no longer attach to an input that already has an upstream.

### `InputPort`
- New `_upstream: OutputPort | None` field.
- Read-only `upstream` property.
- Managed by the output side so callers never have to set it manually.

### `OutputPort`
- `can_connect(input)` additionally returns `False` when the input already has a different upstream.
- `connect(input)` raises a clear `TypeError` in that case: *"Input '…' is already connected to '…'. Disconnect it first."*
- `disconnect(input)` and `disconnect_all()` clear the input's upstream when it points to this output.

### UI / loader
No changes needed:
- Interactive drag: `FlowScene.mouseReleaseEvent` already catches the `TypeError` from `connect_ports` and surfaces it via the error-banner through `connection_error`.
- Flow loader: `flow_io.load_flow_into` catches incompatible edges and logs; remaining edges still load.

## New tests (`tests/test_port_connections.py`)
- Fan-out to multiple inputs works.
- Second-upstream attempt raises and is not recorded.
- Idempotent reconnect of the same pair is a no-op.
- `disconnect` / `disconnect_all` clear the upstream.
- An input is reusable after disconnect.

## Test plan
- [x] Full suite passes (34/34).
- [ ] Manually verify:
  - [ ] Dragging a second output onto an already-fed input: link is rejected, error banner shows the reason.
  - [ ] Dragging from one output to two different inputs: both connections form.
  - [ ] Disconnecting the old edge then connecting a new one: works.
  - [ ] Loading a saved flow with accidentally-doubled upstreams: the first edge is kept, the second is skipped with a log warning.

https://claude.ai/code/session_011SeuaREwuB4aa874XHPi3J