### PR TITLE
Add NCC (Normalized Cross-Correlation) template matching node

### DIFF
--- a/flow/ncc.flowjs
+++ b/flow/ncc.flowjs
@@ -1,0 +1,106 @@
+{
+  "version": 1,
+  "name": "ncc",
+  "nodes": [
+    {
+      "id": 0,
+      "module": "nodes.filters.ncc",
+      "class": "Ncc",
+      "position": [
+        -1178.0,
+        -599.0
+      ],
+      "params": {
+        "retain_size": true
+      }
+    },
+    {
+      "id": 1,
+      "module": "nodes.sources.image_source",
+      "class": "ImageSource",
+      "position": [
+        -1694.0,
+        -637.0
+      ],
+      "params": {
+        "file_path": "chip.jpg"
+      }
+    },
+    {
+      "id": 2,
+      "module": "nodes.sources.image_source",
+      "class": "ImageSource",
+      "position": [
+        -1690.0,
+        -500.0
+      ],
+      "params": {
+        "file_path": "pad.jpg"
+      }
+    },
+    {
+      "id": 3,
+      "module": "nodes.filters.grayscale",
+      "class": "Grayscale",
+      "position": [
+        -1401.0,
+        -613.0
+      ],
+      "params": {}
+    },
+    {
+      "id": 4,
+      "module": "nodes.filters.grayscale",
+      "class": "Grayscale",
+      "position": [
+        -1397.0,
+        -476.0
+      ],
+      "params": {}
+    },
+    {
+      "id": 5,
+      "module": "nodes.sinks.file_sink",
+      "class": "FileSink",
+      "position": [
+        -976.0,
+        -606.0
+      ],
+      "params": {
+        "output_path": "out.png"
+      }
+    }
+  ],
+  "connections": [
+    {
+      "src_node": 1,
+      "src_output": 0,
+      "dst_node": 3,
+      "dst_input": 0
+    },
+    {
+      "src_node": 2,
+      "src_output": 0,
+      "dst_node": 4,
+      "dst_input": 0
+    },
+    {
+      "src_node": 4,
+      "src_output": 0,
+      "dst_node": 0,
+      "dst_input": 1
+    },
+    {
+      "src_node": 3,
+      "src_output": 0,
+      "dst_node": 0,
+      "dst_input": 0
+    },
+    {
+      "src_node": 0,
+      "src_output": 0,
+      "dst_node": 5,
+      "dst_input": 0
+    }
+  ]
+}

--- a/src/nodes/filters/ncc.py
+++ b/src/nodes/filters/ncc.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import cv2
+import numpy as np
+from typing_extensions import override
+
+from core.io_data import IoData, IoDataType
+from core.node_base import NodeBase, NodeParam, NodeParamType
+from core.port import InputPort, OutputPort
+
+
+class Ncc(NodeBase):
+    """Normalised cross-correlation template matching.
+
+    Wraps ``cv2.matchTemplate`` with ``TM_CCORR_NORMED`` and rescales the
+    score map to a ``uint8`` greyscale image. The ``template`` input is
+    the pattern searched for within ``image``. Both inputs must be
+    single-channel greyscale. Ported from the original OCVL
+    ``NccProcessor``.
+
+    With ``retain_size=True`` (default) the match map is pasted into a
+    canvas the same size as ``image`` and offset by half the template
+    size, so each response sits at the pixel it corresponds to (template
+    centre). With ``retain_size=False`` the raw ``matchTemplate`` output
+    is emitted, which is smaller than the input by ``template.shape - 1``
+    on each axis.
+    """
+
+    def __init__(self) -> None:
+        super().__init__("NCC", section="Processing")
+        self._retain_size: bool = True
+
+        self._add_input(InputPort("image", {IoDataType.IMAGE_GREY}))
+        self._add_input(InputPort("template", {IoDataType.IMAGE_GREY}))
+        self._add_output(OutputPort("image", {IoDataType.IMAGE_GREY}))
+
+        self._apply_default_params()
+
+    # ── Parameters ─────────────────────────────────────────────────────────────
+
+    @property
+    @override
+    def params(self) -> list[NodeParam]:
+        return [NodeParam("retain_size", NodeParamType.BOOL, {"default": True})]
+
+    # ── Properties ─────────────────────────────────────────────────────────────
+
+    @property
+    def retain_size(self) -> bool:
+        return self._retain_size
+
+    @retain_size.setter
+    def retain_size(self, value: bool) -> None:
+        self._retain_size = bool(value)
+
+    # ── NodeBase interface ─────────────────────────────────────────────────────
+
+    @override
+    def process_impl(self) -> None:
+        image: np.ndarray = self.inputs[0].data.image
+        template: np.ndarray = self.inputs[1].data.image
+
+        res = cv2.matchTemplate(image, template, cv2.TM_CCORR_NORMED)
+        res = cv2.normalize(
+            (res * 255).astype(np.uint8),
+            None,
+            alpha=0,
+            beta=255,
+            norm_type=cv2.NORM_MINMAX,
+        )
+
+        if self._retain_size:
+            h_t, w_t = template.shape[:2]
+            h_orig, w_orig = image.shape[:2]
+            h_m, w_m = res.shape[:2]
+
+            y0 = h_t // 2
+            x0 = w_t // 2
+
+            canvas = np.zeros((h_orig, w_orig), dtype=np.uint8)
+            canvas[y0:y0 + h_m, x0:x0 + w_m] = res
+            out = canvas
+        else:
+            out = res
+
+        self.outputs[0].send(IoData.from_greyscale(out))

--- a/src/nodes/filters/ncc.py
+++ b/src/nodes/filters/ncc.py
@@ -24,7 +24,20 @@ class Ncc(NodeBase):
     centre). With ``retain_size=False`` the raw ``matchTemplate`` output
     is emitted, which is smaller than the input by ``template.shape - 1``
     on each axis.
+
+    Multi-input EOS handling: ``Flow.run`` drives sources serially, so
+    one upstream chain can deliver its data *and* EOS before the other
+    has emitted anything. The default dispatcher would see EOS on one
+    input paired with real data on the other and take the
+    :meth:`_on_end_of_stream` branch — skipping the match entirely. This
+    node overrides :meth:`_signal_input_ready` to latch the last real
+    frame on each input and only forward EOS once every input has seen
+    it, so processing runs whenever both image and template are
+    available even if one upstream finished first.
     """
+
+    _IMAGE_IDX = 0
+    _TEMPLATE_IDX = 1
 
     def __init__(self) -> None:
         super().__init__("NCC", section="Processing")
@@ -33,6 +46,10 @@ class Ncc(NodeBase):
         self._add_input(InputPort("image", {IoDataType.IMAGE_GREY}))
         self._add_input(InputPort("template", {IoDataType.IMAGE_GREY}))
         self._add_output(OutputPort("image", {IoDataType.IMAGE_GREY}))
+
+        self._latched: list[np.ndarray | None] = [None, None]
+        self._eos_seen: list[bool] = [False, False]
+        self._eos_forwarded: bool = False
 
         self._apply_default_params()
 
@@ -56,9 +73,40 @@ class Ncc(NodeBase):
     # ── NodeBase interface ─────────────────────────────────────────────────────
 
     @override
+    def _before_run_impl(self) -> None:
+        super()._before_run_impl()
+        self._latched = [None, None]
+        self._eos_seen = [False, False]
+        self._eos_forwarded = False
+
+    @override
+    def _signal_input_ready(self) -> None:
+        new_frame = False
+        for idx, port in enumerate(self._inputs):
+            if not port.has_data:
+                continue
+            data = port.data
+            port.clear()
+            if data.is_end_of_stream():
+                self._eos_seen[idx] = True
+            else:
+                self._latched[idx] = data.image
+                new_frame = True
+
+        if new_frame and all(img is not None for img in self._latched):
+            self.process()
+
+        if not self._eos_forwarded and all(self._eos_seen):
+            self._eos_forwarded = True
+            eos = IoData.end_of_stream()
+            for out in self._outputs:
+                out.send(eos)
+
+    @override
     def process_impl(self) -> None:
-        image: np.ndarray = self.inputs[0].data.image
-        template: np.ndarray = self.inputs[1].data.image
+        image = self._latched[self._IMAGE_IDX]
+        template = self._latched[self._TEMPLATE_IDX]
+        assert image is not None and template is not None  # guarded by _signal_input_ready
 
         res = cv2.matchTemplate(image, template, cv2.TM_CCORR_NORMED)
         res = cv2.normalize(

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -7,7 +7,7 @@ import pytest
 
 from core.io_data import IoData
 from core.io_data import IoDataType
-from core.port import OutputPort
+from core.port import InputPort, OutputPort
 from nodes.filters.adaptive_gaussian_threshold import AdaptiveGaussianThreshold
 from nodes.filters.dither import Dither, DitherMethod
 from nodes.filters.median import Median
@@ -249,17 +249,10 @@ def test_ncc_rejects_colour_image_input() -> None:
         node.inputs[0].receive(IoData.from_image(colour))
 
 
-@pytest.mark.xfail(
-    reason=(
-        "Flow.run() starts sources sequentially, so ImageSource 1 emits "
-        "IMAGE_GREY + EOS on NCC.image before ImageSource 2 has delivered "
-        "anything to NCC.template. When template's first real frame then "
-        "arrives, the default dispatcher sees EOS already on image and "
-        "takes the _on_end_of_stream() branch — process_impl is skipped."
-    ),
-    strict=True,
-)
 def test_ncc_fires_when_first_chain_emits_eos_before_second_chain_emits_data() -> None:
+    """Regression: NCC must latch per-input data and defer EOS so
+    sequential sources (first chain emits image + EOS before second chain
+    emits anything) still produce a match."""
     node = Ncc()
 
     image_up = OutputPort("image", {IoDataType.IMAGE_GREY})
@@ -281,3 +274,39 @@ def test_ncc_fires_when_first_chain_emits_eos_before_second_chain_emits_data() -
     assert out is not None, "process_impl was never called"
     assert out.type == IoDataType.IMAGE_GREY
     assert out.image.shape == image.shape
+
+
+def test_ncc_reuses_latched_template_across_streamed_image_frames() -> None:
+    """Template arrives once; each new image frame should match against
+    the same latched template and emit its own output."""
+    node = Ncc()
+
+    image_up = OutputPort("image", {IoDataType.IMAGE_GREY})
+    template_up = OutputPort("template", {IoDataType.IMAGE_GREY})
+    image_up.connect(node.inputs[0])
+    template_up.connect(node.inputs[1])
+
+    template = np.full((4, 4), 255, dtype=np.uint8)
+    template_up.send(IoData.from_greyscale(template))
+    template_up.send(IoData.end_of_stream())
+
+    emitted: list[np.ndarray] = []
+    sink = InputPort("sink", {IoDataType.IMAGE_GREY})
+    sink.set_on_data_received(
+        lambda: emitted.append(sink.data.image) if sink.data.is_image() else None
+    )
+    node.outputs[0].connect(sink)
+
+    for y in (6, 12, 20):
+        frame = np.zeros((32, 32), dtype=np.uint8)
+        frame[y:y + 4, y:y + 4] = 255
+        image_up.send(IoData.from_greyscale(frame))
+
+    image_up.send(IoData.end_of_stream())
+
+    assert len(emitted) == 3
+    # Each frame's match peak should sit at the template centre of the
+    # bright square in that frame (offset by template//2 = 2).
+    for y, out in zip((6, 12, 20), emitted):
+        peak = np.unravel_index(int(np.argmax(out)), out.shape)
+        assert peak == (y + 2, y + 2)

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -6,6 +6,8 @@ import numpy as np
 import pytest
 
 from core.io_data import IoData
+from core.io_data import IoDataType
+from core.port import OutputPort
 from nodes.filters.adaptive_gaussian_threshold import AdaptiveGaussianThreshold
 from nodes.filters.dither import Dither, DitherMethod
 from nodes.filters.median import Median
@@ -245,3 +247,37 @@ def test_ncc_rejects_colour_image_input() -> None:
     colour = np.zeros((8, 8, 3), dtype=np.uint8)
     with pytest.raises(TypeError):
         node.inputs[0].receive(IoData.from_image(colour))
+
+
+@pytest.mark.xfail(
+    reason=(
+        "Flow.run() starts sources sequentially, so ImageSource 1 emits "
+        "IMAGE_GREY + EOS on NCC.image before ImageSource 2 has delivered "
+        "anything to NCC.template. When template's first real frame then "
+        "arrives, the default dispatcher sees EOS already on image and "
+        "takes the _on_end_of_stream() branch — process_impl is skipped."
+    ),
+    strict=True,
+)
+def test_ncc_fires_when_first_chain_emits_eos_before_second_chain_emits_data() -> None:
+    node = Ncc()
+
+    image_up = OutputPort("image", {IoDataType.IMAGE_GREY})
+    template_up = OutputPort("template", {IoDataType.IMAGE_GREY})
+    image_up.connect(node.inputs[0])
+    template_up.connect(node.inputs[1])
+
+    image = np.zeros((32, 32), dtype=np.uint8)
+    image[12:20, 12:20] = 255
+    template = np.full((8, 8), 255, dtype=np.uint8)
+
+    image_up.send(IoData.from_greyscale(image))
+    image_up.send(IoData.end_of_stream())
+
+    template_up.send(IoData.from_greyscale(template))
+    template_up.send(IoData.end_of_stream())
+
+    out = node.outputs[0].last_emitted
+    assert out is not None, "process_impl was never called"
+    assert out.type == IoDataType.IMAGE_GREY
+    assert out.image.shape == image.shape

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -9,6 +9,7 @@ from core.io_data import IoData
 from nodes.filters.adaptive_gaussian_threshold import AdaptiveGaussianThreshold
 from nodes.filters.dither import Dither, DitherMethod
 from nodes.filters.median import Median
+from nodes.filters.ncc import Ncc
 from nodes.filters.normalize import Normalize
 from nodes.filters.scale import Scale
 from nodes.filters.shift import Shift
@@ -190,3 +191,57 @@ def test_dither_rejects_unknown_method() -> None:
     node = Dither()
     with pytest.raises(ValueError):
         node.method = 99
+
+
+# ── NCC ───────────────────────────────────────────────────────────────────────
+
+def _feed_ncc(node: Ncc, image: np.ndarray, template: np.ndarray) -> np.ndarray:
+    node.inputs[0].receive(IoData.from_greyscale(image))
+    node.inputs[1].receive(IoData.from_greyscale(template))
+    out = node.outputs[0].last_emitted
+    assert out is not None, "NCC did not emit on output 0"
+    return out.image
+
+
+def test_ncc_retain_size_matches_input_shape() -> None:
+    image = _gradient(h=32, w=32)
+    template = image[10:16, 10:16].copy()
+
+    out = _feed_ncc(Ncc(), image, template)
+
+    assert out.shape == image.shape
+    assert out.dtype == np.uint8
+
+
+def test_ncc_peaks_at_template_centre_when_retain_size() -> None:
+    image = np.zeros((32, 32), dtype=np.uint8)
+    image[12:20, 12:20] = 255
+    template = np.full((8, 8), 255, dtype=np.uint8)
+
+    out = _feed_ncc(Ncc(), image, template)
+
+    # The perfect match sits at the top-left of the matchTemplate result
+    # (row=12, col=12); with retain_size it's offset by template/2 (=4),
+    # so the peak lands at the template centre (16, 16).
+    peak = np.unravel_index(int(np.argmax(out)), out.shape)
+    assert peak == (16, 16)
+    assert out[peak] == 255
+
+
+def test_ncc_without_retain_size_returns_raw_match_shape() -> None:
+    image = _gradient(h=32, w=32)
+    template = image[0:8, 0:8].copy()
+
+    node = Ncc()
+    node.retain_size = False
+    out = _feed_ncc(node, image, template)
+
+    # cv2.matchTemplate output: (H - h + 1, W - w + 1)
+    assert out.shape == (32 - 8 + 1, 32 - 8 + 1)
+
+
+def test_ncc_rejects_colour_image_input() -> None:
+    node = Ncc()
+    colour = np.zeros((8, 8, 3), dtype=np.uint8)
+    with pytest.raises(TypeError):
+        node.inputs[0].receive(IoData.from_image(colour))


### PR DESCRIPTION
## Summary
Adds a new image processing node that performs normalized cross-correlation (NCC) template matching using OpenCV's `matchTemplate` function. This node searches for a template pattern within an image and outputs a correlation score map.

## Changes
- **New node**: `Ncc` class in `src/nodes/filters/ncc.py`
  - Wraps `cv2.matchTemplate` with `TM_CCORR_NORMED` method
  - Rescales correlation scores to uint8 greyscale image
  - Supports two output modes via `retain_size` parameter:
    - `retain_size=True` (default): Outputs match map same size as input image, with responses centered at corresponding template positions
    - `retain_size=False`: Outputs raw matchTemplate result (smaller by template dimensions)
  - Accepts only single-channel greyscale images for both input and template

- **Tests**: Comprehensive test coverage in `tests/test_filters.py`
  - Validates output shape matches input when `retain_size=True`
  - Verifies peak correlation response aligns with template center position
  - Tests raw output shape when `retain_size=False`
  - Validates rejection of colour image inputs

## Implementation Details
- The node uses canvas-based offset positioning to align correlation responses with their corresponding template center pixels when `retain_size=True`
- Normalization is applied post-correlation to ensure proper uint8 range (0-255)
- Ported from original OCVL `NccProcessor` implementation

https://claude.ai/code/session_01SAAKpjiRahqsaBS8CwcYnN