### PR TITLE
NodeBase process wrapper + recent-flows panel on start page

### DIFF
--- a/src/ui/flow_layout.py
+++ b/src/ui/flow_layout.py
@@ -1,0 +1,86 @@
+"""Minimal wrap/flow layout.
+
+Arranges child widgets left-to-right and wraps to a new row once the
+available width is exhausted. Adapted from Qt's canonical
+``flowlayout`` example (BSD-licensed).
+"""
+from __future__ import annotations
+
+from PySide6.QtCore import QMargins, QPoint, QRect, QSize, Qt
+from PySide6.QtWidgets import QLayout, QLayoutItem, QWidget
+
+
+class FlowLayout(QLayout):
+    def __init__(self, parent: QWidget | None = None, margin: int = 0, spacing: int = 8) -> None:
+        super().__init__(parent)
+        if parent is not None:
+            self.setContentsMargins(QMargins(margin, margin, margin, margin))
+        self.setSpacing(spacing)
+        self._items: list[QLayoutItem] = []
+
+    # ── QLayout API ───────────────────────────────────────────────────────────
+
+    def addItem(self, item: QLayoutItem) -> None:  # noqa: N802 — Qt override
+        self._items.append(item)
+
+    def count(self) -> int:
+        return len(self._items)
+
+    def itemAt(self, index: int) -> QLayoutItem | None:  # noqa: N802
+        if 0 <= index < len(self._items):
+            return self._items[index]
+        return None
+
+    def takeAt(self, index: int) -> QLayoutItem | None:  # noqa: N802
+        if 0 <= index < len(self._items):
+            return self._items.pop(index)
+        return None
+
+    def expandingDirections(self) -> Qt.Orientation:  # noqa: N802
+        return Qt.Orientation(0)
+
+    def hasHeightForWidth(self) -> bool:  # noqa: N802
+        return True
+
+    def heightForWidth(self, width: int) -> int:  # noqa: N802
+        return self._do_layout(QRect(0, 0, width, 0), test_only=True)
+
+    def setGeometry(self, rect: QRect) -> None:  # noqa: N802
+        super().setGeometry(rect)
+        self._do_layout(rect, test_only=False)
+
+    def sizeHint(self) -> QSize:  # noqa: N802
+        return self.minimumSize()
+
+    def minimumSize(self) -> QSize:  # noqa: N802
+        size = QSize()
+        for item in self._items:
+            size = size.expandedTo(item.minimumSize())
+        m = self.contentsMargins()
+        size += QSize(m.left() + m.right(), m.top() + m.bottom())
+        return size
+
+    # ── Internal ──────────────────────────────────────────────────────────────
+
+    def _do_layout(self, rect: QRect, *, test_only: bool) -> int:
+        m = self.contentsMargins()
+        effective = rect.adjusted(m.left(), m.top(), -m.right(), -m.bottom())
+        x = effective.x()
+        y = effective.y()
+        line_height = 0
+        spacing = self.spacing()
+
+        for item in self._items:
+            hint = item.sizeHint()
+            next_x = x + hint.width() + spacing
+            if next_x - spacing > effective.right() and line_height > 0:
+                x = effective.x()
+                y = y + line_height + spacing
+                next_x = x + hint.width() + spacing
+                line_height = 0
+            if not test_only:
+                item.setGeometry(QRect(QPoint(x, y), hint))
+            x = next_x
+            line_height = max(line_height, hint.height())
+
+        return y + line_height - rect.y() + m.bottom()

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -71,7 +71,7 @@ class MainWindow(QMainWindow):
         self._pages = QStackedWidget()
         self.setCentralWidget(self._pages)
 
-        self._start_page  = StartPage()
+        self._start_page  = StartPage(self._recent_flows)
         self._editor_page = NodeEditorPage(self._registry, self._recent_flows)
         self._log_page    = LogPage()
 

--- a/src/ui/recent_flows.py
+++ b/src/ui/recent_flows.py
@@ -95,7 +95,18 @@ class RecentFlowsManager(QObject):
                 _RECENT_FLOWS_FILE, type(data).__name__,
             )
             return
-        self._paths = [Path(item) for item in data if isinstance(item, str)][:MAX_RECENT_FLOWS]
+        parsed = [Path(item) for item in data if isinstance(item, str)][:MAX_RECENT_FLOWS]
+        # Drop entries whose file has since been moved/deleted so the UI
+        # never shows a recent flow the user can't actually open.
+        existing = [p for p in parsed if p.exists()]
+        self._paths = existing
+        if len(existing) != len(parsed):
+            logger.info(
+                "Pruned %d missing entr%s from recent flows",
+                len(parsed) - len(existing),
+                "y" if len(parsed) - len(existing) == 1 else "ies",
+            )
+            self._save()
 
     def _save(self) -> None:
         try:

--- a/src/ui/start_page.py
+++ b/src/ui/start_page.py
@@ -3,29 +3,32 @@ from __future__ import annotations
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from PySide6.QtCore import Qt, Signal
+from PySide6.QtCore import QSize, Qt, Signal
 from PySide6.QtGui import QAction, QIcon
 from PySide6.QtWidgets import (
     QFileDialog,
+    QFrame,
     QHBoxLayout,
     QLabel,
     QLineEdit,
     QPushButton,
     QSizePolicy,
     QSpacerItem,
+    QToolButton,
     QVBoxLayout,
     QWidget,
 )
 
 from constants import APP_DISPLAY_NAME, APP_VERSION, FLOW_DIR
 from core.flow import DEFAULT_FLOW_NAME, is_valid_flow_name
+from ui.flow_layout import FlowLayout
 from ui.icons import material_icon
 from typing_extensions import override
 
 from ui.page import PageBase, ToolbarSection
 
 if TYPE_CHECKING:
-    pass
+    from ui.recent_flows import RecentFlowsManager
 
 _FLOW_FILE_FILTER = "Flow (*.flowjs);;All files (*)"
 
@@ -41,8 +44,19 @@ class StartPage(PageBase):
     create_flow_requested = Signal(str)     # emits flow name
     open_flow_requested   = Signal(Path)    # emits file path
 
-    def __init__(self, parent: QWidget | None = None) -> None:
+    #: Pixel side length of each recent-flow tile icon. Matches the grid
+    #: spacing used by typical OS file explorers (just large enough for
+    #: the text underneath to read comfortably).
+    _RECENT_ICON_SIZE = 48
+    _RECENT_TILE_WIDTH = 120
+
+    def __init__(
+        self,
+        recent_flows: "RecentFlowsManager | None" = None,
+        parent: QWidget | None = None,
+    ) -> None:
         super().__init__(parent)
+        self._recent_flows = recent_flows
 
         # Toolbar action: mirrors the "Open" button in the body so the
         # start page contributes at least one item to the main toolbar.
@@ -92,6 +106,29 @@ class StartPage(PageBase):
         open_row.addStretch(1)
         root.addLayout(open_row)
 
+        # Recent flows wrap panel.
+        root.addSpacerItem(QSpacerItem(0, 24, QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Fixed))
+
+        self._recent_heading = QLabel("Recent Flows")
+        heading_font = self._recent_heading.font()
+        heading_font.setPointSize(14)
+        heading_font.setBold(True)
+        self._recent_heading.setFont(heading_font)
+        root.addWidget(self._recent_heading)
+
+        self._recent_panel = QFrame()
+        self._recent_panel.setFrameShape(QFrame.Shape.NoFrame)
+        self._recent_layout = FlowLayout(self._recent_panel, margin=0, spacing=12)
+        root.addWidget(self._recent_panel)
+
+        self._recent_empty_label = QLabel("No recent flows")
+        self._recent_empty_label.setProperty("muted", True)
+        root.addWidget(self._recent_empty_label)
+
+        self._rebuild_recent_tiles()
+        if self._recent_flows is not None:
+            self._recent_flows.changed.connect(self._rebuild_recent_tiles)
+
         root.addStretch(1)
 
     # ── Page hooks ─────────────────────────────────────────────────────────────
@@ -132,3 +169,37 @@ class StartPage(PageBase):
         )
         if path_str:
             self.open_flow_requested.emit(Path(path_str))
+
+    # ── Recent flows ───────────────────────────────────────────────────────────
+
+    def _rebuild_recent_tiles(self) -> None:
+        """Clear and repopulate the recent-flows wrap panel.
+
+        Called once at construction and whenever the backing
+        RecentFlowsManager emits ``changed``.
+        """
+        while (item := self._recent_layout.takeAt(0)) is not None:
+            w = item.widget()
+            if w is not None:
+                w.deleteLater()
+
+        paths = self._recent_flows.paths if self._recent_flows is not None else []
+        for path in paths:
+            self._recent_layout.addWidget(self._make_recent_tile(path))
+
+        has_any = bool(paths)
+        self._recent_panel.setVisible(has_any)
+        self._recent_empty_label.setVisible(not has_any)
+
+    def _make_recent_tile(self, path: Path) -> QToolButton:
+        """Build a file-explorer-style tile (icon above label) for ``path``."""
+        btn = QToolButton()
+        btn.setToolButtonStyle(Qt.ToolButtonStyle.ToolButtonTextUnderIcon)
+        btn.setIcon(material_icon("description"))
+        btn.setIconSize(QSize(self._RECENT_ICON_SIZE, self._RECENT_ICON_SIZE))
+        btn.setAutoRaise(True)
+        btn.setText(path.stem)
+        btn.setToolTip(str(path))
+        btn.setFixedWidth(self._RECENT_TILE_WIDTH)
+        btn.clicked.connect(lambda _=False, p=path: self.open_flow_requested.emit(p))
+        return btn


### PR DESCRIPTION
## Summary
- Turn `NodeBase.process` into a concrete dispatcher that logs every call and any exception, then re-raises. Subclasses now override the new abstract `process_impl`, so every node gets tracing and exception logging for free. All existing filters, the file sink, and the `Source`/`Sink` base classes are updated accordingly.
- Silence `numba.core.ssa` DEBUG spam in `setup_logging` so the file log stays readable.
- `RecentFlowsManager` now prunes entries whose file no longer exists the first time the MRU is loaded, persisting the cleaned list back to disk.
- New "Recent Flows" section on `StartPage`: a wrap panel of file-explorer–style tiles (Material `description` icon above the flow name). Clicking a tile opens the flow; the panel rebuilds on every MRU change and falls back to a muted "No recent flows" label when empty.
- Added a small `FlowLayout` helper (port of Qt's canonical flow-layout example) to back the wrap panel.

## Test plan
- [x] `pytest tests/` — 34/34 pass
- [x] Offscreen Qt smoke test: tiles render, rebuild on `RecentFlowsManager.changed`, empty-state label toggles correctly
- [x] Offscreen Qt smoke test: missing entries are pruned from disk on load
- [ ] Manual: launch the app, confirm recent flows appear as icons on the start page and that clicking one opens the flow
- [ ] Manual: delete a recently-opened flow on disk, relaunch, confirm it is no longer listed