### PR TITLE
Add Merge node for 2x2 image composites

### DIFF
--- a/src/nodes/filters/merge.py
+++ b/src/nodes/filters/merge.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import cv2
+import numpy as np
+from typing_extensions import override
+
+from core.io_data import IMAGE_TYPES, IoData, IoDataType
+from core.node_base import NodeBase, NodeParam
+from core.port import InputPort, OutputPort
+
+
+class Merge(NodeBase):
+    """Composite up to four images into a 2x2 grid.
+
+    Inputs ``top_left``, ``top_right``, ``bottom_left`` and ``bottom_right``
+    are pasted into the corresponding quadrant of a single output canvas.
+    Not every input has to be connected — missing quadrants become black.
+
+    Size strategy (per row / per column):
+      * Top-row height  = max(top_left.h, top_right.h)
+      * Bottom-row ""   = max(bottom_left.h, bottom_right.h)
+      * Left-column width  = max(top_left.w, bottom_left.w)
+      * Right-column ""    = max(top_right.w, bottom_right.w)
+      A row/column whose quadrants are all unconnected contributes 0.
+      Quadrants smaller than their cell are top-left aligned and padded
+      with black on the right / bottom edges.
+
+    Type strategy (promote to widest):
+      If any connected input is colour (:data:`IoDataType.IMAGE`), every
+      grayscale input is promoted to BGR via ``cv2.cvtColor(...,
+      COLOR_GRAY2BGR)`` and the output is emitted as ``IMAGE``. If every
+      connected input is :data:`IoDataType.IMAGE_GREY`, the output stays
+      grayscale.
+    """
+
+    _QUADRANTS = ("top_left", "top_right", "bottom_left", "bottom_right")
+
+    def __init__(self) -> None:
+        super().__init__("Merge", section="Composit")
+        for name in self._QUADRANTS:
+            self._add_input(InputPort(name, set(IMAGE_TYPES)))
+        self._add_output(OutputPort("image", set(IMAGE_TYPES)))
+
+    # ── Parameters ─────────────────────────────────────────────────────────────
+
+    @property
+    @override
+    def params(self) -> list[NodeParam]:
+        return []
+
+    # ── NodeBase interface ─────────────────────────────────────────────────────
+
+    @override
+    def _signal_input_ready(self) -> None:
+        """Fire when every *connected* input has delivered data.
+
+        Overrides the default (all-inputs-ready) because Merge deliberately
+        supports partial connections — unconnected ports never receive
+        anything, so waiting on them would deadlock the node.
+        """
+        connected = [p for p in self._inputs if p.upstream is not None]
+        if not connected or not all(p.has_data for p in connected):
+            return
+
+        if any(p.data.is_end_of_stream() for p in connected):
+            self._on_end_of_stream()
+        else:
+            self.process()
+
+        for p in connected:
+            p.clear()
+
+    @override
+    def process_impl(self) -> None:
+        # Collect the IoData for every quadrant (None when unconnected).
+        quads: list[IoData | None] = [
+            p.data if p.has_data else None for p in self._inputs
+        ]
+        tl, tr, bl, br = quads
+
+        # "Promote to colour" — if any input is colour, output is colour.
+        any_color = any(
+            q is not None and q.type == IoDataType.IMAGE for q in quads
+        )
+
+        def cell(q: IoData | None) -> np.ndarray | None:
+            if q is None:
+                return None
+            img = q.image
+            if any_color and q.type == IoDataType.IMAGE_GREY:
+                return cv2.cvtColor(img, cv2.COLOR_GRAY2BGR)
+            return img
+
+        tl_img, tr_img, bl_img, br_img = cell(tl), cell(tr), cell(bl), cell(br)
+
+        def max_dim(imgs: tuple[np.ndarray | None, ...], axis: int) -> int:
+            return max((img.shape[axis] for img in imgs if img is not None), default=0)
+
+        top_h    = max_dim((tl_img, tr_img), 0)
+        bottom_h = max_dim((bl_img, br_img), 0)
+        left_w   = max_dim((tl_img, bl_img), 1)
+        right_w  = max_dim((tr_img, br_img), 1)
+
+        total_h = top_h + bottom_h
+        total_w = left_w + right_w
+        if total_h == 0 or total_w == 0:
+            return  # nothing to emit — every connected quadrant was empty
+
+        if any_color:
+            canvas = np.zeros((total_h, total_w, 3), dtype=np.uint8)
+        else:
+            canvas = np.zeros((total_h, total_w), dtype=np.uint8)
+
+        def paste(img: np.ndarray | None, y0: int, x0: int) -> None:
+            if img is None:
+                return
+            h, w = img.shape[:2]
+            canvas[y0:y0 + h, x0:x0 + w] = img
+
+        paste(tl_img, 0,     0)
+        paste(tr_img, 0,     left_w)
+        paste(bl_img, top_h, 0)
+        paste(br_img, top_h, left_w)
+
+        if any_color:
+            self.outputs[0].send(IoData.from_image(canvas))
+        else:
+            self.outputs[0].send(IoData.from_greyscale(canvas))

--- a/src/ui/node_list.py
+++ b/src/ui/node_list.py
@@ -29,6 +29,7 @@ _SECTION_ORDER: tuple[str, ...] = (
     "Color Spaces",
     "Transform",
     "Processing",
+    "Composit",
 )
 
 

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -1,0 +1,157 @@
+"""Unit tests for the Merge (2x2 composite) node."""
+from __future__ import annotations
+
+import numpy as np
+
+from core.io_data import IoData, IoDataType
+from core.port import OutputPort
+from nodes.filters.merge import Merge
+
+
+def _bgr(h: int, w: int, value: int) -> np.ndarray:
+    return np.full((h, w, 3), value, dtype=np.uint8)
+
+
+def _grey(h: int, w: int, value: int) -> np.ndarray:
+    return np.full((h, w), value, dtype=np.uint8)
+
+
+def _wire(node: Merge, quadrants: dict[str, IoData]) -> None:
+    """Connect a fake upstream per quadrant, then send all the data.
+
+    Merge only fires once every *connected* input has data, so every
+    upstream must be connected before any send() runs — otherwise the
+    node fires after the first frame with only one input ready.
+    """
+    upstreams: list[tuple[OutputPort, IoData]] = []
+    for name, data in quadrants.items():
+        idx = node._QUADRANTS.index(name)
+        up = OutputPort(name, {data.type})
+        up.connect(node.inputs[idx])
+        upstreams.append((up, data))
+    for up, data in upstreams:
+        up.send(data)
+
+
+def test_merge_all_four_color_inputs_builds_2x2_grid() -> None:
+    node = Merge()
+    _wire(node, {
+        "top_left":     IoData.from_image(_bgr(4, 6, 10)),
+        "top_right":    IoData.from_image(_bgr(4, 6, 20)),
+        "bottom_left":  IoData.from_image(_bgr(4, 6, 30)),
+        "bottom_right": IoData.from_image(_bgr(4, 6, 40)),
+    })
+
+    out = node.outputs[0].last_emitted
+    assert out is not None
+    assert out.type == IoDataType.IMAGE
+    assert out.image.shape == (8, 12, 3)
+    assert out.image[0, 0, 0] == 10
+    assert out.image[0, 6, 0] == 20
+    assert out.image[4, 0, 0] == 30
+    assert out.image[4, 6, 0] == 40
+
+
+def test_merge_all_greyscale_inputs_emits_greyscale() -> None:
+    node = Merge()
+    _wire(node, {
+        "top_left":     IoData.from_greyscale(_grey(3, 5, 10)),
+        "top_right":    IoData.from_greyscale(_grey(3, 5, 20)),
+        "bottom_left":  IoData.from_greyscale(_grey(3, 5, 30)),
+        "bottom_right": IoData.from_greyscale(_grey(3, 5, 40)),
+    })
+
+    out = node.outputs[0].last_emitted
+    assert out is not None
+    assert out.type == IoDataType.IMAGE_GREY
+    assert out.image.shape == (6, 10)
+    assert out.image[0, 0] == 10
+    assert out.image[0, 5] == 20
+    assert out.image[3, 0] == 30
+    assert out.image[3, 5] == 40
+
+
+def test_merge_mixed_types_promotes_to_color() -> None:
+    node = Merge()
+    _wire(node, {
+        "top_left":  IoData.from_greyscale(_grey(2, 2, 77)),
+        "top_right": IoData.from_image(_bgr(2, 2, 200)),
+    })
+
+    out = node.outputs[0].last_emitted
+    assert out is not None
+    assert out.type == IoDataType.IMAGE
+    # Grey quadrant is promoted to BGR, so every channel should equal 77.
+    np.testing.assert_array_equal(out.image[0:2, 0:2], _bgr(2, 2, 77))
+    np.testing.assert_array_equal(out.image[0:2, 2:4], _bgr(2, 2, 200))
+
+
+def test_merge_partial_inputs_pads_missing_quadrants_with_black() -> None:
+    node = Merge()
+    # Only TL and BR connected — canvas size comes from those two, TR and
+    # BL cells stay zero.
+    _wire(node, {
+        "top_left":     IoData.from_image(_bgr(4, 5, 111)),
+        "bottom_right": IoData.from_image(_bgr(6, 7, 222)),
+    })
+
+    out = node.outputs[0].last_emitted
+    assert out is not None
+    assert out.image.shape == (10, 12, 3)
+    np.testing.assert_array_equal(out.image[0:4, 0:5], _bgr(4, 5, 111))
+    np.testing.assert_array_equal(out.image[4:10, 5:12], _bgr(6, 7, 222))
+    # Missing TR cell (rows 0:4, cols 5:12) is black.
+    assert out.image[0:4, 5:12].sum() == 0
+    # Missing BL cell (rows 4:10, cols 0:5) is black.
+    assert out.image[4:10, 0:5].sum() == 0
+
+
+def test_merge_row_and_column_heights_take_per_axis_max() -> None:
+    node = Merge()
+    _wire(node, {
+        "top_left":  IoData.from_image(_bgr(4, 5, 10)),  # tall + narrow
+        "top_right": IoData.from_image(_bgr(2, 7, 20)),  # short + wide
+    })
+
+    out = node.outputs[0].last_emitted
+    assert out is not None
+    # top_h = max(4, 2) = 4; bottom row is empty so bottom_h = 0;
+    # left_w = 5; right_w = 7 → canvas = (4, 12).
+    assert out.image.shape == (4, 12, 3)
+    # TR is 2 rows tall but its cell is 4 rows — rows 2:4, cols 5:12 are pad.
+    assert out.image[2:4, 5:12].sum() == 0
+
+
+def test_merge_does_not_fire_until_every_connected_input_has_data() -> None:
+    node = Merge()
+    # Connect upstreams but only push data into two of them.
+    up0 = OutputPort("a", {IoDataType.IMAGE})
+    up1 = OutputPort("b", {IoDataType.IMAGE})
+    up2 = OutputPort("c", {IoDataType.IMAGE})
+    up0.connect(node.inputs[0])
+    up1.connect(node.inputs[1])
+    up2.connect(node.inputs[2])
+    up0.send(IoData.from_image(_bgr(2, 2, 1)))
+    up1.send(IoData.from_image(_bgr(2, 2, 2)))
+
+    assert node.outputs[0].last_emitted is None
+
+    up2.send(IoData.from_image(_bgr(2, 2, 3)))
+    assert node.outputs[0].last_emitted is not None
+
+
+def test_merge_forwards_end_of_stream() -> None:
+    from core.port import InputPort
+
+    node = Merge()
+    up = OutputPort("a", {IoDataType.IMAGE})
+    up.connect(node.inputs[0])
+
+    downstream_received: list[IoData] = []
+    sink = InputPort("sink", {IoDataType.IMAGE})
+    sink.set_on_data_received(lambda: downstream_received.append(sink.data))
+    node.outputs[0].connect(sink)
+
+    up.send(IoData.end_of_stream())
+
+    assert any(d.is_end_of_stream() for d in downstream_received)


### PR DESCRIPTION
## Summary
- New `Merge` node in a new **Composit** palette section. Four optional inputs — `top_left`, `top_right`, `bottom_left`, `bottom_right` — are pasted into the matching quadrant of a single output image.
- **Size strategy (per-axis max):** top-row height = `max(TL.h, TR.h)`, bottom = `max(BL.h, BR.h)`; left-col width = `max(TL.w, BL.w)`, right = `max(TR.w, BR.w)`. Missing quadrants contribute `0`; smaller cells are top-left aligned and padded with black (no stretching, no data loss).
- **Type strategy (promote to widest):** if any connected input is colour, grey inputs are `cvtColor`'d to BGR and the output is `IMAGE`; if every connected input is grey the output stays `IMAGE_GREY`.
- Overrides `_signal_input_ready` so the node fires once every *connected* input has data — the default dispatcher waits for every input, which would deadlock with partial wiring.

## Test plan
- [x] `pytest tests/test_merge.py` — 7 new tests: 4-quadrant colour grid, 4-quadrant grey grid, mixed-type promotion, partial-connection padding, per-axis max sizing, dispatcher fires only once every connected input has data, EOS forwarding.
- [x] `pytest tests/` — full suite, 41 passed.
- [ ] Drop the node onto the canvas, wire 1–4 `ImageSource`s into its inputs, and confirm the palette shows it under **Composit** and the composite renders as expected in the Output Inspector.

https://claude.ai/code/session_014HCwGWmvDhJ4Lpebk47JX4