### PR TITLE
Warm numba JIT on main thread to avoid worker-thread segfault

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -194,6 +194,40 @@ def _paint_splash_text(pixmap: QPixmap) -> QPixmap:
     return canvas
 
 
+def _warmup_numba() -> None:
+    """Force numba's lazy registry loading onto the main thread.
+
+    Numba lazily loads its compilation registries the first time any
+    ``@njit`` function is compiled or a cached overload is loaded in a
+    process (``numba.core.cpu.load_additional_registries`` → imports of
+    ``charseq`` → ``unicode`` → ``hashing`` → ``randomimpl``). If that
+    first compile happens on a :class:`QThread` worker — as it does
+    when :class:`FlowRunner` executes a node like :class:`Dither` — the
+    import chain runs under GC pressure on a non-main thread, and has
+    been observed to segfault in Python's ABC class construction on
+    some numba/CPython builds (fatal "Garbage-collecting" crash in
+    ``abc.__new__``).
+
+    Compiling a trivial njit here runs the whole lazy-import chain on
+    the main thread at startup, so workers later only ever hit an
+    already-populated registry.
+    """
+    try:
+        import numba
+        import numpy as np
+
+        @numba.njit(cache=True)
+        def _noop(x: np.ndarray) -> np.ndarray:
+            return x + 1
+
+        _noop(np.zeros(1, dtype=np.float32))
+    except Exception:
+        # Warmup is a stability measure, not a correctness requirement —
+        # if numba itself is broken the real JIT call will surface the
+        # error at run time with a more useful traceback.
+        logger.exception("numba warmup failed; continuing without it")
+
+
 def _make_splash(screen: QScreen) -> QSplashScreen | None:
     """Build the startup splash screen, or return ``None`` if the image
     is missing / unreadable. Never fatal — a missing splash should not
@@ -266,6 +300,11 @@ def main(argv: list[str]) -> int:
     if splash is not None:
         splash.show()
         app.processEvents()
+
+    # Must happen on the main thread, before any FlowRunner QThread can
+    # trigger its own first @njit compile — see _warmup_numba for the
+    # segfault this prevents.
+    _warmup_numba()
 
     window = MainWindow(initial_flow_path=initial_flow_path)
     # Anchor the window on the chosen monitor before maximizing so the


### PR DESCRIPTION
## Summary

Fixes a segfault reproducible by loading a flow with a `Dither` node and clicking Run. faulthandler traced it to GC running during `abc.__new__` on a `FlowRunner` QThread worker, inside numba's lazy-import chain (`numba.core.cpu.load_additional_registries` → `charseq` → `unicode` → `hashing` → `randomimpl`). That chain creates ABC classes whose construction triggers a GC cycle, and GC on the non-main QThread crashes on some numba/CPython builds.

`cache=True` on `_dither_diffusion` only caches the compiled binary — the Python-level registry load still runs on the first compile or first cached-overload load in the process, i.e. on whichever thread gets there first.

**Fix**: added `_warmup_numba()` in `src/main.py` that compiles a trivial `@njit` on the main thread after the splash renders and before the main window is constructed. This forces the registry load to happen on the main thread, so the FlowRunner worker only ever hits an already-populated registry. Guarded with try/except so a broken numba install still lets the app start and surfaces the real error from the actual JIT call.

## Test plan

- [ ] Launch the app and confirm startup still completes (splash → main window).
- [ ] Load a flow containing a `Dither` node (error-diffusion method, e.g. Stucki / Floyd-Steinberg).
- [ ] Click Run — the flow should finish without a fatal "Garbage-collecting" segfault.
- [ ] Click Run a second time — still works (no regression on repeat runs / cached overload).
- [ ] Run existing test suite (`pytest tests/`) to verify no regressions.

https://claude.ai/code/session_01Y6Gfbvs2UVbNeBvVuhY2hD

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y6Gfbvs2UVbNeBvVuhY2hD)_