### PR TITLE
Move file dialog filter strings into constants

### DIFF
--- a/src/constants.py
+++ b/src/constants.py
@@ -35,6 +35,12 @@ BUILTIN_NODES_DIR: Path = Path(__file__).parent / "nodes"
 INPUT_DIR:  Path = Path(__file__).parent.parent / "input"
 OUTPUT_DIR: Path = Path(__file__).parent.parent / "output"
 
+# File dialog extension filters used by FilePathParamWidget.
+FILE_SAVE_FILTER:  str = "Images (*.png *.jpg *.jpeg)"
+FILE_OPEN_FILTER:  str = "Images (*.png *.jpg *.jpeg *.cr2);;All files (*)"
+VIDEO_SAVE_FILTER: str = "Video (*.mp4)"
+VIDEO_OPEN_FILTER: str = "Video (*.mp4 *.avi *.mov *.mkv);;All files (*)"
+
 # Folder where saved flows are written (one JSON file per flow).
 FLOW_DIR:   Path = Path(__file__).parent.parent / "flow"
 

--- a/src/constants.py
+++ b/src/constants.py
@@ -37,9 +37,9 @@ OUTPUT_DIR: Path = Path(__file__).parent.parent / "output"
 
 # File dialog extension filters used by FilePathParamWidget.
 FILE_SAVE_FILTER:  str = "Images (*.png *.jpg *.jpeg)"
-FILE_OPEN_FILTER:  str = "Images (*.png *.jpg *.jpeg *.cr2);;All files (*)"
+FILE_OPEN_FILTER:  str = "Images (*.webp, *.png *.jpg *.jpeg *.cr2)"
 VIDEO_SAVE_FILTER: str = "Video (*.mp4)"
-VIDEO_OPEN_FILTER: str = "Video (*.mp4 *.avi *.mov *.mkv);;All files (*)"
+VIDEO_OPEN_FILTER: str = "Video (*.mp4 *.avi *.mov *.mkv)"
 
 # Folder where saved flows are written (one JSON file per flow).
 FLOW_DIR:   Path = Path(__file__).parent.parent / "flow"

--- a/src/nodes/sinks/file_sink.py
+++ b/src/nodes/sinks/file_sink.py
@@ -43,7 +43,7 @@ class FileSink(SinkNodeBase):
     @property
     @override
     def params(self) -> list[NodeParam]:
-        return [NodeParam("output_path", NodeParamType.FILE_PATH, {"default": "out.png", "mode": "save"})]
+        return [NodeParam("output_path", NodeParamType.FILE_PATH, {"default": "out.png", "mode": "save", "filetype": "image"})]
 
     # ── Properties ─────────────────────────────────────────────────────────────
 

--- a/src/nodes/sinks/video_sink.py
+++ b/src/nodes/sinks/video_sink.py
@@ -66,7 +66,7 @@ class VideoSink(SinkNodeBase):
     @override
     def params(self) -> list[NodeParam]:
         return [
-            NodeParam("output_path", NodeParamType.FILE_PATH, {"default": "out.mp4", "mode": "save"}),
+            NodeParam("output_path", NodeParamType.FILE_PATH, {"default": "out.mp4", "mode": "save", "filetype": "video"}),
             NodeParam("fps",         NodeParamType.FLOAT,     {"default": 30.0}),
             NodeParam(
                 "codec",

--- a/src/nodes/sources/image_source.py
+++ b/src/nodes/sources/image_source.py
@@ -46,7 +46,7 @@ class ImageSource(SourceNodeBase):
     @override
     def params(self) -> list[NodeParam]:
         return [
-            NodeParam("file_path", NodeParamType.FILE_PATH, {"default": "example.jpg"}),
+            NodeParam("file_path", NodeParamType.FILE_PATH, {"default": "example.jpg", "filetype": "image"}),
         ]
 
     @property

--- a/src/nodes/sources/video_source.py
+++ b/src/nodes/sources/video_source.py
@@ -39,7 +39,7 @@ class VideoSource(SourceNodeBase):
     @override
     def params(self) -> list[NodeParam]:
         return [
-            NodeParam("file_path",      NodeParamType.FILE_PATH, {"default": "./input/example.mp4"}),
+            NodeParam("file_path",      NodeParamType.FILE_PATH, {"default": "./input/example.mp4", "filetype": "video"}),
             NodeParam("max_num_frames", NodeParamType.INT,       {"default": -1}),
         ]
 

--- a/src/ui/param_widgets.py
+++ b/src/ui/param_widgets.py
@@ -19,19 +19,19 @@ from PySide6.QtWidgets import (
     QWidget,
 )
 
-from constants import INPUT_DIR, OUTPUT_DIR
+from constants import (
+    FILE_OPEN_FILTER,
+    FILE_SAVE_FILTER,
+    INPUT_DIR,
+    OUTPUT_DIR,
+    VIDEO_OPEN_FILTER,
+    VIDEO_SAVE_FILTER,
+)
 from core.node_base import NodeBase, NodeParam, NodeParamType
 from ui.controls.scene_aware_combobox import SceneAwareComboBox
 from ui.icons import material_icon
 
 logger = logging.getLogger(__name__)
-
-
-_SAVE_FILTER = "Images (*.png *.jpg *.jpeg)"
-_OPEN_FILTER = (
-    "Images / video (*.png *.jpg *.jpeg *.mp4 *.cr2);;"
-    "All files (*)"
-)
 
 
 class ParamWidgetBase(QWidget):
@@ -341,6 +341,7 @@ class FilePathParamWidget(ParamWidgetBase):
     def __init__(self, node: NodeBase, param: NodeParam) -> None:
         super().__init__(node, param)
         self._is_save = param.metadata.get("mode") == "save"
+        self._is_video = param.metadata.get("filetype") == "video"
 
         self._line = QLineEdit()
         self._line.setPlaceholderText("Select a file…")
@@ -399,12 +400,14 @@ class FilePathParamWidget(ParamWidgetBase):
         initial = str(folder) if folder.is_dir() else str(fallback)
 
         if self._is_save:
+            save_filter = VIDEO_SAVE_FILTER if self._is_video else FILE_SAVE_FILTER
             path, _ = QFileDialog.getSaveFileName(
-                self._line, "Save File As", initial, _SAVE_FILTER,
+                self._line, "Save File As", initial, save_filter,
             )
         else:
+            open_filter = VIDEO_OPEN_FILTER if self._is_video else FILE_OPEN_FILTER
             path, _ = QFileDialog.getOpenFileName(
-                self._line, "Select File", initial, _OPEN_FILTER,
+                self._line, "Select File", initial, open_filter,
             )
         if path:
             # Run the value through the node setter (which may normalise it


### PR DESCRIPTION
Split the image/video dialog filter that used to live as private _SAVE_FILTER / _OPEN_FILTER strings inside param_widgets into four public constants (FILE_SAVE_FILTER, FILE_OPEN_FILTER, VIDEO_SAVE_FILTER, VIDEO_OPEN_FILTER) and tag the video source/sink FILE_PATH params with filetype="video" so FilePathParamWidget can pick the right filter.