### PR TITLE
Update README and CHANGELOG for 0.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-All notable changes to Sparklehoof (repo: `image-inquest`) are tracked
+All notable changes to Stjörnhorn (repo: `image-inquest`) are tracked
 in this file.
 
 The format loosely follows [Keep a
@@ -9,6 +9,57 @@ to adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 once a first tagged release is cut.
 
 ## [Unreleased]
+
+## [0.1.3] — 2026-04-21
+
+### Added
+- **Display node** (palette section *Output*) — pass-through node
+  that renders every frame inline inside its own node body via a
+  live `QLabel` preview. Drop it anywhere in the graph to watch
+  frames in real time without leaving the editor.
+- **Video Sink** — encodes incoming frames to a video file via
+  `cv2.VideoWriter`. The writer opens lazily on the first frame (so
+  dimensions are inferred from the data) and is finalised in
+  `_on_finish` when the runner signals end-of-stream. Params:
+  `output_path`, `fps`, `codec` (MP4V or XVID).
+- **NCC** — normalised cross-correlation template matching node
+  (`cv2.matchTemplate` with `TM_CCORR_NORMED`). Takes separate
+  `image` and `template` greyscale inputs and emits an 8-bit score
+  map; `retain_size` controls whether the match is padded back to
+  the input image size (#110).
+- **Resizable nodes.** Every `NodeItem` grows a diagonal grip at
+  its bottom-right corner; drag to resize. Preview-bearing nodes
+  honour both axes (the preview fills spare vertical space), others
+  resize in width only. Sizes round-trip through `flow_io` via a
+  new `"size": [w, h]` field on saved nodes.
+- **`NodeParamType.STRING`** + `StringParamWidget` — line-edit
+  editor that commits on `editingFinished` so validating setters
+  don't raise mid-typing. Supports `placeholder` and `max_length`
+  metadata.
+- **Splash screen text.** The splash pixmap is overlaid with
+  `APP_DISPLAY_NAME` and the current version in large type, with
+  font sizes scaling to the pixmap height so the splash reads well
+  at any asset resolution.
+
+### Changed
+- **Stream lifetime is no longer a payload.** `IoData.END_OF_STREAM`
+  and `IoData.end_of_stream()` are gone; `InputPort` / `OutputPort`
+  gain a dedicated `finish()` method plus a `finished` property that
+  propagates across connections. `NodeBase._on_end_of_stream` →
+  `_on_finish`. `Flow.run` signals end-of-stream centrally by
+  calling `finish()` on every source output once every source's
+  `start()` has returned, so a one-shot source can no longer drive
+  EOS into a sibling input before the sibling has produced data.
+  Sources stop emitting EOS inline; Merge reacts to `port.finished`.
+
+### Fixed
+- **Running a flow twice** no longer raises "`send() called after
+  finish()`". `NodeBase.before_run()` calls `port.reset()` on every
+  input and output port before dispatching to the subclass hook, so
+  stale `finished` flags from the previous run don't block the new
+  one.
+
+## [pre-0.1.3] — accumulated, previously unreleased
 
 ### Added
 - **Enum-typed node parameters.** `NodeParamType.ENUM` + an

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="assets/title.png" alt="Sparklehoof" width="640"/>
+  <img src="assets/title.png" alt="Stjörnhorn" width="640"/>
 </p>
 
 This is a vibe coding experiment. It is based on an image processing pipeline that
@@ -93,8 +93,10 @@ toolbar to drive the flow.
 - **Canvas** (centre) — the flow graph. Each node shows its title,
   input ports on the left, output ports on the right, and editable
   parameters in the body. A small × in the top-right of a node
-  deletes it. Scroll to zoom; middle-mouse-drag to pan. Dropping a
-  node from the palette places it at the cursor.
+  deletes it; a diagonal grip in the bottom-right lets you drag to
+  resize the node (preview-bearing nodes grow in both axes, others
+  in width only). Scroll to zoom; middle-mouse-drag to pan. Dropping
+  a node from the palette places it at the cursor.
 - **Output Inspector** (dockable, below the Node List) — previews the
   current output of whichever node is selected. Float it for a larger
   view; once floating, press <kbd>F11</kbd> to toggle full-screen
@@ -170,6 +172,21 @@ label the node carries in the **Node List**.
   path. Paths under the app's output folder are stored relative to it
   so saved flows stay portable. An eye button next to the path opens
   the written file in the OS default image viewer.
+- **Video Sink** — encodes incoming frames to a video file using
+  `cv2.VideoWriter`. The writer is opened lazily on the first frame
+  (dimensions inferred from the data), frames are written as they
+  arrive, and the container is finalised when the runner signals
+  end-of-stream. Parameters: `output_path` (relative to the output
+  folder stays portable), `fps`, and `codec` (MP4V or XVID).
+  Greyscale inputs are promoted to BGR automatically.
+
+### Output
+
+- **Display** — pass-through node that renders each frame inline in
+  its own node body via a live QLabel preview. Drop it anywhere in a
+  flow to watch frames as they flow through (e.g. upstream of a
+  Video Sink to monitor encoding in real time). Resize the node to
+  grow the preview.
 
 ### Color Spaces
 
@@ -209,6 +226,13 @@ label the node carries in the **Node List**.
 - **Normalize** — histogram equalisation
   (`cv2.equalizeHist`). Colour inputs are equalised per channel;
   greyscale inputs are equalised directly. Output type matches input.
+- **NCC** — normalised cross-correlation template matching
+  (`cv2.matchTemplate` with `TM_CCORR_NORMED`). Both the `image` and
+  `template` inputs must be greyscale; the output is an 8-bit score
+  map. `retain_size=True` (default) pads the match map back to the
+  input image size and centres each response on its corresponding
+  template-centre pixel; `retain_size=False` emits the raw
+  `matchTemplate` result.
 
 ### Composit
 


### PR DESCRIPTION
## Summary

Follow-up to #113 (splash + version bump) — brings the README and CHANGELOG in line with what actually ships in 0.1.3. No code changes.

## README.md

- Fix stale hero image `alt="Sparklehoof"` → `"Stjörnhorn"`.
- Canvas description now documents the bottom-right resize grip (both-axis for preview-bearing nodes, width-only for others).
- **Sinks** section: add **Video Sink** (lazy `cv2.VideoWriter`, finalised on end-of-stream; `output_path` / `fps` / `codec` params).
- New **Output** section under built-in nodes with **Display** (pass-through, inline `QLabel` preview, resize to grow the preview).
- **Processing** section: add **NCC** (normalised cross-correlation template matching).

## CHANGELOG.md

- Fix stale "Sparklehoof" reference in the opening paragraph.
- Cut a `[0.1.3] — 2026-04-21` section covering the features actually shipped in 0.1.3:
  - **Added**: Display, Video Sink, NCC, resizable nodes, `StringParamWidget` / `NodeParamType.STRING`, splash screen with app name + version.
  - **Changed**: `IoData.END_OF_STREAM` → dedicated `port.finish()` channel; `_on_end_of_stream` → `_on_finish`; `Flow.run` signals end-of-stream centrally after every source returns.
  - **Fixed**: running a flow twice no longer raises "`send() called after finish()`" — `NodeBase.before_run` resets port lifecycle state.
- Preserve the existing pre-0.1.3 accumulated `[Unreleased]` entries verbatim under a new `[pre-0.1.3] — accumulated, previously unreleased` heading so none of that history is lost.
- Fresh empty `[Unreleased]` at the top, ready for the next version.

## Test plan

- [x] Markdown renders cleanly (no unclosed emphasis, code fences intact).
- [x] No code touched — existing test suite unaffected.
- [ ] Eyeball the changelog to confirm the pre-0.1.3 section still reads as expected; edit or collapse that section further if desired.

https://claude.ai/code/session_01SAAKpjiRahqsaBS8CwcYnN