### PR TITLE
Make SourceNodeBase.start() final and route through process()

### DIFF
--- a/src/core/node_base.py
+++ b/src/core/node_base.py
@@ -59,7 +59,9 @@ class NodeBase(ABC):
     Source and sink nodes subclass SourceNodeBase or SinkNodeBase instead.
 
     Execution model (push-based):
-      - SourceNodeBase.start() pushes IoData to its OutputPorts.
+      - SourceNodeBase.start() drives each source by calling process(), which
+        dispatches to process_impl(); a source's process_impl() pushes IoData
+        to its OutputPorts.
       - OutputPort.send() forwards data to all connected InputPorts.
       - Each InputPort notifies its owner node via _signal_input_ready().
       - Once all inputs have data, process() is invoked automatically.
@@ -254,8 +256,14 @@ class SourceNodeBase(NodeBase, ABC):
     """Abstract base class for source nodes.
 
     A source has outputs only — it produces data and drives the pipeline by
-    implementing start(). Subclasses must call OutputPort.send() for each
-    frame and send IoData.end_of_stream() on all outputs when done.
+    implementing :meth:`process_impl`. Subclasses must call OutputPort.send()
+    for each frame and send IoData.end_of_stream() on all outputs when done.
+
+    :meth:`start` is the public entry point used by :class:`core.flow.Flow`
+    to kick a source off. It is final and simply routes through
+    :meth:`process`, so source nodes benefit from the same per-node logging
+    and observer hook that filters and sinks do (the UI uses that hook to
+    highlight the currently-running node).
 
     Override :attr:`is_reactive` to ``True`` in sources that produce a single
     static result (e.g. a still image). The node editor will automatically
@@ -275,17 +283,15 @@ class SourceNodeBase(NodeBase, ABC):
         """
         return False
 
-    @abstractmethod
+    @final
     def start(self) -> None:
-        """Produce data and push it to output ports.
+        """Drive the source by invoking :meth:`process`.
 
-        Must send IoData.end_of_stream() on all outputs when done.
+        Kept as a distinct entry point so :meth:`core.flow.Flow.run` can
+        tell source nodes apart from ordinary nodes without type-sniffing
+        on every call.
         """
-        ...
-
-    @override
-    def process_impl(self) -> None:
-        raise RuntimeError("SourceNodeBase has no inputs; call start() instead")
+        self.process()
 
     @override
     def _on_end_of_stream(self) -> None:

--- a/src/core/node_registry.py
+++ b/src/core/node_registry.py
@@ -234,18 +234,21 @@ def _validate_node_class(
     """Return structural errors for a node class.
 
     Enforced rules:
-      - ``start()`` is only valid on source nodes. Only source nodes can be
-        entry points for a flow (see :meth:`Flow.run`), so a non-source class
-        that defines ``start()`` would silently never be called. Reject it.
+      - ``start()`` must not be overridden. It is a final trampoline on
+        :class:`SourceNodeBase` that routes through :meth:`process`;
+        overriding it would bypass the per-node logging and observer hook
+        that the UI relies on to show which node is currently running.
+        Non-source classes that define ``start()`` would also silently
+        never be called by :meth:`Flow.run`.
     """
     errors: list[ScanError] = []
-    if category != "Sources" and _has_method(class_node, "start"):
+    if _has_method(class_node, "start"):
         errors.append(ScanError(
             file=path,
             message=(
-                f"'{class_node.name}' defines start(), but start() is only "
-                f"valid on source nodes. Only source nodes can be entry "
-                f"points for a flow."
+                f"'{class_node.name}' defines start(), but start() must not "
+                f"be overridden. Source nodes should implement process_impl() "
+                f"instead; start() is a final trampoline on SourceNodeBase."
             ),
         ))
     return errors

--- a/src/nodes/sources/image_source.py
+++ b/src/nodes/sources/image_source.py
@@ -71,7 +71,7 @@ class ImageSource(SourceNodeBase):
         return True
 
     @override
-    def start(self) -> None:
+    def process_impl(self) -> None:
         resolved = self._resolved_path()
         if not resolved.exists():
             raise FileNotFoundError(f"Input file not found: {resolved}")

--- a/src/nodes/sources/video_source.py
+++ b/src/nodes/sources/video_source.py
@@ -62,7 +62,7 @@ class VideoSource(SourceNodeBase):
     # ── SourceNodeBase interface ────────────────────────────────────────────────
 
     @override
-    def start(self) -> None:
+    def process_impl(self) -> None:
         if not self._file_path.exists():
             raise FileNotFoundError(f"Input file not found: {self._file_path}")
 


### PR DESCRIPTION
## Summary
Refactored the source node execution model to make `start()` a final method that routes through `process()`, ensuring all source nodes benefit from per-node logging and observer hooks used by the UI.

## Key Changes
- **SourceNodeBase.start()**: Changed from abstract method to `@final` implementation that simply calls `self.process()`. This ensures source nodes go through the same logging and observer infrastructure as filters and sinks.
- **SourceNodeBase.process_impl()**: Removed the default implementation that raised `RuntimeError`. Source nodes now override `process_impl()` instead of `start()`.
- **Source node implementations**: Updated `ImageSource` and `VideoSource` to implement `process_impl()` instead of `start()`.
- **Validation rules**: Updated `node_registry._validate_node_class()` to reject any class (source or non-source) that defines `start()`, since it's now a final method on `SourceNodeBase`.
- **Documentation**: Enhanced docstrings to clarify the execution flow and explain why `start()` is kept as a distinct entry point for `Flow.run()` to identify source nodes without type-checking.

## Implementation Details
The change maintains backward compatibility at the API level while improving the internal architecture. The `start()` method remains the public entry point that `Flow.run()` calls to identify and execute source nodes, but it now delegates to `process()` which provides the necessary instrumentation for logging and UI updates. This eliminates the need for special-case handling of source nodes in the observer/logging system.

https://claude.ai/code/session_01DNSUf1KZzQe3mp8YQ46jRf