### PR TITLE
Add _path member to FilePathParamWidget with base_dir-aware normalization

### DIFF
--- a/src/ui/param_widgets.py
+++ b/src/ui/param_widgets.py
@@ -360,7 +360,9 @@ class FilePathParamWidget(ParamWidgetBase):
         # self._view exists, since _update_view_enabled touches it.
         self._line.textChanged.connect(self._on_value_changed)
         self._line.textChanged.connect(self._update_view_enabled)
-        self._line.setText(str(self._initial_value("")))
+        initial = str(self._initial_value(""))
+        self._path = Path(initial)
+        self._line.setText(initial)
         self._update_view_enabled()
 
         layout = QHBoxLayout(self)
@@ -376,6 +378,7 @@ class FilePathParamWidget(ParamWidgetBase):
 
     @override
     def set_value(self, value: object) -> None:
+        self._path = Path(str(value))
         self._line.setText(str(value))
 
     @override

--- a/src/ui/param_widgets.py
+++ b/src/ui/param_widgets.py
@@ -378,17 +378,25 @@ class FilePathParamWidget(ParamWidgetBase):
 
     @override
     def set_value(self, value: object) -> None:
-        new_path = Path(str(value)).resolve()
-        if new_path in self._base_dir.parents:
-            # check if the path is a child of the base dir; if so, display it as 
-            # a relative path to keep saved flows portable across machines with 
-            # different absolute layouts
+        text = str(value)
+        if not text:
+            self._line.setText("")
+            self._path = Path()
+            return
+
+        # Relative inputs are resolved against base_dir (matching the
+        # node setters), not the process CWD.
+        raw = Path(text)
+        new_path = (raw if raw.is_absolute() else self._base_dir / raw).resolve()
+
+        # Paths that live under base_dir are displayed as relative, so
+        # saved flows stay portable across machines with different
+        # absolute layouts.
+        if new_path.is_relative_to(self._base_dir):
             self._line.setText(new_path.relative_to(self._base_dir).as_posix())
         else:
-            # otherwise, display it as an absolute path
             self._line.setText(new_path.as_posix())
-
-        self._path = new_path.resolve()
+        self._path = new_path
 
     @override
     def get_value(self) -> object:

--- a/src/ui/param_widgets.py
+++ b/src/ui/param_widgets.py
@@ -380,8 +380,8 @@ class FilePathParamWidget(ParamWidgetBase):
     def set_value(self, value: object) -> None:
         text = str(value)
         if not text:
-            self._line.setText("")
             self._path = Path()
+            self._line.setText("")
             return
 
         # Relative inputs are resolved against base_dir (matching the
@@ -393,10 +393,14 @@ class FilePathParamWidget(ParamWidgetBase):
         # saved flows stay portable across machines with different
         # absolute layouts.
         if new_path.is_relative_to(self._base_dir):
-            self._line.setText(new_path.relative_to(self._base_dir).as_posix())
+            display = new_path.relative_to(self._base_dir).as_posix()
         else:
-            self._line.setText(new_path.as_posix())
+            display = new_path.as_posix()
+
+        # Assign _path before setText so the textChanged slots
+        # (_update_view_enabled in particular) see a valid path.
         self._path = new_path
+        self._line.setText(display)
 
     @override
     def get_value(self) -> object:

--- a/src/ui/param_widgets.py
+++ b/src/ui/param_widgets.py
@@ -337,7 +337,7 @@ class FilePathParamWidget(ParamWidgetBase):
         self._filter = str(param.metadata.get("filter", ""))
         self._base_dir = Path(
             param.metadata.get("base_dir", OUTPUT_DIR if self._is_save else INPUT_DIR)
-        )
+        ).resolve()
 
         self._line = QLineEdit()
         self._line.setPlaceholderText("Select a file…")
@@ -360,9 +360,9 @@ class FilePathParamWidget(ParamWidgetBase):
         # self._view exists, since _update_view_enabled touches it.
         self._line.textChanged.connect(self._on_value_changed)
         self._line.textChanged.connect(self._update_view_enabled)
-        initial = str(self._initial_value(""))
-        self._path = Path(initial)
-        self._line.setText(initial)
+
+        # initialize self._path and the line edit's text to the node's current value (or the
+        self.set_value(str(self._initial_value(""))) 
         self._update_view_enabled()
 
         layout = QHBoxLayout(self)
@@ -378,8 +378,17 @@ class FilePathParamWidget(ParamWidgetBase):
 
     @override
     def set_value(self, value: object) -> None:
-        self._path = Path(str(value))
-        self._line.setText(str(value))
+        new_path = Path(str(value)).resolve()
+        if new_path in self._base_dir.parents:
+            # check if the path is a child of the base dir; if so, display it as 
+            # a relative path to keep saved flows portable across machines with 
+            # different absolute layouts
+            self._line.setText(new_path.relative_to(self._base_dir).as_posix())
+        else:
+            # otherwise, display it as an absolute path
+            self._line.setText(new_path.as_posix())
+
+        self._path = new_path.resolve()
 
     @override
     def get_value(self) -> object:
@@ -421,19 +430,8 @@ class FilePathParamWidget(ParamWidgetBase):
             self._update_view_enabled()
             self.value_changed.emit(canonical)
 
-    def _resolved_current_path(self) -> Path:
-        """Return the absolute path referenced by the line edit.
-
-        Relative values are joined with the node's base_dir to match
-        how the corresponding node setters resolve them.
-        """
-        p = Path(self._line.text() or "")
-        if not p.is_absolute():
-            p = self._base_dir / p
-        return p
-
     def _update_view_enabled(self) -> None:
-        self._view.setEnabled(self._resolved_current_path().is_file())
+        self._view.setEnabled(self._path.is_file())
 
     @override
     def refresh(self) -> None:
@@ -444,9 +442,8 @@ class FilePathParamWidget(ParamWidgetBase):
         self._update_view_enabled()
 
     def _open_in_viewer(self) -> None:
-        path = self._resolved_current_path()
-        if path.is_file():
-            QDesktopServices.openUrl(QUrl.fromLocalFile(str(path)))
+        if self._path.is_file():
+            QDesktopServices.openUrl(QUrl.fromLocalFile(str(self._path)))
 
 
 # ── Registry & factory ─────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Introduce a `_path: Path` member on `FilePathParamWidget`, maintained exclusively by `set_value` (called once from `__init__` to seed the initial state).
- Normalize paths in `set_value`: resolve relative inputs against the node's `base_dir` (not the process CWD), and display paths that live under `base_dir` as relative so saved flows stay portable across machines.
- Drop `_resolved_current_path` in favor of reading `self._path` directly in `_update_view_enabled` / `_open_in_viewer`.
- Fix init-order bug where `self._line.setText(...)` fired `textChanged` → `_update_view_enabled` before `self._path` existed; `_path` is now assigned before `setText`.

## Test plan
- [ ] Open a flow containing an `ImageSource` — the `file_path` widget shows the stored relative value (e.g. `example.jpg`) and the view button is enabled iff the file exists.
- [ ] Browse to an image under `INPUT_DIR`; confirm the line edit shows the path relative to `INPUT_DIR`.
- [ ] Browse to an image outside `INPUT_DIR`; confirm the line edit shows the absolute path.
- [ ] Run a flow with a `FileSink` that writes to `OUTPUT_DIR`; after the run, the view button lights up without re-opening the flow.
- [ ] Load a flow with an empty `file_path` — the widget initializes with an empty line edit and a disabled view button (no AttributeError in the log).

---
_Generated by [Claude Code](https://claude.ai/code/session_01NTKMFjiDzRm1AfBviZiEH4)_