### PR TITLE
Fix node param widget visibility (combobox popup and bool checkbox)

### DIFF
--- a/src/ui/theme.py
+++ b/src/ui/theme.py
@@ -117,6 +117,29 @@ QMenu::item:selected {
 QLabel[muted="true"] {
     color: #909090;
 }
+QCheckBox {
+    color: #e0e0e0;
+    spacing: 6px;
+    background: transparent;
+}
+QCheckBox::indicator {
+    width: 14px;
+    height: 14px;
+    background: #1f1f22;
+    border: 1px solid #5a5a60;
+    border-radius: 2px;
+}
+QCheckBox::indicator:hover {
+    border-color: #7a7a85;
+}
+QCheckBox::indicator:checked {
+    background: #3a5b8a;
+    border-color: #e0c040;
+}
+QCheckBox::indicator:disabled {
+    background: #2d2d30;
+    border-color: #1a1a1d;
+}
 """
 
 


### PR DESCRIPTION
## Summary

Fixes two visibility issues with param editor widgets embedded in node items on the flow canvas.

### Combobox popup hidden behind other graphics items
The `EnumParamWidget` used a stock `QComboBox`. When embedded via `QGraphicsProxyWidget`, Qt renders the popup as a child proxy of the host item, so it could be occluded by:
- Sibling `NodeItem`s painted at the same Z-value (inter-node).
- The node's own close button and ports, which sit at higher Z within the node (intra-node).

Introduce a `SceneAwareComboBox` subclass (new `src/ui/controls/` subpackage) that, while the popup is open, boosts both the host `NodeItem`'s Z-value and the params proxy's Z-value by 10,000 and restores them on close.

### Bool param indicator invisible
`BoolParamWidget` was built with a `QCheckBox`, but the params container's `QWidget { background: transparent; }` rule cascaded into the checkbox subcontrols and erased the indicator fill, so the user saw the caption with no visible control (e.g. RGB Join `three_color`).

Add explicit `QCheckBox::indicator` styling to the dark theme: a framed 14×14 box, dark fill when unchecked, blue fill with gold border when checked.

## Test plan

- [ ] Open a flow with an RGB Join node; verify the `three_color` checkbox is visible and toggles cleanly.
- [ ] Open the dither node's algorithm combobox and confirm the popup is fully visible over adjacent nodes.
- [ ] Confirm the popup also covers the same node's close button and ports.
- [ ] Toggle the checkbox on a few other BOOL params; verify checked/unchecked states are clearly distinguishable.