### PR TITLE
Refactor file paths to be relative to OUTPUT_DIR

### DIFF
--- a/flow/Untitled_flow.flowjs
+++ b/flow/Untitled_flow.flowjs
@@ -33,7 +33,7 @@
         -652.0
       ],
       "params": {
-        "output_path": "output/out.png"
+        "output_path": "out.png"
       }
     }
   ],

--- a/flow/debug_error.flowjs
+++ b/flow/debug_error.flowjs
@@ -33,7 +33,7 @@
         -652.0
       ],
       "params": {
-        "output_path": "output/out.png"
+        "output_path": "out.png"
       }
     }
   ],

--- a/flow/jjj.flowjs
+++ b/flow/jjj.flowjs
@@ -24,7 +24,7 @@
         -398.0
       ],
       "params": {
-        "output_path": "output/out.png"
+        "output_path": "out.png"
       }
     }
   ],

--- a/flow/mosaic.flowjs
+++ b/flow/mosaic.flowjs
@@ -36,7 +36,7 @@
         -830.9250736530222
       ],
       "params": {
-        "output_path": "output/out.png"
+        "output_path": "out.png"
       }
     }
   ],

--- a/flow/rgb_dither.flowjs
+++ b/flow/rgb_dither.flowjs
@@ -33,7 +33,7 @@
         -600.0
       ],
       "params": {
-        "output_path": "output/out.png"
+        "output_path": "out.png"
       }
     },
     {

--- a/flow/rgb_split.flowjs
+++ b/flow/rgb_split.flowjs
@@ -31,7 +31,7 @@
         -661.9506808931591
       ],
       "params": {
-        "output_path": "output/out.png"
+        "output_path": "out.png"
       }
     },
     {

--- a/flow/test_dither.flowjs
+++ b/flow/test_dither.flowjs
@@ -23,7 +23,7 @@
         -562.0
       ],
       "params": {
-        "output_path": "output/out.png"
+        "output_path": "out.png"
       }
     },
     {

--- a/flow/tt.flowjs
+++ b/flow/tt.flowjs
@@ -24,7 +24,7 @@
         -489.20442937499996
       ],
       "params": {
-        "output_path": "output/dither_rgbout.png"
+        "output_path": "dither_rgbout.png"
       }
     },
     {

--- a/src/nodes/sinks/file_sink.py
+++ b/src/nodes/sinks/file_sink.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
-import os
 from enum import Enum
+from pathlib import Path
 
 import cv2
 from typing_extensions import override
 
+from constants import OUTPUT_DIR
 from core.io_data import IMAGE_TYPES
 from core.node_base import SinkNodeBase, NodeParam, NodeParamType
 from core.port import InputPort
@@ -17,10 +18,19 @@ class OutputFormat(Enum):
 
 
 class FileSink(SinkNodeBase):
+    """Sink node that writes the incoming frame to disk.
+
+    Paths inside the application's :data:`OUTPUT_DIR` are stored — and
+    therefore displayed — relative to that folder. Anything outside is kept
+    as an absolute path. Relative paths are resolved against ``OUTPUT_DIR``
+    at run time, which keeps saved flows portable across machines that
+    share the same output layout.
+    """
+
     def __init__(self):
         super().__init__("File Sink", section="Sinks")
 
-        self._output_path: str = "output/out.png"
+        self._output_path: Path = Path("out.png")
         self._output_format: OutputFormat = OutputFormat.SAME_AS_INPUT
 
         self._add_input(InputPort("image", set(IMAGE_TYPES)))
@@ -33,7 +43,7 @@ class FileSink(SinkNodeBase):
     @property
     @override
     def params(self) -> list[NodeParam]:
-        return [NodeParam("output_path", NodeParamType.FILE_PATH, {"default": "output/out.png", "mode": "save"})]
+        return [NodeParam("output_path", NodeParamType.FILE_PATH, {"default": "out.png", "mode": "save"})]
 
     # ── Properties ─────────────────────────────────────────────────────────────
 
@@ -46,24 +56,38 @@ class FileSink(SinkNodeBase):
         self._output_format = output_format
 
     @property
-    def output_path(self) -> str:
+    def output_path(self) -> Path:
         return self._output_path
 
     @output_path.setter
-    def output_path(self, output_path: str) -> None:
-        self._output_path = output_path
+    def output_path(self, output_path: str | Path) -> None:
+        p = Path(output_path)
+        if p.is_absolute():
+            try:
+                p = p.resolve().relative_to(OUTPUT_DIR.resolve())
+            except (OSError, ValueError):
+                pass  # outside OUTPUT_DIR — keep absolute
+        self._output_path = p
 
     # ── SinkNodeBase interface ──────────────────────────────────────────────────
 
     @override
     def process_impl(self) -> None:
-        file_name, file_ext = os.path.splitext(self._output_path)
+        resolved = self._resolved_path()
 
         if self._output_format == OutputFormat.SAME_AS_INPUT:
-            output = file_name + file_ext
+            output = resolved
         elif self._output_format == OutputFormat.PNG:
-            output = file_name + ".png"
+            output = resolved.with_suffix(".png")
         else:
             raise ValueError(f"Unsupported output format: {self._output_format}")
 
-        cv2.imwrite(output, self.inputs[0].data.image)
+        cv2.imwrite(str(output), self.inputs[0].data.image)
+
+    # ── Internals ──────────────────────────────────────────────────────────────
+
+    def _resolved_path(self) -> Path:
+        """Return an absolute path; relative values are joined with OUTPUT_DIR."""
+        if self._output_path.is_absolute():
+            return self._output_path
+        return OUTPUT_DIR / self._output_path

--- a/src/ui/flow_scene.py
+++ b/src/ui/flow_scene.py
@@ -145,6 +145,29 @@ class FlowScene(QGraphicsScene):
             y += item.boundingRect().height() + self.STACK_GAP
         return len(items)
 
+    def stack_selected_horizontally(self) -> int:
+        """Align selected nodes on a single Y axis and stack them horizontally.
+
+        Preserves the current left-to-right order (nodes further left on the
+        canvas stay left in the new stack). All selected nodes are anchored
+        to the topmost selected Y so they share a horizontal axis; each
+        subsequent node is placed to the right of the previous one with a
+        fixed :data:`STACK_GAP` between their bounding boxes. Returns the
+        number of nodes that were moved (two or more selected nodes required
+        — otherwise a no-op).
+        """
+        items = [s for s in self.selectedItems() if isinstance(s, NodeItem)]
+        if len(items) < 2:
+            return 0
+        items.sort(key=lambda it: it.pos().x())
+        y = min(it.pos().y() for it in items)
+        x = items[0].pos().x()
+        for item in items:
+            item.setPos(x, y)
+            item.refresh_all_links()
+            x += item.boundingRect().width() + self.STACK_GAP
+        return len(items)
+
     def _delete_node_item(self, item: NodeItem) -> None:
         if self._flow is not None:
             try:

--- a/src/ui/icons.py
+++ b/src/ui/icons.py
@@ -43,6 +43,7 @@ _CODEPOINTS: Final[dict[str, str]] = {
     "zoom_out_map": "e56b",
     "fullscreen_exit": "e5d1",
     "view_stream": "e8f2",
+    "view_column": "e8ec",
     "description":  "e873",
     "visibility":   "e8f4",
 }

--- a/src/ui/icons.py
+++ b/src/ui/icons.py
@@ -44,6 +44,7 @@ _CODEPOINTS: Final[dict[str, str]] = {
     "fullscreen_exit": "e5d1",
     "view_stream": "e8f2",
     "description":  "e873",
+    "visibility":   "e8f4",
 }
 
 

--- a/src/ui/node_editor_page.py
+++ b/src/ui/node_editor_page.py
@@ -120,9 +120,10 @@ class NodeEditorPage(PageBase):
 
         # Actions: reused by both the page menu and the main toolbar.
         self._actions = self._build_actions()
-        # V-Stack needs at least two selected nodes; keep it disabled until
-        # that is true and toggle it on selection changes.
+        # Stack actions need at least two selected nodes; keep them disabled
+        # until that is true and toggle them on selection changes.
         self._actions["stack_vertical"].setEnabled(False)
+        self._actions["stack_horizontal"].setEnabled(False)
         self._scene.selectionChanged.connect(self._update_selection_actions)
 
         # Status bar at the bottom of the inner window.
@@ -184,6 +185,7 @@ class NodeEditorPage(PageBase):
                 self._actions["fit"],
                 self._actions["reset_zoom"],
                 self._actions["stack_vertical"],
+                self._actions["stack_horizontal"],
             ]),
         ]
 
@@ -293,6 +295,9 @@ class NodeEditorPage(PageBase):
             "stack_vertical": mk(
                 "V-Stack", "view_stream", self._on_stack_vertical_clicked,
             ),
+            "stack_horizontal": mk(
+                "H-Stack", "view_column", self._on_stack_horizontal_clicked,
+            ),
         }
 
     # ── Action handlers ────────────────────────────────────────────────────────
@@ -304,10 +309,15 @@ class NodeEditorPage(PageBase):
             1 for s in self._scene.selectedItems() if isinstance(s, NodeItem)
         )
         self._actions["stack_vertical"].setEnabled(selected_nodes >= 2)
+        self._actions["stack_horizontal"].setEnabled(selected_nodes >= 2)
 
     def _on_stack_vertical_clicked(self) -> None:
         """Align selected nodes on a shared X axis and stack them vertically."""
         self._scene.stack_selected_vertically()
+
+    def _on_stack_horizontal_clicked(self) -> None:
+        """Align selected nodes on a shared Y axis and stack them horizontally."""
+        self._scene.stack_selected_horizontally()
 
     def _on_viewer_top_level_changed(self, floating: bool) -> None:
         """Promote the floating Output Inspector to a real top-level window.

--- a/src/ui/param_widgets.py
+++ b/src/ui/param_widgets.py
@@ -267,8 +267,15 @@ class FilePathParamWidget(ParamWidgetBase):
 
     def _browse(self) -> None:
         current = self._line.text() or ""
-        folder = Path(current).parent.resolve()
         fallback = OUTPUT_DIR if self._is_save else INPUT_DIR
+        # Relative values (e.g. "out.png" or "example.jpg") are stored
+        # relative to OUTPUT_DIR / INPUT_DIR, so resolve against that base
+        # before taking the parent — otherwise the dialog would open in
+        # the process CWD instead of the folder the file actually lives in.
+        path_obj = Path(current)
+        if not path_obj.is_absolute():
+            path_obj = fallback / path_obj
+        folder = path_obj.parent.resolve()
         initial = str(folder) if folder.is_dir() else str(fallback)
 
         if self._is_save:

--- a/src/ui/param_widgets.py
+++ b/src/ui/param_widgets.py
@@ -242,9 +242,6 @@ class FilePathParamWidget(ParamWidgetBase):
         # inside the fixed-width node body, otherwise the line edit overflows
         # and visually overlaps the button.
         self._line.setMinimumWidth(80)
-        self._line.textChanged.connect(self._on_value_changed)
-        self._line.textChanged.connect(self._update_view_enabled)
-        self._line.setText(str(self._initial_value("")))
 
         browse = QPushButton("...")
         browse.setFixedWidth(36)
@@ -255,6 +252,12 @@ class FilePathParamWidget(ParamWidgetBase):
         self._view.setFixedWidth(36)
         self._view.setToolTip("Open in system image viewer")
         self._view.clicked.connect(self._open_in_viewer)
+
+        # Connect textChanged and seed the initial value only once
+        # self._view exists, since _update_view_enabled touches it.
+        self._line.textChanged.connect(self._on_value_changed)
+        self._line.textChanged.connect(self._update_view_enabled)
+        self._line.setText(str(self._initial_value("")))
         self._update_view_enabled()
 
         layout = QHBoxLayout(self)

--- a/src/ui/param_widgets.py
+++ b/src/ui/param_widgets.py
@@ -6,7 +6,8 @@ from pathlib import Path
 
 from typing_extensions import override
 
-from PySide6.QtCore import Qt, Signal
+from PySide6.QtCore import Qt, QUrl, Signal
+from PySide6.QtGui import QDesktopServices
 from PySide6.QtWidgets import (
     QCheckBox,
     QFileDialog,
@@ -20,6 +21,7 @@ from PySide6.QtWidgets import (
 from constants import INPUT_DIR, OUTPUT_DIR
 from core.node_base import NodeBase, NodeParam, NodeParamType
 from ui.controls.scene_aware_combobox import SceneAwareComboBox
+from ui.icons import material_icon
 
 logger = logging.getLogger(__name__)
 
@@ -241,17 +243,26 @@ class FilePathParamWidget(ParamWidgetBase):
         # and visually overlaps the button.
         self._line.setMinimumWidth(80)
         self._line.textChanged.connect(self._on_value_changed)
+        self._line.textChanged.connect(self._update_view_enabled)
         self._line.setText(str(self._initial_value("")))
 
         browse = QPushButton("...")
         browse.setFixedWidth(36)
         browse.clicked.connect(self._browse)
 
+        self._view = QPushButton()
+        self._view.setIcon(material_icon("visibility"))
+        self._view.setFixedWidth(36)
+        self._view.setToolTip("Open in system image viewer")
+        self._view.clicked.connect(self._open_in_viewer)
+        self._update_view_enabled()
+
         layout = QHBoxLayout(self)
         layout.setContentsMargins(0, 0, 0, 0)
         layout.setSpacing(4)
         layout.addWidget(self._line, 1)
         layout.addWidget(browse, 0)
+        layout.addWidget(self._view, 0)
 
     def _on_value_changed(self, value: str) -> None:
         self._write_to_node(value)
@@ -299,7 +310,28 @@ class FilePathParamWidget(ParamWidgetBase):
                 self._line.setText(canonical)
             finally:
                 self._line.blockSignals(False)
+            self._update_view_enabled()
             self.value_changed.emit(canonical)
+
+    def _resolved_current_path(self) -> Path:
+        """Return the absolute path referenced by the line edit.
+
+        Relative values are joined with ``OUTPUT_DIR`` / ``INPUT_DIR``
+        to match how the corresponding node setters resolve them.
+        """
+        base = OUTPUT_DIR if self._is_save else INPUT_DIR
+        p = Path(self._line.text() or "")
+        if not p.is_absolute():
+            p = base / p
+        return p
+
+    def _update_view_enabled(self) -> None:
+        self._view.setEnabled(self._resolved_current_path().is_file())
+
+    def _open_in_viewer(self) -> None:
+        path = self._resolved_current_path()
+        if path.is_file():
+            QDesktopServices.openUrl(QUrl.fromLocalFile(str(path)))
 
 
 # ── Registry & factory ─────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
Refactored the FileSink node to store and manage output paths relative to `OUTPUT_DIR`, improving portability of flows across machines with shared output layouts.

## Key Changes

- **FileSink path handling**: Changed `_output_path` from `str` to `Path` type for better path manipulation
  - Paths inside `OUTPUT_DIR` are now stored relative to that folder
  - Absolute paths outside `OUTPUT_DIR` are preserved as-is
  - Relative paths are resolved against `OUTPUT_DIR` at runtime via new `_resolved_path()` method

- **Path normalization**: Updated the `output_path` setter to automatically convert absolute paths to relative paths when they fall within `OUTPUT_DIR`, with fallback to keep absolute paths for files outside the output directory

- **UI improvements**: Enhanced the file browser dialog in `param_widgets.py` to correctly resolve relative paths against their base directory (`OUTPUT_DIR` or `INPUT_DIR`) before opening the folder picker, ensuring the dialog opens in the expected location

- **Flow file updates**: Updated all flow files to use relative paths (e.g., `"out.png"` instead of `"output/out.png"`)

## Implementation Details

- Added `_resolved_path()` helper method to FileSink that joins relative paths with `OUTPUT_DIR` and returns absolute paths as-is
- Updated `process_impl()` to use `Path` methods (`with_suffix()`) instead of string manipulation
- Added comprehensive docstring to FileSink explaining the path resolution behavior
- Maintained backward compatibility by accepting both `str` and `Path` types in the `output_path` setter

https://claude.ai/code/session_014HCwGWmvDhJ4Lpebk47JX4