### PR TITLE
Add logging for toolbar actions and flow execution

### DIFF
--- a/src/core/flow.py
+++ b/src/core/flow.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+import logging
 import re
 
 from core.node_base import NodeBase, SinkNodeBase, SourceNodeBase
 from core.port import InputPort, OutputPort
+
+logger = logging.getLogger(__name__)
 
 
 DEFAULT_FLOW_NAME: str = "Untitled_flow"
@@ -138,6 +141,7 @@ class Flow:
         Raises:
             RuntimeError: if the flow has no source node or no sink node.
         """
+        logger.info("Flow run started: %s", self._name)
         if not self.sources:
             raise RuntimeError("Flow has no source node; at least one is required")
         if not self.sinks:

--- a/src/ui/node_editor_page.py
+++ b/src/ui/node_editor_page.py
@@ -307,6 +307,12 @@ class NodeEditorPage(PageBase):
     def _build_actions(self) -> dict[str, QAction]:
         def mk(text: str, icon_name: str, slot) -> QAction:
             a = QAction(material_icon(icon_name), text, self)
+            # Log every toolbar/menu activation before the real handler
+            # runs. QAction.triggered passes a `checked` bool, which the
+            # lambda swallows via *_.
+            a.triggered.connect(
+                lambda *_ , _text=text: logger.info("Toolbar action: %s", _text)
+            )
             a.triggered.connect(slot)
             return a
 


### PR DESCRIPTION
## Summary
This PR adds logging instrumentation to track user interactions with toolbar/menu actions and flow execution events.

## Key Changes
- **Toolbar action logging**: Added logging to the `_build_actions()` method in `node_editor_page.py` to log every toolbar/menu action activation before the handler executes. The implementation uses a lambda with `*_` to swallow the `checked` bool parameter passed by `QAction.triggered`.
- **Flow execution logging**: Added logging to the `Flow.run()` method in `flow.py` to log when a flow execution starts, including the flow name.
- **Logger setup**: Added logging module import and logger initialization in `flow.py`.

## Implementation Details
- The toolbar action logging is connected as a separate signal handler that runs before the actual action handler, allowing for non-intrusive monitoring of user actions.
- The lambda parameter handling (`*_, _text=text`) ensures the text parameter is captured correctly while ignoring the `checked` parameter from the signal.

https://claude.ai/code/session_01MmM6Kmqmo1JEqtzkbxcxEy