### PR TITLE
Add application icon support and Windows taskbar integration

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,7 +9,10 @@
                 "type" : "debugpy",
                 "request" : "launch",
                 "program" : "${workspaceFolder}/src/main.py",
-                "console" : "integratedTerminal"
+                "cwd" : "${workspaceFolder}",
+                "env" : { "PYTHONPATH": "${workspaceFolder}/src" },
+                "console" : "integratedTerminal",
+                "justMyCode" : false
             },
             {
                 "name" : "Unit Tests (pytest)",
@@ -18,6 +21,7 @@
                 "module" : "pytest",
                 "args" : ["tests/", "-v"],
                 "cwd" : "${workspaceFolder}",
+                "env" : { "PYTHONPATH": "${workspaceFolder}/src" },
                 "console" : "integratedTerminal",
                 "justMyCode" : false
             }

--- a/src/constants.py
+++ b/src/constants.py
@@ -10,6 +10,17 @@ ASSETS_DIR:        Path = Path(__file__).parent.parent / "assets"
 SPLASH_IMAGE_PATH: Path = ASSETS_DIR / "title.png"
 SPLASH_DURATION_MS: int = 1800
 
+# Application window / taskbar icon. Prefer the .ico (multi-resolution,
+# correct on Windows title bars and taskbar) with the .png as a fallback
+# for platforms or toolchains that don't pick up ICO.
+APP_ICON_PATH:          Path = ASSETS_DIR / "app_icon.ico"
+APP_ICON_FALLBACK_PATH: Path = ASSETS_DIR / "app_icon.png"
+
+# Windows groups taskbar entries by AppUserModelID and uses it to find
+# the right icon. Without this, Python-hosted apps inherit the generic
+# python.exe icon in the taskbar.
+APP_USER_MODEL_ID: str = "Beltoforion.Sparklehoof.ImageInquest.0.1.1"
+
 # Google Material Icons font, rendered into QIcons by ``ui.icons``.
 MATERIAL_ICONS_FONT_PATH: Path = ASSETS_DIR / "fonts" / "MaterialIcons-Regular.ttf"
 

--- a/src/main.py
+++ b/src/main.py
@@ -6,11 +6,14 @@ import sys
 from pathlib import Path
 
 from PySide6.QtCore import Qt, QTimer
-from PySide6.QtGui import QCursor, QGuiApplication, QPixmap, QScreen
+from PySide6.QtGui import QCursor, QGuiApplication, QIcon, QPixmap, QScreen
 from PySide6.QtWidgets import QApplication, QSplashScreen
 
 from constants import (
+    APP_ICON_FALLBACK_PATH,
+    APP_ICON_PATH,
     APP_NAME,
+    APP_USER_MODEL_ID,
     APP_VERSION,
     FLOW_DIR,
     LOG_DIR,
@@ -54,6 +57,40 @@ def _resolve_flow_arg(arg: str) -> Path | None:
         if c.is_file():
             return c.resolve()
     return None
+
+
+def _set_windows_app_user_model_id() -> None:
+    """On Windows, declare an explicit AppUserModelID for the process.
+
+    Without this, a Python-hosted app inherits ``python.exe``'s identity
+    and the taskbar shows the generic Python icon regardless of what we
+    set via :meth:`QApplication.setWindowIcon`. Harmless (and silently
+    skipped) on every other platform.
+    """
+    if sys.platform != "win32":
+        return
+    try:
+        import ctypes
+        ctypes.windll.shell32.SetCurrentProcessExplicitAppUserModelID(APP_USER_MODEL_ID)
+    except Exception:
+        logger.debug("Could not set AppUserModelID; taskbar icon may fall back to python.exe")
+
+
+def _load_app_icon() -> QIcon:
+    """Return the application icon, preferring the multi-resolution ``.ico``.
+
+    Falls back to the ``.png`` if the ``.ico`` is missing or unreadable,
+    and to an empty icon as a last resort so startup never fails over a
+    missing asset.
+    """
+    for path in (APP_ICON_PATH, APP_ICON_FALLBACK_PATH):
+        if path.exists():
+            icon = QIcon(str(path))
+            if not icon.isNull():
+                return icon
+            logger.warning("App icon at %s could not be loaded", path)
+    logger.debug("No app icon found; using Qt default")
+    return QIcon()
 
 
 def _target_screen() -> QScreen:
@@ -106,6 +143,10 @@ def main(argv: list[str]) -> int:
     setup_logging(LOG_DIR)
     logger.info("Starting %s v%s", APP_NAME, APP_VERSION)
 
+    # Must happen before QApplication so Windows associates our icon with
+    # the process's taskbar entry from the very first window.
+    _set_windows_app_user_model_id()
+
     initial_flow_path: Path | None = None
     if args.flow:
         initial_flow_path = _resolve_flow_arg(args.flow)
@@ -122,6 +163,7 @@ def main(argv: list[str]) -> int:
     # build the full caption ourselves, so clear the display name.
     app.setApplicationDisplayName("")
     app.setApplicationVersion(APP_VERSION)
+    app.setWindowIcon(_load_app_icon())
     apply_dark_theme(app)
 
     # Decide which monitor we're launching on before creating any


### PR DESCRIPTION
## Summary
This PR adds proper application icon support with Windows taskbar integration. The app now displays a custom icon in window title bars and taskbar entries on all platforms, with special handling for Windows to ensure the correct icon appears in the taskbar.

## Key Changes
- **Icon Loading**: Added `_load_app_icon()` function that loads the application icon with fallback support:
  - Prefers multi-resolution `.ico` format (better for Windows)
  - Falls back to `.png` if `.ico` is unavailable
  - Gracefully handles missing assets with an empty icon as last resort
  
- **Windows Taskbar Integration**: Added `_set_windows_app_user_model_id()` function that:
  - Sets an explicit `AppUserModelID` on Windows before `QApplication` initialization
  - Prevents Python-hosted apps from inheriting the generic `python.exe` icon in the taskbar
  - Silently skips on non-Windows platforms
  
- **Constants**: Added new constants in `constants.py`:
  - `APP_ICON_PATH`: Path to the primary `.ico` icon file
  - `APP_ICON_FALLBACK_PATH`: Path to the fallback `.png` icon file
  - `APP_USER_MODEL_ID`: Windows AppUserModelID string for taskbar grouping
  
- **Application Setup**: Updated `main()` to:
  - Call `_set_windows_app_user_model_id()` before creating `QApplication`
  - Set the loaded icon via `app.setWindowIcon()`
  
- **Debug Configuration**: Enhanced VS Code launch configurations with:
  - Proper working directory and `PYTHONPATH` setup
  - Disabled `justMyCode` for better debugging experience

## Implementation Details
The Windows AppUserModelID must be set before `QApplication` initialization to ensure the taskbar entry is created with the correct identity from the start. The icon loading uses a try-first approach with comprehensive fallback handling to ensure startup never fails due to missing or corrupted icon assets.

https://claude.ai/code/session_01NohK2Lj8FgZY9XsSCYpCWX