### PR TITLE
Refresh param widgets after flow runs to update filesystem state

### DIFF
--- a/src/ui/node_editor_page.py
+++ b/src/ui/node_editor_page.py
@@ -357,7 +357,13 @@ class NodeEditorPage(PageBase):
             detail = str(err).strip() or "(no message)"
             self._set_status(f"Run failed ({type(err).__name__}): {detail}", kind="fail")
             return
-        
+
+        # Sinks may have just written output files; let every node's
+        # param widgets re-evaluate filesystem-dependent state (e.g.
+        # the FilePathParamWidget "view" button).
+        for item in self._scene.iter_node_items():
+            item.refresh_param_widgets()
+
         self._set_status(
             f"Ran at {datetime.now().strftime('%H:%M:%S')}",
             kind="ok",

--- a/src/ui/node_item.py
+++ b/src/ui/node_item.py
@@ -165,6 +165,7 @@ class NodeItem(QGraphicsItem):
         self._input_ports: list[PortItem] = []
         self._output_ports: list[PortItem] = []
         self._params_widget: QWidget | None = None  # container; holds ParamWidgetBases
+        self._param_widgets: list[ParamWidgetBase] = []
         self._proxy: QGraphicsProxyWidget | None = None
         self._params_height: float = 0.0
         self._body_height: float = 0.0
@@ -363,6 +364,16 @@ class NodeItem(QGraphicsItem):
         content = max(header_need, port_need, params_need)
         return max(self.MIN_WIDTH, min(self.MAX_WIDTH, content))
 
+    def refresh_param_widgets(self) -> None:
+        """Ask every param widget to re-evaluate external state.
+
+        Used by the editor after a flow run so that e.g. FileSink's
+        ``view`` button can recognise output files that have just
+        appeared on disk.
+        """
+        for editor in self._param_widgets:
+            editor.refresh()
+
     def _build_params_widget(self) -> None:
         if not self._node.params:
             return
@@ -381,6 +392,7 @@ class NodeItem(QGraphicsItem):
             if editor is not None:
                 editor.value_changed.connect(lambda _v: self._signals.param_changed.emit())
                 layout.addWidget(editor)
+                self._param_widgets.append(editor)
             else:
                 layout.addWidget(QLabel(f"(unsupported: {param.param_type.name})"))
 

--- a/src/ui/param_widgets.py
+++ b/src/ui/param_widgets.py
@@ -60,6 +60,15 @@ class ParamWidgetBase(QWidget):
         """Return the widget's current value."""
         raise NotImplementedError
 
+    def refresh(self) -> None:
+        """Re-evaluate any state that depends on external conditions.
+
+        Default is a no-op. Widgets whose enabled state depends on
+        things the Qt signal machinery doesn't track — e.g. whether a
+        file on disk exists — override this so the host page can ask
+        every param widget to re-check after events like a flow run.
+        """
+
     # ── Helpers shared by all subclasses ───────────────────────────────────────
 
     def _initial_value(self, fallback: object) -> object:
@@ -330,6 +339,14 @@ class FilePathParamWidget(ParamWidgetBase):
 
     def _update_view_enabled(self) -> None:
         self._view.setEnabled(self._resolved_current_path().is_file())
+
+    @override
+    def refresh(self) -> None:
+        # The view button's enabled state depends on whether the file
+        # exists on disk — something a flow run can change. Re-check so
+        # sinks that just wrote their output light up without the user
+        # having to edit the path.
+        self._update_view_enabled()
 
     def _open_in_viewer(self) -> None:
         path = self._resolved_current_path()


### PR DESCRIPTION
## Summary
Add a refresh mechanism for parameter widgets to re-evaluate state that depends on external conditions (like filesystem changes) after a flow run completes. This allows widgets like FileSink's "view" button to recognize newly created output files without requiring user interaction.

## Key Changes
- **ParamWidgetBase**: Added `refresh()` method as an extension point for subclasses to re-evaluate external state
- **FilePathParamWidget**: Implemented `refresh()` to re-check if the target file exists on disk and update the "view" button's enabled state accordingly
- **NodeItem**: Added `_param_widgets` list to track all parameter widgets and `refresh_param_widgets()` method to trigger refresh on all contained widgets
- **NodeEditorPage**: After a successful flow run, iterate through all nodes and call `refresh_param_widgets()` to update filesystem-dependent state

## Implementation Details
The refresh mechanism is designed as a no-op by default in the base class, allowing only widgets with external state dependencies to override it. This keeps the architecture clean and avoids unnecessary work for simple widgets. The refresh is triggered at the editor level after a successful run, ensuring all nodes get a chance to update their state based on changes made by the flow execution.

https://claude.ai/code/session_014HCwGWmvDhJ4Lpebk47JX4