### PR TITLE
Extract subpixel mosaic visualization into dedicated node

### DIFF
--- a/src/nodes/filters/rgb_join.py
+++ b/src/nodes/filters/rgb_join.py
@@ -1,52 +1,34 @@
 from __future__ import annotations
 
 import cv2
-import numpy as np
 from typing_extensions import override
 
 from core.io_data import IoData, IoDataType
-from core.node_base import NodeBase, NodeParam, NodeParamType
+from core.node_base import NodeBase, NodeParam
 from core.port import InputPort, OutputPort
 
 
 class RgbJoin(NodeBase):
     """Merge three single-channel images into a BGR image.
 
-    Inputs ``B``, ``G`` and ``R`` are combined with ``cv2.merge``. When
-    ``three_color`` is enabled, the merged image is further rendered into
-    a stylised BGR pattern on a 1.5×/2× upscaled canvas — ported unchanged
-    from the original OCVL ``RbgJoinProcessor``.
+    Inputs ``B``, ``G`` and ``R`` are combined with ``cv2.merge`` and
+    emitted as a standard BGR :data:`IoDataType.IMAGE` payload.
     """
 
     def __init__(self) -> None:
         super().__init__("RGB Join", section="Color Spaces")
-        self._three_color: bool = False
 
         self._add_input(InputPort("B", {IoDataType.IMAGE_GREY}))
         self._add_input(InputPort("G", {IoDataType.IMAGE_GREY}))
         self._add_input(InputPort("R", {IoDataType.IMAGE_GREY}))
         self._add_output(OutputPort("image", {IoDataType.IMAGE}))
 
-        # Sync attributes with declared NodeParam defaults; see
-        # NodeBase._apply_default_params for rationale.
-        self._apply_default_params()
-
     # ── Parameters ─────────────────────────────────────────────────────────────
 
     @property
     @override
     def params(self) -> list[NodeParam]:
-        return [NodeParam("three_color", NodeParamType.BOOL, {"default": False})]
-
-    # ── Properties ─────────────────────────────────────────────────────────────
-
-    @property
-    def three_color(self) -> bool:
-        return self._three_color
-
-    @three_color.setter
-    def three_color(self, value: bool) -> None:
-        self._three_color = bool(value)
+        return []
 
     # ── NodeBase interface ─────────────────────────────────────────────────────
 
@@ -55,36 +37,4 @@ class RgbJoin(NodeBase):
         b = self.inputs[0].data.image
         g = self.inputs[1].data.image
         r = self.inputs[2].data.image
-
-        merged = cv2.merge((b, g, r))
-        if self._three_color:
-            merged = _rgbify(merged)
-        self.outputs[0].send(IoData.from_image(merged))
-
-
-def _rgbify(image: np.ndarray) -> np.ndarray:
-    """Scatter each source pixel's BGR samples across an upscaled canvas.
-
-    Faithful port of OCVL's ``RbgJoinProcessor.__rgbify``. No numba here —
-    the loop is O(w*h), so expect it to be slow on large frames; enable
-    ``three_color`` only when you want the stylised visualisation.
-    """
-    h, w, _ = image.shape
-    nh = h * 2
-    nw = int(w * 1.5)
-    rgb = np.zeros((nh, nw, 3), dtype=np.uint8)
-
-    for x in range(w):
-        for y in range(h):
-            b, g, r = image[y, x, :]
-            if x % 2 == 0:
-                ox = int(x * 1.5)
-                rgb[2 * y + 0, ox,     :] = (0, g, 0)
-                rgb[2 * y + 0, ox + 1, :] = (b, 0, 0)
-                rgb[2 * y + 1, ox,     :] = (0, 0, r)
-            else:
-                ox = 1 + int(x * 1.5 - 0.5)
-                rgb[2 * y + 0, ox,     :] = (0, 0, r)
-                rgb[2 * y + 1, ox,     :] = (b, 0, 0)
-                rgb[2 * y + 1, ox - 1, :] = (0, g, 0)
-    return rgb
+        self.outputs[0].send(IoData.from_image(cv2.merge((b, g, r))))

--- a/src/nodes/filters/subpixel_mosaic.py
+++ b/src/nodes/filters/subpixel_mosaic.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+import cv2
+import numba
+import numpy as np
+from typing_extensions import override
+
+from core.io_data import IMAGE_TYPES, IoData, IoDataType
+from core.node_base import NodeBase, NodeParam, NodeParamType
+from core.port import InputPort, OutputPort
+
+
+class SubpixelMosaic(NodeBase):
+    """Render a BGR image as a stylised RGB sub-pixel mosaic.
+
+    Each source pixel is scattered across three mono-channel sub-pixels
+    on a 1.5× wider, 2× taller canvas, echoing the R/G/B arrangement of
+    a physical display's shadow mask. Even and odd source columns use
+    mirrored tile patterns so the sub-pixels pack without gaps.
+
+    The raw mosaic distorts the source aspect ratio (vertical stretch
+    by 4/3). When ``keep_aspect`` is enabled the canvas is nearest-
+    neighbour rescaled to 2w × 2h so the output matches the source
+    proportions. ``output_grayscale`` drops the colour and emits the
+    per-pixel sample intensity as a single-channel image.
+
+    Ported from OCVL's ``RbgJoinProcessor.__rgbify`` visualisation; the
+    scatter kernel is JIT-compiled by numba (``@njit(cache=True)``).
+    """
+
+    def __init__(self) -> None:
+        super().__init__("Subpixel Mosaic", section="Experimental")
+        self._keep_aspect: bool = False
+        self._output_grayscale: bool = False
+
+        self._add_input(InputPort("image", {IoDataType.IMAGE}))
+        self._add_output(OutputPort("image", set(IMAGE_TYPES)))
+
+        self._apply_default_params()
+
+    # ── Parameters ─────────────────────────────────────────────────────────────
+
+    @property
+    @override
+    def params(self) -> list[NodeParam]:
+        return [
+            NodeParam("keep_aspect",      NodeParamType.BOOL, {"default": False}),
+            NodeParam("output_grayscale", NodeParamType.BOOL, {"default": False}),
+        ]
+
+    # ── Properties ─────────────────────────────────────────────────────────────
+
+    @property
+    def keep_aspect(self) -> bool:
+        return self._keep_aspect
+
+    @keep_aspect.setter
+    def keep_aspect(self, value: bool) -> None:
+        self._keep_aspect = bool(value)
+
+    @property
+    def output_grayscale(self) -> bool:
+        return self._output_grayscale
+
+    @output_grayscale.setter
+    def output_grayscale(self, value: bool) -> None:
+        self._output_grayscale = bool(value)
+
+    # ── NodeBase interface ─────────────────────────────────────────────────────
+
+    @override
+    def process(self) -> None:
+        image: np.ndarray = self.inputs[0].data.image
+        if image.ndim != 3 or image.shape[2] != 3:
+            raise ValueError("Subpixel Mosaic requires a 3-channel BGR image")
+
+        mosaic = _rgbify(image)
+
+        if self._keep_aspect:
+            h, w, _ = image.shape
+            mosaic = cv2.resize(mosaic, (2 * w, 2 * h), interpolation=cv2.INTER_NEAREST)
+
+        if self._output_grayscale:
+            # Every mosaic pixel carries exactly one non-zero channel, so
+            # the per-pixel max equals the original source sample value
+            # without luminance weighting — this preserves the raw sample
+            # intensity in a single-channel image.
+            grey = mosaic.max(axis=2).astype(np.uint8)
+            self.outputs[0].send(IoData.from_greyscale(grey))
+        else:
+            self.outputs[0].send(IoData.from_image(mosaic))
+
+
+@numba.njit(cache=True)
+def _rgbify(image: np.ndarray) -> np.ndarray:
+    """Scatter each source pixel's BGR samples across an upscaled canvas.
+
+    Faithful port of OCVL's ``RbgJoinProcessor.__rgbify``. Output canvas
+    is 1.5w × 2h; each source pixel contributes three mono-channel
+    sub-pixels whose positions depend on whether the source column is
+    even or odd so the tile patterns mesh.
+    """
+    h, w, _ = image.shape
+    nh = h * 2
+    nw = int(w * 1.5)
+    rgb = np.zeros((nh, nw, 3), dtype=np.uint8)
+
+    for x in range(w):
+        for y in range(h):
+            b = image[y, x, 0]
+            g = image[y, x, 1]
+            r = image[y, x, 2]
+            if x % 2 == 0:
+                ox = int(x * 1.5)
+                rgb[2 * y + 0, ox,     1] = g
+                rgb[2 * y + 0, ox + 1, 0] = b
+                rgb[2 * y + 1, ox,     2] = r
+            else:
+                ox = 1 + int(x * 1.5 - 0.5)
+                rgb[2 * y + 0, ox,     2] = r
+                rgb[2 * y + 1, ox,     0] = b
+                rgb[2 * y + 1, ox - 1, 1] = g
+    return rgb


### PR DESCRIPTION
## Summary
Refactored the subpixel mosaic visualization functionality from `RgbJoin` into a new dedicated `SubpixelMosaic` node. This separation of concerns allows the mosaic effect to be used independently and improves code organization.

## Key Changes
- **New node**: Created `SubpixelMosaic` class in `src/nodes/filters/subpixel_mosaic.py`
  - Implements the RGB sub-pixel mosaic rendering with configurable options
  - Adds `keep_aspect` parameter to rescale output to match source proportions
  - Adds `output_grayscale` parameter to emit single-channel intensity image
  - Uses numba JIT compilation (`@njit(cache=True)`) for the scatter kernel to improve performance

- **Simplified `RgbJoin`**: Removed the `three_color` parameter and associated visualization logic
  - Now focuses solely on merging three grayscale channels into a BGR image
  - Removed `_rgbify` implementation and related imports
  - Cleaner, more focused responsibility

## Implementation Details
- The `_rgbify` scatter kernel was ported from OCVL's `RbgJoinProcessor.__rgbify` visualization
- Output canvas is 1.5w × 2h with mirrored tile patterns for even/odd columns to pack sub-pixels without gaps
- When `keep_aspect` is enabled, nearest-neighbor rescaling to 2w × 2h preserves source aspect ratio
- When `output_grayscale` is enabled, per-pixel max intensity is extracted as single-channel output
- Numba JIT compilation replaces the pure Python loop for significantly better performance

https://claude.ai/code/session_01EdURH8FGnYrDpt2amKj17A