### PR TITLE
Run flows asynchronously on worker thread with UI feedback

### DIFF
--- a/flow/delay.flowjs
+++ b/flow/delay.flowjs
@@ -1,0 +1,56 @@
+{
+  "version": 1,
+  "name": "delay",
+  "nodes": [
+    {
+      "id": 0,
+      "module": "nodes.filters.delay",
+      "class": "Delay",
+      "position": [
+        -1076.0,
+        -361.0
+      ],
+      "params": {
+        "delay_seconds": 5.0
+      }
+    },
+    {
+      "id": 1,
+      "module": "nodes.sources.image_source",
+      "class": "ImageSource",
+      "position": [
+        -1382.0,
+        -363.0
+      ],
+      "params": {
+        "file_path": "ship.jpg"
+      }
+    },
+    {
+      "id": 2,
+      "module": "nodes.sinks.file_sink",
+      "class": "FileSink",
+      "position": [
+        -779.0,
+        -361.0
+      ],
+      "params": {
+        "output_path": "out.png"
+      }
+    }
+  ],
+  "connections": [
+    {
+      "src_node": 1,
+      "src_output": 0,
+      "dst_node": 0,
+      "dst_input": 0
+    },
+    {
+      "src_node": 0,
+      "src_output": 0,
+      "dst_node": 2,
+      "dst_input": 0
+    }
+  ]
+}

--- a/src/core/flow_runner.py
+++ b/src/core/flow_runner.py
@@ -5,6 +5,7 @@ import logging
 from PySide6.QtCore import QObject, Signal, Slot
 
 from core.flow import Flow
+from core.node_base import NodeBase, set_process_observer
 
 logger = logging.getLogger(__name__)
 
@@ -14,7 +15,7 @@ class FlowRunner(QObject):
 
     Intended to be moved onto a :class:`QThread` so expensive
     ``process_impl`` calls do not stall the Qt event loop. The runner
-    holds no UI state; it only exposes two queued signals the caller can
+    holds no UI state; it only exposes queued signals the caller can
     connect to slots on the main thread:
 
       - :attr:`finished` — emitted once the source nodes have fully
@@ -24,10 +25,14 @@ class FlowRunner(QObject):
         letting them propagate across the thread boundary, which Qt
         cannot marshal) so the UI can show a banner instead of
         crashing the worker.
+      - :attr:`node_started` — emitted with the node's display name
+        just before each :meth:`NodeBase.process_impl` call. The UI
+        uses this to show which node is currently running.
     """
 
     finished = Signal()
     failed = Signal(str)
+    node_started = Signal(str)
 
     def __init__(self, flow: Flow, parent: QObject | None = None) -> None:
         super().__init__(parent)
@@ -35,6 +40,12 @@ class FlowRunner(QObject):
 
     @Slot()
     def run(self) -> None:
+        # Route every node's process() call through our node_started
+        # signal. The observer fires on the worker thread, but the
+        # signal carries across via a queued connection so the UI slot
+        # sees it on the main thread. The install/clear pair is a
+        # try/finally so we don't leak the hook when a run raises.
+        set_process_observer(self._on_node_processing)
         try:
             self._flow.run()
         except Exception as err:
@@ -42,4 +53,9 @@ class FlowRunner(QObject):
             detail = str(err).strip() or "(no message)"
             self.failed.emit(f"{type(err).__name__}: {detail}")
             return
+        finally:
+            set_process_observer(None)
         self.finished.emit()
+
+    def _on_node_processing(self, node: NodeBase) -> None:
+        self.node_started.emit(node.display_name)

--- a/src/core/flow_runner.py
+++ b/src/core/flow_runner.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import logging
+
+from PySide6.QtCore import QObject, Signal, Slot
+
+from core.flow import Flow
+
+logger = logging.getLogger(__name__)
+
+
+class FlowRunner(QObject):
+    """Runs :meth:`Flow.run` on whichever thread the ``QObject`` lives on.
+
+    Intended to be moved onto a :class:`QThread` so expensive
+    ``process_impl`` calls do not stall the Qt event loop. The runner
+    holds no UI state; it only exposes two queued signals the caller can
+    connect to slots on the main thread:
+
+      - :attr:`finished` — emitted once the source nodes have fully
+        drained and the graph settled without error.
+      - :attr:`failed`   — emitted with a human-readable detail string
+        if any node raised. Exceptions are caught here (rather than
+        letting them propagate across the thread boundary, which Qt
+        cannot marshal) so the UI can show a banner instead of
+        crashing the worker.
+    """
+
+    finished = Signal()
+    failed = Signal(str)
+
+    def __init__(self, flow: Flow, parent: QObject | None = None) -> None:
+        super().__init__(parent)
+        self._flow = flow
+
+    @Slot()
+    def run(self) -> None:
+        try:
+            self._flow.run()
+        except Exception as err:
+            logger.exception("Flow run failed")
+            detail = str(err).strip() or "(no message)"
+            self.failed.emit(f"{type(err).__name__}: {detail}")
+            return
+        self.finished.emit()

--- a/src/core/node_base.py
+++ b/src/core/node_base.py
@@ -4,12 +4,34 @@ import logging
 from abc import ABC, abstractmethod
 
 from enum import Enum
+from typing import Callable
 from typing_extensions import override
 
 from core.io_data import IoData
 from core.port import InputPort, OutputPort
 
 logger = logging.getLogger(__name__)
+
+
+# Optional observer invoked at the start of every NodeBase.process() call.
+# A FlowRunner installs one of these to surface the currently-executing
+# node on the UI (via a queued Qt signal). Module-level rather than
+# per-instance because the push-based dispatcher doesn't otherwise carry
+# a reference to the Flow / runner across node boundaries.
+_process_observer: Callable[["NodeBase"], None] | None = None
+
+
+def set_process_observer(callback: Callable[["NodeBase"], None] | None) -> None:
+    """Install (or clear) the function invoked on every ``process()`` call.
+
+    Pass ``None`` to clear. Thread-safety relies on the GIL making the
+    module-attribute read/write atomic — good enough for the
+    install-before-run / clear-after-run pattern used by
+    :class:`core.flow_runner.FlowRunner`, not for rapid concurrent
+    reconfiguration.
+    """
+    global _process_observer
+    _process_observer = callback
 
 
 class NodeParamType(Enum):
@@ -156,9 +178,18 @@ class NodeBase(ABC):
         that every node automatically benefits from the per-call tracing log
         and the common exception-logging path.
         """
-        
+
         logger.debug(f"  - Executing {self._display_name} ({type(self).__name__})")
-        
+
+        observer = _process_observer
+        if observer is not None:
+            try:
+                observer(self)
+            except Exception:
+                # An observer must never block node execution; log and
+                # carry on so a buggy UI hook can't kill a flow.
+                logger.exception("Process observer raised; ignoring")
+
         try:
             self.process_impl()
         except Exception:

--- a/src/nodes/filters/delay.py
+++ b/src/nodes/filters/delay.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import time
+
+from typing_extensions import override
+
+from core.io_data import IMAGE_TYPES
+from core.node_base import NodeBase, NodeParam, NodeParamType
+from core.port import InputPort, OutputPort
+
+
+class Delay(NodeBase):
+    """Debug node that sleeps for ``delay_seconds`` before forwarding its input.
+
+    Exists to make pipeline timing visible during development — dropping it
+    between two nodes introduces a deterministic pause so scheduling, status
+    bar updates and progress indicators can be observed without contrived
+    workloads. The image payload is passed straight through unchanged.
+    """
+
+    def __init__(self) -> None:
+        super().__init__("Delay", section="Debug")
+        self._delay_seconds: float = 5.0
+
+        self._add_input(InputPort("image", set(IMAGE_TYPES)))
+        self._add_output(OutputPort("image", set(IMAGE_TYPES)))
+
+        self._apply_default_params()
+
+    @property
+    @override
+    def params(self) -> list[NodeParam]:
+        return [
+            NodeParam("delay_seconds", NodeParamType.FLOAT, {"default": 5.0}),
+        ]
+
+    @property
+    def delay_seconds(self) -> float:
+        return self._delay_seconds
+
+    @delay_seconds.setter
+    def delay_seconds(self, value: float) -> None:
+        v = float(value)
+        if v < 0:
+            raise ValueError(f"delay_seconds must be >= 0 (got {v})")
+        self._delay_seconds = v
+
+    @override
+    def process_impl(self) -> None:
+        in_data = self.inputs[0].data
+        time.sleep(self._delay_seconds)
+        self.outputs[0].send(in_data)

--- a/src/ui/flow_status_widget.py
+++ b/src/ui/flow_status_widget.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+from PySide6.QtCore import Qt
+from PySide6.QtWidgets import (
+    QHBoxLayout,
+    QLabel,
+    QStackedLayout,
+    QVBoxLayout,
+    QWidget,
+)
+
+from constants import APP_DISPLAY_NAME, APP_VERSION
+from ui.spinner import SpinnerWidget
+
+
+_RUNNING_SPINNER_SIZE = 28
+
+
+class FlowStatusWidget(QWidget):
+    """Toolbar status widget for the node editor.
+
+    Has two modes selected via :class:`QStackedLayout`:
+
+    * **Idle** — a single ``AppName vX.Y.Z`` label, visually identical
+      to the default :class:`ui.page.AppVersionStatusWidget` so the
+      toolbar looks the same whether the editor is open or not.
+    * **Running** — a spinner on the right; on the left, two stacked
+      labels: the flow name in bold on top, the currently-executing
+      node name muted beneath.
+
+    The page drives the widget via :meth:`show_idle`, :meth:`show_running`
+    and :meth:`set_current_node`. The widget owns no timers besides its
+    spinner, so leaving it mounted while idle costs effectively nothing.
+    """
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+
+        self._stack = QStackedLayout(self)
+        self._stack.setContentsMargins(0, 0, 0, 0)
+        self._stack.setSpacing(0)
+
+        # ── Idle page ──────────────────────────────────────────────────
+        self._idle_page = QWidget()
+        idle_layout = QHBoxLayout(self._idle_page)
+        idle_layout.setContentsMargins(8, 0, 8, 0)
+        idle_layout.setSpacing(0)
+        self._idle_label = QLabel(f"{APP_DISPLAY_NAME} v{APP_VERSION}")
+        self._idle_label.setAlignment(
+            Qt.AlignmentFlag.AlignRight | Qt.AlignmentFlag.AlignVCenter
+        )
+        self._idle_label.setProperty("muted", True)
+        idle_layout.addWidget(self._idle_label)
+        self._stack.addWidget(self._idle_page)
+
+        # ── Running page ───────────────────────────────────────────────
+        self._running_page = QWidget()
+        running_layout = QHBoxLayout(self._running_page)
+        running_layout.setContentsMargins(8, 0, 8, 0)
+        running_layout.setSpacing(10)
+
+        labels_col = QVBoxLayout()
+        labels_col.setContentsMargins(0, 0, 0, 0)
+        labels_col.setSpacing(0)
+
+        self._flow_label = QLabel("")
+        self._flow_label.setAlignment(
+            Qt.AlignmentFlag.AlignRight | Qt.AlignmentFlag.AlignVCenter
+        )
+        # Bold is set via the stylesheet so the theme's text colour
+        # still applies; setProperty-based selectors would need a QSS
+        # rule we don't otherwise need.
+        self._flow_label.setStyleSheet("font-weight: bold;")
+
+        self._node_label = QLabel("")
+        self._node_label.setAlignment(
+            Qt.AlignmentFlag.AlignRight | Qt.AlignmentFlag.AlignVCenter
+        )
+        self._node_label.setProperty("muted", True)
+
+        labels_col.addWidget(self._flow_label)
+        labels_col.addWidget(self._node_label)
+
+        self._spinner = SpinnerWidget(size=_RUNNING_SPINNER_SIZE, interval_ms=60)
+
+        running_layout.addLayout(labels_col, 1)
+        running_layout.addWidget(self._spinner, 0, Qt.AlignmentFlag.AlignVCenter)
+        self._stack.addWidget(self._running_page)
+
+        self._stack.setCurrentWidget(self._idle_page)
+
+    # ── Public API ─────────────────────────────────────────────────────────────
+
+    def show_idle(self) -> None:
+        """Switch back to the app-name/version display and stop the spinner."""
+        self._spinner.stop()
+        self._flow_label.clear()
+        self._node_label.clear()
+        self._stack.setCurrentWidget(self._idle_page)
+
+    def show_running(self, flow_name: str) -> None:
+        """Switch to running mode; ``flow_name`` is shown in bold.
+
+        The node label starts blank — call :meth:`set_current_node` as
+        soon as the first node starts processing to populate it.
+        """
+        self._flow_label.setText(flow_name)
+        self._node_label.setText("")
+        self._stack.setCurrentWidget(self._running_page)
+        self._spinner.start()
+
+    def set_current_node(self, display_name: str) -> None:
+        """Update the muted "current node" label shown under the flow name."""
+        self._node_label.setText(display_name)

--- a/src/ui/flow_status_widget.py
+++ b/src/ui/flow_status_widget.py
@@ -45,12 +45,28 @@ class FlowStatusWidget(QWidget):
         idle_layout = QHBoxLayout(self._idle_page)
         idle_layout.setContentsMargins(8, 0, 8, 0)
         idle_layout.setSpacing(0)
-        self._idle_label = QLabel(f"{APP_DISPLAY_NAME} v{APP_VERSION}")
-        self._idle_label.setAlignment(
+
+        idle_column = QVBoxLayout()
+        idle_column.setContentsMargins(0, 0, 0, 0)
+        idle_column.setSpacing(0)
+        idle_column.addStretch(1)
+
+        self._idle_name_label = QLabel(APP_DISPLAY_NAME)
+        self._idle_name_label.setAlignment(
             Qt.AlignmentFlag.AlignRight | Qt.AlignmentFlag.AlignVCenter
         )
-        self._idle_label.setProperty("muted", True)
-        idle_layout.addWidget(self._idle_label)
+        self._idle_name_label.setStyleSheet("font-size: 14pt;")
+
+        self._idle_version_label = QLabel(f"v{APP_VERSION}")
+        self._idle_version_label.setAlignment(
+            Qt.AlignmentFlag.AlignRight | Qt.AlignmentFlag.AlignVCenter
+        )
+        self._idle_version_label.setProperty("muted", True)
+
+        idle_column.addWidget(self._idle_name_label)
+        idle_column.addWidget(self._idle_version_label)
+        idle_column.addStretch(1)
+        idle_layout.addLayout(idle_column)
         self._stack.addWidget(self._idle_page)
 
         # ── Running page ───────────────────────────────────────────────
@@ -62,15 +78,20 @@ class FlowStatusWidget(QWidget):
         labels_col = QVBoxLayout()
         labels_col.setContentsMargins(0, 0, 0, 0)
         labels_col.setSpacing(0)
+        # Stretches above and below centre the pair within the widget's
+        # full height so the labels line up with the toolbar action row
+        # rather than hugging the top edge.
+        labels_col.addStretch(1)
 
         self._flow_label = QLabel("")
         self._flow_label.setAlignment(
             Qt.AlignmentFlag.AlignRight | Qt.AlignmentFlag.AlignVCenter
         )
-        # Bold is set via the stylesheet so the theme's text colour
-        # still applies; setProperty-based selectors would need a QSS
-        # rule we don't otherwise need.
-        self._flow_label.setStyleSheet("font-weight: bold;")
+        # Bold + larger size for the flow name so it reads as the
+        # primary label. Inline stylesheet keeps the theme's palette
+        # colour; setProperty-based selectors would need a QSS rule we
+        # don't otherwise need.
+        self._flow_label.setStyleSheet("font-size: 14pt; font-weight: bold;")
 
         self._node_label = QLabel("")
         self._node_label.setAlignment(
@@ -80,6 +101,7 @@ class FlowStatusWidget(QWidget):
 
         labels_col.addWidget(self._flow_label)
         labels_col.addWidget(self._node_label)
+        labels_col.addStretch(1)
 
         self._spinner = SpinnerWidget(size=_RUNNING_SPINNER_SIZE, interval_ms=60)
 

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -10,9 +10,12 @@ from PySide6.QtWidgets import (
     QMainWindow,
     QMenu,
     QMenuBar,
+    QSizePolicy,
     QStackedWidget,
     QToolBar,
     QToolButton,
+    QWidget,
+    QWidgetAction,
 )
 
 from constants import APP_DISPLAY_NAME, BUILTIN_NODES_DIR, USER_NODES_DIR
@@ -21,6 +24,7 @@ from core.node_registry import NodeRegistry
 from ui.node_editor_page import NodeEditorPage
 from ui.page import PageBase
 from ui.recent_flows import RecentFlowsManager
+from ui.spinner import SpinnerWidget
 from ui.start_page import StartPage
 from ui.log_page import LogPage
 
@@ -32,6 +36,10 @@ logger = logging.getLogger(__name__)
 # Icon size and fixed button dimensions for the main toolbar.
 _TOOLBAR_ICON_SIZE   = QSize(40, 40)
 _TOOLBAR_BUTTON_SIZE = QSize(72, 72)
+# Big right-aligned busy spinner. Sized to visually match the toolbar
+# icons (a touch smaller than the button, with room on every side) so it
+# reads as a peer of the surrounding actions, not a stray decoration.
+_TOOLBAR_SPINNER_SIZE = 36
 
 
 class MainWindow(QMainWindow):
@@ -113,6 +121,30 @@ class MainWindow(QMainWindow):
         # Separator between the page-selector radio group and the
         # page-specific toolbar actions.
         self._page_separator = self._toolbar.addSeparator()
+
+        # Right-aligned busy spinner. The spacer consumes all slack so
+        # the spinner sits flush against the far edge of the toolbar,
+        # regardless of how many actions the active page contributes.
+        # Both actions are persistent members (not recreated per page)
+        # so we don't churn QWidget parentage on page switches.
+        self._right_spacer = QWidget(self)
+        self._right_spacer.setSizePolicy(
+            QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Preferred,
+        )
+        self._right_spacer_action = QWidgetAction(self)
+        self._right_spacer_action.setDefaultWidget(self._right_spacer)
+
+        self._big_spinner = SpinnerWidget(
+            self, size=_TOOLBAR_SPINNER_SIZE, interval_ms=60,
+        )
+        self._big_spinner_action = QWidgetAction(self)
+        self._big_spinner_action.setDefaultWidget(self._big_spinner)
+
+        # Reflect the editor's run state on the global toolbar spinner.
+        # Wired once, here, so the spinner responds whether or not the
+        # editor page is currently active.
+        self._editor_page.run_started.connect(self._big_spinner.start)
+        self._editor_page.run_finished.connect(self._big_spinner.stop)
 
         self._activate_page(self._start_page)
 
@@ -197,7 +229,11 @@ class MainWindow(QMainWindow):
         # Remove previously-installed page-specific items (actions and
         # separators). QActions are owned by the page, so we only detach
         # them from the toolbar — do not deleteLater. Separators are
-        # owned by us, so we delete them.
+        # owned by us, so we delete them. The right-aligned spacer and
+        # spinner actions are persistent (owned by MainWindow), so we
+        # detach them here and re-add them at the very end below.
+        self._toolbar.removeAction(self._right_spacer_action)
+        self._toolbar.removeAction(self._big_spinner_action)
         for item in self._installed_page_actions:
             self._toolbar.removeAction(item)
             if item.isSeparator():
@@ -211,6 +247,13 @@ class MainWindow(QMainWindow):
             for action in section.actions:
                 self._toolbar.addAction(action)
                 self._installed_page_actions.append(action)
+
+        # Anchor spacer + spinner at the right edge. The expanding
+        # spacer pushes the spinner flush against the far end of the
+        # toolbar regardless of how many page-specific actions came
+        # before it.
+        self._toolbar.addAction(self._right_spacer_action)
+        self._toolbar.addAction(self._big_spinner_action)
 
         self._apply_consistent_button_sizes()
 

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -126,16 +126,18 @@ class MainWindow(QMainWindow):
         # the spinner sits flush against the far edge of the toolbar,
         # regardless of how many actions the active page contributes.
         # Both actions are persistent members (not recreated per page)
-        # so we don't churn QWidget parentage on page switches.
-        self._right_spacer = QWidget(self)
+        # so we don't churn QWidget parentage on page switches. The
+        # spacer uses Expanding in both axes so QToolBarLayout allocates
+        # remaining horizontal space to it.
+        self._right_spacer = QWidget()
         self._right_spacer.setSizePolicy(
-            QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Preferred,
+            QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding,
         )
         self._right_spacer_action = QWidgetAction(self)
         self._right_spacer_action.setDefaultWidget(self._right_spacer)
 
         self._big_spinner = SpinnerWidget(
-            self, size=_TOOLBAR_SPINNER_SIZE, interval_ms=60,
+            size=_TOOLBAR_SPINNER_SIZE, interval_ms=60,
         )
         self._big_spinner_action = QWidgetAction(self)
         self._big_spinner_action.setDefaultWidget(self._big_spinner)

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -24,7 +24,6 @@ from core.node_registry import NodeRegistry
 from ui.node_editor_page import NodeEditorPage
 from ui.page import PageBase
 from ui.recent_flows import RecentFlowsManager
-from ui.spinner import SpinnerWidget
 from ui.start_page import StartPage
 from ui.log_page import LogPage
 
@@ -36,10 +35,6 @@ logger = logging.getLogger(__name__)
 # Icon size and fixed button dimensions for the main toolbar.
 _TOOLBAR_ICON_SIZE   = QSize(40, 40)
 _TOOLBAR_BUTTON_SIZE = QSize(72, 72)
-# Big right-aligned busy spinner. Sized to visually match the toolbar
-# icons (a touch smaller than the button, with room on every side) so it
-# reads as a peer of the surrounding actions, not a stray decoration.
-_TOOLBAR_SPINNER_SIZE = 36
 
 
 class MainWindow(QMainWindow):
@@ -96,6 +91,14 @@ class MainWindow(QMainWindow):
         for page in self._pages_list:
             self._pages.addWidget(page)
             page.title_changed.connect(self._update_window_title)
+            # Pages that want to swap their status widget mid-lifetime
+            # (e.g. the editor flipping from "idle" to a running-flow
+            # indicator) emit status_widget_changed; MainWindow re-pulls
+            # the current widget from page_status_widget() when the
+            # affected page is active.
+            page.status_widget_changed.connect(
+                lambda p=page: self._on_page_status_widget_changed(p)
+            )
 
         # Per-page signals that only make sense on one page live outside
         # the iteration above.
@@ -122,31 +125,26 @@ class MainWindow(QMainWindow):
         # page-specific toolbar actions.
         self._page_separator = self._toolbar.addSeparator()
 
-        # Right-aligned busy spinner. The spacer consumes all slack so
-        # the spinner sits flush against the far edge of the toolbar,
-        # regardless of how many actions the active page contributes.
-        # Both actions are persistent members (not recreated per page)
-        # so we don't churn QWidget parentage on page switches. The
-        # spacer uses Expanding in both axes so QToolBarLayout allocates
-        # remaining horizontal space to it.
+        # Right-aligned status slot. The spacer is persistent (an
+        # expanding QWidget that consumes all slack so whatever sits
+        # after it ends up flush against the far edge of the toolbar);
+        # the status widget itself is pulled from the active page via
+        # page_status_widget() on every page switch and whenever a page
+        # emits status_widget_changed, so pages own the lifecycle of
+        # their own indicators.
         self._right_spacer = QWidget()
         self._right_spacer.setSizePolicy(
             QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding,
         )
         self._right_spacer_action = QWidgetAction(self)
         self._right_spacer_action.setDefaultWidget(self._right_spacer)
-
-        self._big_spinner = SpinnerWidget(
-            size=_TOOLBAR_SPINNER_SIZE, interval_ms=60,
-        )
-        self._big_spinner_action = QWidgetAction(self)
-        self._big_spinner_action.setDefaultWidget(self._big_spinner)
-
-        # Reflect the editor's run state on the global toolbar spinner.
-        # Wired once, here, so the spinner responds whether or not the
-        # editor page is currently active.
-        self._editor_page.run_started.connect(self._big_spinner.start)
-        self._editor_page.run_finished.connect(self._big_spinner.stop)
+        # Per-page QWidgetActions keep their wrapped widgets alive across
+        # page switches. QWidgetAction's destructor deletes the default
+        # widget, so we must NOT create-and-delete a fresh action on
+        # every install — doing so would also free the page-owned widget
+        # behind its back.
+        self._page_status_actions: dict[PageBase, QWidgetAction] = {}
+        self._installed_status_action: QWidgetAction | None = None
 
         self._activate_page(self._start_page)
 
@@ -232,10 +230,10 @@ class MainWindow(QMainWindow):
         # separators). QActions are owned by the page, so we only detach
         # them from the toolbar — do not deleteLater. Separators are
         # owned by us, so we delete them. The right-aligned spacer and
-        # spinner actions are persistent (owned by MainWindow), so we
-        # detach them here and re-add them at the very end below.
+        # page status actions are persistent; we only detach them from
+        # the toolbar here and re-add them at the end.
         self._toolbar.removeAction(self._right_spacer_action)
-        self._toolbar.removeAction(self._big_spinner_action)
+        self._detach_page_status_action()
         for item in self._installed_page_actions:
             self._toolbar.removeAction(item)
             if item.isSeparator():
@@ -250,13 +248,58 @@ class MainWindow(QMainWindow):
                 self._toolbar.addAction(action)
                 self._installed_page_actions.append(action)
 
-        # Anchor spacer + spinner at the right edge. The expanding
-        # spacer pushes the spinner flush against the far end of the
-        # toolbar regardless of how many page-specific actions came
-        # before it.
+        # Anchor the spacer + page status widget at the right edge. The
+        # expanding spacer consumes all slack so the status widget ends
+        # up flush against the far end of the toolbar regardless of how
+        # many page-specific actions came before it.
         self._toolbar.addAction(self._right_spacer_action)
-        self._toolbar.addAction(self._big_spinner_action)
+        self._install_page_status_widget(page)
 
+        self._apply_consistent_button_sizes()
+
+    def _install_page_status_widget(self, page: PageBase) -> None:
+        """Attach the page's status widget to the toolbar.
+
+        The wrapping :class:`QWidgetAction` is cached per page and
+        reused on subsequent activations so its destructor can't delete
+        the page-owned default widget. A fresh action is minted only
+        when the page hands back a different widget than last time
+        (typically in response to ``status_widget_changed``).
+        """
+        status = page.page_status_widget()
+        if status is None:
+            return
+        action = self._page_status_actions.get(page)
+        if action is None or action.defaultWidget() is not status:
+            action = QWidgetAction(self)
+            action.setDefaultWidget(status)
+            self._page_status_actions[page] = action
+        self._toolbar.addAction(action)
+        self._installed_status_action = action
+
+    def _detach_page_status_action(self) -> None:
+        """Remove the currently-installed status action from the toolbar.
+
+        The action is kept alive in ``_page_status_actions`` so its
+        default widget (owned by the page) survives the detach.
+        """
+        if self._installed_status_action is None:
+            return
+        self._toolbar.removeAction(self._installed_status_action)
+        self._installed_status_action = None
+
+    def _on_page_status_widget_changed(self, page: PageBase) -> None:
+        """Swap the toolbar's status widget when the active page asks.
+
+        Only acts when *page* is the currently-active one; an inactive
+        page emitting ``status_widget_changed`` is a no-op because its
+        widget will be pulled fresh the next time the page is
+        activated.
+        """
+        if self._pages.currentWidget() is not page:
+            return
+        self._detach_page_status_action()
+        self._install_page_status_widget(page)
         self._apply_consistent_button_sizes()
 
     def _apply_consistent_button_sizes(self) -> None:

--- a/src/ui/node_editor_page.py
+++ b/src/ui/node_editor_page.py
@@ -33,6 +33,7 @@ from ui.page import PageBase, ToolbarSection
 from ui.node_list import NodeList
 from ui.recent_flows import RecentFlowsManager
 from ui.error_banner import ErrorBanner
+from ui.spinner import SpinnerWidget
 from ui.theme import STATUS_MUTED_COLOR, STATUS_OK_COLOR
 from ui.viewer_panel import ViewerPanel
 
@@ -134,9 +135,13 @@ class NodeEditorPage(PageBase):
         self._actions["stack_horizontal"].setEnabled(False)
         self._scene.selectionChanged.connect(self._update_selection_actions)
 
-        # Status bar at the bottom of the inner window.
+        # Status bar at the bottom of the inner window. The spinner
+        # sits on the left, flush with the status label, and is shown
+        # only while a flow run is in flight.
         self._status_bar = QStatusBar(self._inner)
+        self._run_spinner = SpinnerWidget(self._status_bar)
         self._status_label = QLabel("")
+        self._status_bar.addWidget(self._run_spinner, 0)
         self._status_bar.addWidget(self._status_label, 1)
         self._inner.setStatusBar(self._status_bar)
 
@@ -369,6 +374,8 @@ class NodeEditorPage(PageBase):
         self._live_timer.stop()
         self._actions["run"].setEnabled(False)
         self._set_param_widgets_enabled(False)
+        self._run_spinner.start()
+        self._set_status("Running…", kind="muted")
 
         thread = QThread(self)
         runner = FlowRunner(self._flow)
@@ -431,6 +438,7 @@ class NodeEditorPage(PageBase):
         self._run_runner = None
         self._actions["run"].setEnabled(True)
         self._set_param_widgets_enabled(True)
+        self._run_spinner.stop()
 
     def _set_param_widgets_enabled(self, enabled: bool) -> None:
         """Freeze or thaw every node's param editors for the duration of a run."""

--- a/src/ui/node_editor_page.py
+++ b/src/ui/node_editor_page.py
@@ -372,7 +372,7 @@ class NodeEditorPage(PageBase):
         # change fires the timer during the run, _on_run_clicked will
         # early-return anyway, but stopping it keeps the intent obvious.
         self._live_timer.stop()
-        self._actions["run"].setEnabled(False)
+        self._set_toolbar_enabled(False)
         self._set_param_widgets_enabled(False)
         self._run_spinner.start()
         self._set_status("Running…", kind="muted")
@@ -436,7 +436,7 @@ class NodeEditorPage(PageBase):
         """
         self._run_thread = None
         self._run_runner = None
-        self._actions["run"].setEnabled(True)
+        self._set_toolbar_enabled(True)
         self._set_param_widgets_enabled(True)
         self._run_spinner.stop()
 
@@ -444,6 +444,21 @@ class NodeEditorPage(PageBase):
         """Freeze or thaw every node's param editors for the duration of a run."""
         for item in self._scene.iter_node_items():
             item.set_params_enabled(enabled)
+
+    def _set_toolbar_enabled(self, enabled: bool) -> None:
+        """Disable every toolbar action for the duration of a run.
+
+        Covers everything exposed via :meth:`page_toolbar_sections` — Run,
+        the file actions and the view actions — so the user can't save,
+        open or clear a flow that is still executing on the worker thread.
+        When re-enabling, ``_update_selection_actions`` re-applies the
+        selection-dependent gating for the stack actions instead of
+        leaving them unconditionally enabled.
+        """
+        for action in self._actions.values():
+            action.setEnabled(enabled)
+        if enabled:
+            self._update_selection_actions()
 
     def _best_viewer_node(self):
         """Return the most downstream non-sink node with IMAGE output data.

--- a/src/ui/node_editor_page.py
+++ b/src/ui/node_editor_page.py
@@ -5,7 +5,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from PySide6.QtCore import Qt, QThread, QTimer, Signal
+from PySide6.QtCore import Qt, QThread, QTimer
 from PySide6.QtGui import QAction, QIcon, QKeySequence, QShortcut
 from PySide6.QtWidgets import (
     QDockWidget,
@@ -16,6 +16,7 @@ from PySide6.QtWidgets import (
     QMessageBox,
     QStatusBar,
     QVBoxLayout,
+    QWidget,
 )
 
 from constants import FLOW_DIR
@@ -33,7 +34,7 @@ from ui.page import PageBase, ToolbarSection
 from ui.node_list import NodeList
 from ui.recent_flows import RecentFlowsManager
 from ui.error_banner import ErrorBanner
-from ui.spinner import SpinnerWidget
+from ui.flow_status_widget import FlowStatusWidget
 from ui.theme import STATUS_MUTED_COLOR, STATUS_OK_COLOR
 from ui.viewer_panel import ViewerPanel
 
@@ -57,13 +58,11 @@ class NodeEditorPage(PageBase):
     global toolbar next to the page-selector radio group.
 
     Signal :attr:`title_changed` fires up to MainWindow whenever the active
-    flow name changes. :attr:`run_started` and :attr:`run_finished` bracket
-    every worker-thread flow execution so MainWindow can reflect the busy
-    state in global chrome (e.g. a spinner on the main toolbar).
+    flow name changes. The toolbar's right-aligned status slot is owned by
+    this page via :class:`FlowStatusWidget` — it shows the app/version by
+    default and flips to a spinner + flow/node labels while a run is in
+    flight.
     """
-
-    run_started = Signal()
-    run_finished = Signal()
 
     def __init__(
         self,
@@ -81,6 +80,10 @@ class NodeEditorPage(PageBase):
         # that suppresses re-entrant Run clicks and reactive auto-runs.
         self._run_thread: QThread | None = None
         self._run_runner: FlowRunner | None = None
+
+        # Right-aligned toolbar status widget. Shows the app name + version
+        # while idle; swaps to a flow-running view during executions.
+        self._flow_status_widget = FlowStatusWidget()
 
         outer = QVBoxLayout(self)
         outer.setContentsMargins(0, 0, 0, 0)
@@ -140,13 +143,11 @@ class NodeEditorPage(PageBase):
         self._actions["stack_horizontal"].setEnabled(False)
         self._scene.selectionChanged.connect(self._update_selection_actions)
 
-        # Status bar at the bottom of the inner window. The spinner
-        # sits on the left, flush with the status label, and is shown
-        # only while a flow run is in flight.
+        # Status bar at the bottom of the inner window. The running-flow
+        # indicator lives on the main toolbar via FlowStatusWidget; the
+        # status bar is kept purely for timestamp/ok messages.
         self._status_bar = QStatusBar(self._inner)
-        self._run_spinner = SpinnerWidget(self._status_bar)
         self._status_label = QLabel("")
-        self._status_bar.addWidget(self._run_spinner, 0)
         self._status_bar.addWidget(self._status_label, 1)
         self._inner.setStatusBar(self._status_bar)
 
@@ -206,6 +207,13 @@ class NodeEditorPage(PageBase):
                 self._actions["stack_horizontal"],
             ]),
         ]
+
+    @override
+    def page_status_widget(self) -> QWidget | None:
+        # The FlowStatusWidget manages its own idle/running transitions
+        # internally, so MainWindow never needs to swap widgets on this
+        # page — we hand back the same instance every call.
+        return self._flow_status_widget
 
     def page_menus(self) -> list[QMenu]:
         # Single "Node Editor" menu mirroring the toolbar actions plus
@@ -379,9 +387,8 @@ class NodeEditorPage(PageBase):
         self._live_timer.stop()
         self._set_toolbar_enabled(False)
         self._set_param_widgets_enabled(False)
-        self._run_spinner.start()
+        self._flow_status_widget.show_running(self._flow.name)
         self._set_status("Running…", kind="muted")
-        self.run_started.emit()
 
         thread = QThread(self)
         runner = FlowRunner(self._flow)
@@ -390,6 +397,9 @@ class NodeEditorPage(PageBase):
         thread.started.connect(runner.run)
         runner.finished.connect(self._on_run_finished)
         runner.failed.connect(self._on_run_failed)
+        # Queued cross-thread signal — the worker fires node_started on
+        # its own thread, Qt marshals it onto the UI thread slot.
+        runner.node_started.connect(self._flow_status_widget.set_current_node)
         # Connection order matters: Qt invokes slots in the order they were
         # connected. We want deleteLater to post on the worker's event loop
         # *before* quit stops that same loop, so the runner is actually
@@ -444,8 +454,7 @@ class NodeEditorPage(PageBase):
         self._run_runner = None
         self._set_toolbar_enabled(True)
         self._set_param_widgets_enabled(True)
-        self._run_spinner.stop()
-        self.run_finished.emit()
+        self._flow_status_widget.show_idle()
 
     def _set_param_widgets_enabled(self, enabled: bool) -> None:
         """Freeze or thaw every node's param editors for the duration of a run."""

--- a/src/ui/node_editor_page.py
+++ b/src/ui/node_editor_page.py
@@ -5,7 +5,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from PySide6.QtCore import Qt, QTimer
+from PySide6.QtCore import Qt, QThread, QTimer
 from PySide6.QtGui import QAction, QIcon, QKeySequence, QShortcut
 from PySide6.QtWidgets import (
     QDockWidget,
@@ -20,6 +20,7 @@ from PySide6.QtWidgets import (
 
 from constants import FLOW_DIR
 from core.flow import Flow, is_valid_flow_name
+from core.flow_runner import FlowRunner
 from core.io_data import IMAGE_TYPES
 from core.node_base import SinkNodeBase, SourceNodeBase
 from ui.flow_io import FlowIoError, load_flow_into, save_flow_to
@@ -67,6 +68,13 @@ class NodeEditorPage(PageBase):
         self._registry = registry
         self._recent_flows = recent_flows
         self._flow: Flow | None = None
+
+        # Worker thread used by _on_run_clicked. Lazily created on the first
+        # run and reused; cleaned up when the run finishes. While a run is in
+        # flight, _run_thread is not None — this doubles as the "busy" flag
+        # that suppresses re-entrant Run clicks and reactive auto-runs.
+        self._run_thread: QThread | None = None
+        self._run_runner: FlowRunner | None = None
 
         outer = QVBoxLayout(self)
         outer.setContentsMargins(0, 0, 0, 0)
@@ -349,15 +357,42 @@ class NodeEditorPage(PageBase):
         if self._flow is None:
             self._set_status("No flow to run", kind="fail")
             return
-        
-        try:
-            self._flow.run()
-        except Exception as err:
-            logger.exception("Flow run failed")
-            detail = str(err).strip() or "(no message)"
-            self._set_status(f"Run failed ({type(err).__name__}): {detail}", kind="fail")
+        if self._run_thread is not None:
+            # A run is already in flight — ignore the click rather than
+            # stacking runs on top of each other. The reactive debounce
+            # timer can also land here if the user tweaks a param mid-run.
             return
 
+        # Stop the reactive debounce timer while we run: if a param
+        # change fires the timer during the run, _on_run_clicked will
+        # early-return anyway, but stopping it keeps the intent obvious.
+        self._live_timer.stop()
+        self._actions["run"].setEnabled(False)
+        self._set_param_widgets_enabled(False)
+
+        thread = QThread(self)
+        runner = FlowRunner(self._flow)
+        runner.moveToThread(thread)
+
+        thread.started.connect(runner.run)
+        runner.finished.connect(self._on_run_finished)
+        runner.failed.connect(self._on_run_failed)
+        # Connection order matters: Qt invokes slots in the order they were
+        # connected. We want deleteLater to post on the worker's event loop
+        # *before* quit stops that same loop, so the runner is actually
+        # destroyed. thread.deleteLater can then run on the UI thread after
+        # the worker has terminated.
+        runner.finished.connect(runner.deleteLater)
+        runner.failed.connect(runner.deleteLater)
+        runner.finished.connect(thread.quit)
+        runner.failed.connect(lambda _msg: thread.quit())
+        thread.finished.connect(thread.deleteLater)
+
+        self._run_thread = thread
+        self._run_runner = runner
+        thread.start()
+
+    def _on_run_finished(self) -> None:
         # Sinks may have just written output files; let every node's
         # param widgets re-evaluate filesystem-dependent state (e.g.
         # the FilePathParamWidget "view" button).
@@ -377,6 +412,30 @@ class NodeEditorPage(PageBase):
                 self._viewer.show_node(best)
         else:
             self._viewer.refresh()
+
+        self._finalize_run()
+
+    def _on_run_failed(self, detail: str) -> None:
+        self._set_status(f"Run failed ({detail})", kind="fail")
+        self._finalize_run()
+
+    def _finalize_run(self) -> None:
+        """Drop references to the worker thread and re-enable the Run action.
+
+        Called from both terminal slots. The QThread itself is torn down
+        via the ``thread.finished`` → ``deleteLater`` connections set up
+        in :meth:`_on_run_clicked`; this just clears our handles so the
+        next click starts a fresh thread.
+        """
+        self._run_thread = None
+        self._run_runner = None
+        self._actions["run"].setEnabled(True)
+        self._set_param_widgets_enabled(True)
+
+    def _set_param_widgets_enabled(self, enabled: bool) -> None:
+        """Freeze or thaw every node's param editors for the duration of a run."""
+        for item in self._scene.iter_node_items():
+            item.set_params_enabled(enabled)
 
     def _best_viewer_node(self):
         """Return the most downstream non-sink node with IMAGE output data.

--- a/src/ui/node_editor_page.py
+++ b/src/ui/node_editor_page.py
@@ -5,7 +5,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from PySide6.QtCore import Qt, QThread, QTimer
+from PySide6.QtCore import Qt, QThread, QTimer, Signal
 from PySide6.QtGui import QAction, QIcon, QKeySequence, QShortcut
 from PySide6.QtWidgets import (
     QDockWidget,
@@ -57,8 +57,13 @@ class NodeEditorPage(PageBase):
     global toolbar next to the page-selector radio group.
 
     Signal :attr:`title_changed` fires up to MainWindow whenever the active
-    flow name changes.
+    flow name changes. :attr:`run_started` and :attr:`run_finished` bracket
+    every worker-thread flow execution so MainWindow can reflect the busy
+    state in global chrome (e.g. a spinner on the main toolbar).
     """
+
+    run_started = Signal()
+    run_finished = Signal()
 
     def __init__(
         self,
@@ -376,6 +381,7 @@ class NodeEditorPage(PageBase):
         self._set_param_widgets_enabled(False)
         self._run_spinner.start()
         self._set_status("Running…", kind="muted")
+        self.run_started.emit()
 
         thread = QThread(self)
         runner = FlowRunner(self._flow)
@@ -439,6 +445,7 @@ class NodeEditorPage(PageBase):
         self._set_toolbar_enabled(True)
         self._set_param_widgets_enabled(True)
         self._run_spinner.stop()
+        self.run_finished.emit()
 
     def _set_param_widgets_enabled(self, enabled: bool) -> None:
         """Freeze or thaw every node's param editors for the duration of a run."""

--- a/src/ui/node_item.py
+++ b/src/ui/node_item.py
@@ -374,6 +374,17 @@ class NodeItem(QGraphicsItem):
         for editor in self._param_widgets:
             editor.refresh()
 
+    def set_params_enabled(self, enabled: bool) -> None:
+        """Enable or disable every param editor on this node.
+
+        Used by the editor to freeze inputs while the flow is running on a
+        worker thread: a setter firing mid-``process_impl`` would race with
+        the node reading its own state. Disabling the widgets sidesteps that
+        cleanly — the user simply cannot edit until the run completes.
+        """
+        for editor in self._param_widgets:
+            editor.setEnabled(enabled)
+
     def _build_params_widget(self) -> None:
         if not self._node.params:
             return

--- a/src/ui/page.py
+++ b/src/ui/page.py
@@ -2,9 +2,11 @@ from __future__ import annotations
 
 from typing import NamedTuple, TYPE_CHECKING
 
-from PySide6.QtCore import Signal
+from PySide6.QtCore import Qt, Signal
 from PySide6.QtGui import QAction, QIcon
-from PySide6.QtWidgets import QWidget
+from PySide6.QtWidgets import QHBoxLayout, QLabel, QWidget
+
+from constants import APP_DISPLAY_NAME, APP_VERSION
 
 if TYPE_CHECKING:
     from PySide6.QtWidgets import QMenu
@@ -16,6 +18,25 @@ class ToolbarSection(NamedTuple):
     actions: list[QAction]
 
 
+class AppVersionStatusWidget(QWidget):
+    """Default page status widget: ``AppName vX.Y.Z`` label.
+
+    Kept as a small standalone class so every page can instantiate its
+    own — two pages must not share the same QWidget instance, because
+    QToolBar reparents widgets it hosts via ``QWidgetAction``.
+    """
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        layout = QHBoxLayout(self)
+        layout.setContentsMargins(8, 0, 8, 0)
+        layout.setSpacing(0)
+        label = QLabel(f"{APP_DISPLAY_NAME} v{APP_VERSION}")
+        label.setAlignment(Qt.AlignmentFlag.AlignRight | Qt.AlignmentFlag.AlignVCenter)
+        label.setProperty("muted", True)
+        layout.addWidget(label)
+
+
 class PageBase(QWidget):
     """Abstract base class for every top-level page stacked inside MainWindow.
 
@@ -25,11 +46,17 @@ class PageBase(QWidget):
     * a list of QMenus installed on the global menu bar while the page
       is active (see :meth:`page_menus`), and
     * a list of QActions installed on the application toolbar next to
-      the page-selector radio group (see :meth:`page_toolbar_actions`).
+      the page-selector radio group (see :meth:`page_toolbar_actions`), and
+    * a status widget anchored to the right of the main toolbar (see
+      :meth:`page_status_widget`), used to surface page-specific state
+      such as a running-flow indicator.
 
     The :attr:`title_changed` signal lets a page request that the main
     window update the window title without knowing about the main window
-    directly.
+    directly. :attr:`status_widget_changed` asks MainWindow to re-install
+    the page's status widget on the toolbar — use it when the page wants
+    to swap widgets (e.g. from an idle label to a busy spinner) without
+    waiting for the next page switch.
 
     Subclasses must implement:
 
@@ -47,11 +74,13 @@ class PageBase(QWidget):
     """
 
     title_changed = Signal(str)
+    status_widget_changed = Signal()
 
     def __init__(self, parent: QWidget | None = None) -> None:
         if type(self) is PageBase:
             raise TypeError("PageBase cannot be instantiated directly")
         super().__init__(parent)
+        self._default_status_widget: AppVersionStatusWidget | None = None
 
     # ── Abstract interface ─────────────────────────────────────────────────────
 
@@ -82,6 +111,20 @@ class PageBase(QWidget):
         Default: empty.
         """
         return []
+
+    def page_status_widget(self) -> QWidget | None:
+        """Return the widget MainWindow should pin to the far right of the toolbar.
+
+        Default: an :class:`AppVersionStatusWidget` showing the app name and
+        version, so every page has a sensible right-edge affordance without
+        boilerplate. Pages that want dynamic state (a progress spinner, a
+        connection light, …) override this and emit
+        :attr:`status_widget_changed` whenever the returned widget needs to
+        be swapped for a different one.
+        """
+        if self._default_status_widget is None:
+            self._default_status_widget = AppVersionStatusWidget()
+        return self._default_status_widget
 
     def page_title(self) -> str:
         """Human-readable page title used in the window caption."""

--- a/src/ui/page.py
+++ b/src/ui/page.py
@@ -4,7 +4,7 @@ from typing import NamedTuple, TYPE_CHECKING
 
 from PySide6.QtCore import Qt, Signal
 from PySide6.QtGui import QAction, QIcon
-from PySide6.QtWidgets import QHBoxLayout, QLabel, QWidget
+from PySide6.QtWidgets import QHBoxLayout, QLabel, QVBoxLayout, QWidget
 
 from constants import APP_DISPLAY_NAME, APP_VERSION
 
@@ -19,7 +19,12 @@ class ToolbarSection(NamedTuple):
 
 
 class AppVersionStatusWidget(QWidget):
-    """Default page status widget: ``AppName vX.Y.Z`` label.
+    """Default page status widget: app name on top, version beneath.
+
+    Two stacked right-aligned labels — the app name rendered at a
+    larger size so it reads as the primary label, and the version
+    muted underneath. The pair is vertically centred in the widget so
+    it looks balanced next to the toolbar's 72 px action buttons.
 
     Kept as a small standalone class so every page can instantiate its
     own — two pages must not share the same QWidget instance, because
@@ -28,13 +33,27 @@ class AppVersionStatusWidget(QWidget):
 
     def __init__(self, parent: QWidget | None = None) -> None:
         super().__init__(parent)
-        layout = QHBoxLayout(self)
-        layout.setContentsMargins(8, 0, 8, 0)
-        layout.setSpacing(0)
-        label = QLabel(f"{APP_DISPLAY_NAME} v{APP_VERSION}")
-        label.setAlignment(Qt.AlignmentFlag.AlignRight | Qt.AlignmentFlag.AlignVCenter)
-        label.setProperty("muted", True)
-        layout.addWidget(label)
+        outer = QHBoxLayout(self)
+        outer.setContentsMargins(8, 0, 8, 0)
+        outer.setSpacing(0)
+
+        column = QVBoxLayout()
+        column.setContentsMargins(0, 0, 0, 0)
+        column.setSpacing(0)
+        column.addStretch(1)
+
+        name = QLabel(APP_DISPLAY_NAME)
+        name.setAlignment(Qt.AlignmentFlag.AlignRight | Qt.AlignmentFlag.AlignVCenter)
+        name.setStyleSheet("font-size: 14pt;")
+
+        version = QLabel(f"v{APP_VERSION}")
+        version.setAlignment(Qt.AlignmentFlag.AlignRight | Qt.AlignmentFlag.AlignVCenter)
+        version.setProperty("muted", True)
+
+        column.addWidget(name)
+        column.addWidget(version)
+        column.addStretch(1)
+        outer.addLayout(column)
 
 
 class PageBase(QWidget):

--- a/src/ui/param_widgets.py
+++ b/src/ui/param_widgets.py
@@ -10,6 +10,7 @@ from PySide6.QtCore import Qt, QUrl, Signal
 from PySide6.QtGui import QDesktopServices
 from PySide6.QtWidgets import (
     QCheckBox,
+    QDoubleSpinBox,
     QFileDialog,
     QHBoxLayout,
     QLineEdit,
@@ -119,6 +120,46 @@ class IntParamWidget(ParamWidgetBase):
     @override
     def set_value(self, value: object) -> None:
         self._spin.setValue(int(value))
+
+    @override
+    def get_value(self) -> object:
+        return self._spin.value()
+
+
+class FloatParamWidget(ParamWidgetBase):
+    """Double-spin-box editor for :attr:`NodeParamType.FLOAT` parameters.
+
+    Supports optional ``metadata`` keys ``min``, ``max``, ``step`` and
+    ``decimals`` to tune the spin box; unspecified keys fall back to a
+    wide default range so arbitrary floats round-trip without clipping.
+    """
+
+    def __init__(self, node: NodeBase, param: NodeParam) -> None:
+        super().__init__(node, param)
+        self._spin = QDoubleSpinBox()
+        meta = param.metadata
+        self._spin.setRange(
+            float(meta.get("min", -1e12)),
+            float(meta.get("max",  1e12)),
+        )
+        self._spin.setDecimals(int(meta.get("decimals", 3)))
+        self._spin.setSingleStep(float(meta.get("step", 0.1)))
+        self._spin.setAlignment(Qt.AlignmentFlag.AlignRight)
+        self._spin.setMinimumWidth(96)
+        self._spin.valueChanged.connect(self._on_value_changed)
+        self._spin.setValue(float(self._initial_value(0.0)))
+
+        layout = QHBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.addWidget(self._spin)
+
+    def _on_value_changed(self, value: float) -> None:
+        self._write_to_node(value)
+        self.value_changed.emit(value)
+
+    @override
+    def set_value(self, value: object) -> None:
+        self._spin.setValue(float(value))
 
     @override
     def get_value(self) -> object:
@@ -359,6 +400,7 @@ class FilePathParamWidget(ParamWidgetBase):
 _PARAM_WIDGET_CLASSES: dict[NodeParamType, type[ParamWidgetBase]] = {
     NodeParamType.FILE_PATH: FilePathParamWidget,
     NodeParamType.INT:       IntParamWidget,
+    NodeParamType.FLOAT:     FloatParamWidget,
     NodeParamType.BOOL:      BoolParamWidget,
     NodeParamType.ENUM:      EnumParamWidget,
 }

--- a/src/ui/spinner.py
+++ b/src/ui/spinner.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from PySide6.QtCore import QRectF, QSize, QTimer, Qt
+from PySide6.QtGui import QColor, QConicalGradient, QPainter, QPen
+from PySide6.QtWidgets import QWidget
+
+from ui.theme import STATUS_MUTED_COLOR
+
+
+class SpinnerWidget(QWidget):
+    """Small indeterminate spinner intended for status-bar use.
+
+    Renders a rotating conical-gradient arc at a fixed size so it fits
+    cleanly next to status-bar labels. The internal :class:`QTimer`
+    only ticks while the widget is visible, so placing several
+    spinners on the UI costs nothing while they are idle.
+
+    Use :meth:`start` to show the spinner and begin animating, and
+    :meth:`stop` to freeze + hide it.
+    """
+
+    def __init__(
+        self,
+        parent: QWidget | None = None,
+        *,
+        size: int = 14,
+        interval_ms: int = 60,
+        color: QColor | None = None,
+    ) -> None:
+        super().__init__(parent)
+        self._size = size
+        self._angle = 0
+        # Status-bar spinner defaults to the muted status colour so it
+        # sits quietly alongside the "Running…" label without shouting.
+        self._color = QColor(color if color is not None else STATUS_MUTED_COLOR)
+
+        self.setFixedSize(QSize(size, size))
+        self.setAttribute(Qt.WidgetAttribute.WA_TranslucentBackground, True)
+
+        self._timer = QTimer(self)
+        self._timer.setInterval(interval_ms)
+        self._timer.timeout.connect(self._advance)
+
+        self.hide()
+
+    # ── Public API ─────────────────────────────────────────────────────────────
+
+    def start(self) -> None:
+        self.show()
+        self._timer.start()
+
+    def stop(self) -> None:
+        self._timer.stop()
+        self.hide()
+
+    # ── Qt overrides ───────────────────────────────────────────────────────────
+
+    def paintEvent(self, _event) -> None:  # type: ignore[override]
+        # A 2 px pen reads clearly at 14 px without dominating the box.
+        # The -1 inset keeps the stroke fully inside the widget rect so
+        # anti-aliasing doesn't clip against the status bar background.
+        pen_width = 2
+        inset = pen_width / 2 + 0.5
+        rect = QRectF(inset, inset, self._size - 2 * inset, self._size - 2 * inset)
+
+        # A conical gradient from transparent → solid produces the
+        # comet-tail fade that readers expect from a spinner; rotating
+        # the gradient start each tick animates it.
+        grad = QConicalGradient(rect.center(), -self._angle)
+        transparent = QColor(self._color)
+        transparent.setAlpha(0)
+        grad.setColorAt(0.0, self._color)
+        grad.setColorAt(1.0, transparent)
+
+        pen = QPen(grad, pen_width)
+        pen.setCapStyle(Qt.PenCapStyle.RoundCap)
+
+        painter = QPainter(self)
+        painter.setRenderHint(QPainter.RenderHint.Antialiasing, True)
+        painter.setPen(pen)
+        painter.drawArc(rect, 0, 360 * 16)
+        painter.end()
+
+    def _advance(self) -> None:
+        self._angle = (self._angle + 30) % 360
+        self.update()

--- a/src/ui/spinner.py
+++ b/src/ui/spinner.py
@@ -8,15 +8,14 @@ from ui.theme import STATUS_MUTED_COLOR
 
 
 class SpinnerWidget(QWidget):
-    """Small indeterminate spinner intended for status-bar use.
+    """Small indeterminate spinner suitable for status bars and toolbars.
 
-    Renders a rotating conical-gradient arc at a fixed size so it fits
-    cleanly next to status-bar labels. The internal :class:`QTimer`
-    only ticks while the widget is visible, so placing several
-    spinners on the UI costs nothing while they are idle.
-
-    Use :meth:`start` to show the spinner and begin animating, and
-    :meth:`stop` to freeze + hide it.
+    Renders a rotating conical-gradient arc at a fixed size. The widget
+    is always visible (so containers like :class:`QToolBar` reserve
+    space for it from first layout), but draws nothing while idle — so
+    a stopped spinner is indistinguishable from empty space. Calling
+    :meth:`start` begins animating; :meth:`stop` freezes and blanks the
+    widget again.
     """
 
     def __init__(
@@ -30,6 +29,7 @@ class SpinnerWidget(QWidget):
         super().__init__(parent)
         self._size = size
         self._angle = 0
+        self._spinning = False
         # Status-bar spinner defaults to the muted status colour so it
         # sits quietly alongside the "Running…" label without shouting.
         self._color = QColor(color if color is not None else STATUS_MUTED_COLOR)
@@ -41,25 +41,32 @@ class SpinnerWidget(QWidget):
         self._timer.setInterval(interval_ms)
         self._timer.timeout.connect(self._advance)
 
-        self.hide()
-
     # ── Public API ─────────────────────────────────────────────────────────────
 
     def start(self) -> None:
-        self.show()
+        self._spinning = True
         self._timer.start()
+        self.update()
 
     def stop(self) -> None:
         self._timer.stop()
-        self.hide()
+        self._spinning = False
+        self.update()
 
     # ── Qt overrides ───────────────────────────────────────────────────────────
 
     def paintEvent(self, _event) -> None:  # type: ignore[override]
-        # A 2 px pen reads clearly at 14 px without dominating the box.
-        # The -1 inset keeps the stroke fully inside the widget rect so
-        # anti-aliasing doesn't clip against the status bar background.
-        pen_width = 2
+        if not self._spinning:
+            # Idle: paint nothing so the widget reads as empty space
+            # even though its fixed size still reserves a layout slot.
+            return
+
+        # Scale the pen with the overall size so the arc stays visually
+        # balanced at both the 14 px status-bar size and the 36 px
+        # toolbar size. The inset keeps the stroke fully inside the
+        # widget rect so anti-aliasing doesn't clip against the
+        # background.
+        pen_width = max(2, self._size // 7)
         inset = pen_width / 2 + 0.5
         rect = QRectF(inset, inset, self._size - 2 * inset, self._size - 2 * inset)
 


### PR DESCRIPTION
## Summary
This PR refactors flow execution to run asynchronously on a dedicated worker thread, preventing the UI from freezing during long-running node operations. It adds visual feedback via a spinning indicator and disables user input while a flow is executing.

## Key Changes

- **Asynchronous Flow Execution**: Introduced `FlowRunner` class that executes `Flow.run()` on a worker thread, emitting `finished` or `failed` signals upon completion
- **Worker Thread Management**: Modified `NodeEditorPage._on_run_clicked()` to create and manage a `QThread` for each flow run, with proper cleanup via signal connections
- **Visual Feedback**: Added `SpinnerWidget` — a rotating arc indicator that displays in the status bar while a flow is running
- **Input Freezing**: Disabled the Run button and all parameter editors during execution via `_set_param_widgets_enabled()` to prevent race conditions with node state reads
- **Float Parameter Support**: Added `FloatParamWidget` to handle `NodeParamType.FLOAT` parameters with configurable min/max/step/decimals
- **Debug Node**: Introduced `Delay` node for testing async execution and timing visibility
- **Test Flow**: Added `delay.flowjs` example demonstrating the new async behavior

## Implementation Details

- The `FlowRunner` catches exceptions on the worker thread and emits them as signal data (strings) rather than propagating across thread boundaries, which Qt cannot marshal
- Signal connection order in `_on_run_clicked()` is carefully sequenced: `deleteLater` signals post to the worker's event loop before `quit()` stops it, ensuring proper cleanup
- The `_run_thread` field doubles as a "busy" flag — when non-None, it suppresses re-entrant Run clicks and prevents reactive auto-runs from stacking
- The spinner only animates while visible, so multiple idle spinners have negligible performance cost
- Parameter widgets are frozen (not hidden) during runs to maintain UI layout stability

https://claude.ai/code/session_01XQwNr4BBC4FbjyGvqGx6uA