### PR TITLE
Add logging and error handling wrapper to node processing

### DIFF
--- a/src/core/node_base.py
+++ b/src/core/node_base.py
@@ -149,8 +149,25 @@ class NodeBase(ABC):
 
     # ── Overridable behaviour ──────────────────────────────────────────────────
 
-    @abstractmethod
     def process(self) -> None:
+        """Dispatch to :meth:`process_impl` with logging and error handling.
+
+        Subclasses should override :meth:`process_impl`, not this method, so
+        that every node automatically benefits from the per-call tracing log
+        and the common exception-logging path.
+        """
+        logger.debug("Processing node %s (%s)", self._display_name, type(self).__name__)
+        try:
+            self.process_impl()
+        except Exception:
+            logger.exception(
+                "Exception in %s.process_impl (%s)",
+                type(self).__name__, self._display_name,
+            )
+            raise
+
+    @abstractmethod
+    def process_impl(self) -> None:
         """Read from self._inputs, compute, and write results to self._outputs."""
         ...
 
@@ -201,7 +218,7 @@ class SourceNodeBase(NodeBase, ABC):
         ...
 
     @override
-    def process(self) -> None:
+    def process_impl(self) -> None:
         raise RuntimeError("SourceNodeBase has no inputs; call start() instead")
 
     @override
@@ -220,7 +237,7 @@ class SinkNodeBase(NodeBase, ABC):
 
     @abstractmethod
     @override
-    def process(self) -> None: ...
+    def process_impl(self) -> None: ...
 
     @override
     def _on_end_of_stream(self) -> None:

--- a/src/core/node_base.py
+++ b/src/core/node_base.py
@@ -156,14 +156,13 @@ class NodeBase(ABC):
         that every node automatically benefits from the per-call tracing log
         and the common exception-logging path.
         """
-        logger.debug("Processing node %s (%s)", self._display_name, type(self).__name__)
+        
+        logger.debug(f"  - Executing {self._display_name} ({type(self).__name__})")
+        
         try:
             self.process_impl()
         except Exception:
-            logger.exception(
-                "Exception in %s.process_impl (%s)",
-                type(self).__name__, self._display_name,
-            )
+            logger.exception(f"Exception in {type(self).__name__}.process_impl ({self._display_name})")
             raise
 
     @abstractmethod

--- a/src/log.py
+++ b/src/log.py
@@ -82,6 +82,10 @@ def setup_logging(log_dir: Path, level: int = logging.DEBUG) -> None:
     root.addHandler(file_handler)
     root.addHandler(console_handler)
 
+    # numba.core.ssa emits a torrent of DEBUG records during JIT compilation
+    # that drowns out everything else in the log file. Cap it at INFO.
+    logging.getLogger("numba.core.ssa").setLevel(logging.INFO)
+
     logger = logging.getLogger(__name__)
     # Each banner line goes through the standard formatter so the log
     # format stays consistent. INFO is below the console handler's

--- a/src/nodes/filters/adaptive_gaussian_threshold.py
+++ b/src/nodes/filters/adaptive_gaussian_threshold.py
@@ -70,7 +70,7 @@ class AdaptiveGaussianThreshold(NodeBase):
     # ── NodeBase interface ─────────────────────────────────────────────────────
 
     @override
-    def process(self) -> None:
+    def process_impl(self) -> None:
         image: np.ndarray = self.inputs[0].data.image
 
         if image.ndim == 3:

--- a/src/nodes/filters/dither.py
+++ b/src/nodes/filters/dither.py
@@ -151,7 +151,7 @@ class Dither(NodeBase):
     # ── NodeBase interface ─────────────────────────────────────────────────────
 
     @override
-    def process(self) -> None:
+    def process_impl(self) -> None:
         image: np.ndarray = self.inputs[0].data.image
 
         if image.ndim == 3:

--- a/src/nodes/filters/grayscale.py
+++ b/src/nodes/filters/grayscale.py
@@ -29,7 +29,7 @@ class Grayscale(NodeBase):
         return []
 
     @override
-    def process(self) -> None:
+    def process_impl(self) -> None:
         image: np.ndarray = self.inputs[0].data.image
         gray = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)
         self.outputs[0].send(IoData.from_greyscale(gray))

--- a/src/nodes/filters/median.py
+++ b/src/nodes/filters/median.py
@@ -55,7 +55,7 @@ class Median(NodeBase):
     # ── NodeBase interface ─────────────────────────────────────────────────────
 
     @override
-    def process(self) -> None:
+    def process_impl(self) -> None:
         in_data = self.inputs[0].data
         blurred = cv2.medianBlur(in_data.image, self._size)
         self.outputs[0].send(in_data.with_image(blurred))

--- a/src/nodes/filters/normalize.py
+++ b/src/nodes/filters/normalize.py
@@ -30,7 +30,7 @@ class Normalize(NodeBase):
         return []
 
     @override
-    def process(self) -> None:
+    def process_impl(self) -> None:
         in_data = self.inputs[0].data
         image = in_data.image
 

--- a/src/nodes/filters/rgb_join.py
+++ b/src/nodes/filters/rgb_join.py
@@ -33,7 +33,7 @@ class RgbJoin(NodeBase):
     # ── NodeBase interface ─────────────────────────────────────────────────────
 
     @override
-    def process(self) -> None:
+    def process_impl(self) -> None:
         b = self.inputs[0].data.image
         g = self.inputs[1].data.image
         r = self.inputs[2].data.image

--- a/src/nodes/filters/rgb_split.py
+++ b/src/nodes/filters/rgb_split.py
@@ -30,7 +30,7 @@ class RgbSplit(NodeBase):
         return []
 
     @override
-    def process(self) -> None:
+    def process_impl(self) -> None:
         image: np.ndarray = self.inputs[0].data.image
         b, g, r = cv2.split(image)
         self.outputs[0].send(IoData.from_greyscale(b))

--- a/src/nodes/filters/scale.py
+++ b/src/nodes/filters/scale.py
@@ -78,7 +78,7 @@ class Scale(NodeBase):
     # ── NodeBase interface ─────────────────────────────────────────────────────
 
     @override
-    def process(self) -> None:
+    def process_impl(self) -> None:
         in_data = self.inputs[0].data
         image: np.ndarray = in_data.image
         h, w = image.shape[:2]

--- a/src/nodes/filters/shift.py
+++ b/src/nodes/filters/shift.py
@@ -60,7 +60,7 @@ class Shift(NodeBase):
     # ── NodeBase interface ─────────────────────────────────────────────────────
 
     @override
-    def process(self) -> None:
+    def process_impl(self) -> None:
         in_data = self.inputs[0].data
         image: np.ndarray = in_data.image
         h, w = image.shape[:2]

--- a/src/nodes/filters/subpixel_mosaic.py
+++ b/src/nodes/filters/subpixel_mosaic.py
@@ -69,7 +69,7 @@ class SubpixelMosaic(NodeBase):
     # ── NodeBase interface ─────────────────────────────────────────────────────
 
     @override
-    def process(self) -> None:
+    def process_impl(self) -> None:
         image: np.ndarray = self.inputs[0].data.image
         if image.ndim != 3 or image.shape[2] != 3:
             raise ValueError("Subpixel Mosaic requires a 3-channel BGR image")

--- a/src/nodes/filters/throw_exception.py
+++ b/src/nodes/filters/throw_exception.py
@@ -28,7 +28,7 @@ class ThrowException(NodeBase):
         return []
 
     @override
-    def process(self) -> None:
+    def process_impl(self) -> None:
         raise RuntimeError(
             "Throw Exception node: intentional failure triggered to exercise "
             "the pipeline's exception-handling path.\n"

--- a/src/nodes/sinks/file_sink.py
+++ b/src/nodes/sinks/file_sink.py
@@ -56,7 +56,7 @@ class FileSink(SinkNodeBase):
     # ── SinkNodeBase interface ──────────────────────────────────────────────────
 
     @override
-    def process(self) -> None:
+    def process_impl(self) -> None:
         file_name, file_ext = os.path.splitext(self._output_path)
 
         if self._output_format == OutputFormat.SAME_AS_INPUT:


### PR DESCRIPTION
## Summary
Refactored the node processing architecture to separate concerns between framework-level logging/error handling and node-specific implementation logic. The `process()` method is now a concrete template method that wraps calls to a new abstract `process_impl()` method.

## Key Changes
- **Introduced `process_impl()` abstract method**: All node subclasses now override `process_impl()` instead of `process()` to implement their core logic
- **Converted `process()` to concrete template method**: Now handles:
  - Debug logging for each node processing call
  - Exception catching and logging with full context (node type and display name)
  - Re-raising exceptions to preserve error propagation
- **Updated all node implementations**: Changed 14 node classes across filters and sinks to override `process_impl()` instead of `process()`

## Implementation Details
The new `process()` method provides automatic instrumentation for all nodes without requiring individual implementations to add logging boilerplate. This ensures consistent tracing and error reporting across the entire node pipeline while keeping node implementations focused on their core logic.

The exception handler logs the full exception traceback along with contextual information (node class name and display name) before re-raising, enabling better debugging while maintaining the original error propagation behavior.

https://claude.ai/code/session_01CZ8C7Ttjdqv9rz1fv8mcdG