### PR TITLE
Screen-topology logging + repo rules in CLAUDE.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,22 @@ once a first tagged release is cut.
 
 ## [Unreleased]
 
+## [0.1.5] — 2026-04-23
+
+### Fixed
+- **Blank node bodies after the display blanks/resumes** on Linux
+  dual-monitor setups. Each node's parameter editors are hosted by a
+  `QGraphicsProxyWidget`, whose offscreen surface gets invalidated when
+  DPMS kicks in or the screen layout changes — leaving every node with
+  only its painted frame (header, ports, close button, resize grip) and
+  no interior content. `FlowView` now listens for `screenAdded`,
+  `screenRemoved`, `primaryScreenChanged`, the window's `screenChanged`,
+  and the view's `QEvent.ScreenChangeInternal`, and on any of those it
+  clears `QPixmapCache` and forces every proxy widget in the scene to
+  repaint. Every screen-topology event is also logged (screen name,
+  geometry, device-pixel ratio, refresh rate) so post-mortems show
+  exactly what the window system did.
+
 ## [0.1.4] — 2026-04-23
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,19 +12,14 @@ once a first tagged release is cut.
 
 ## [0.1.5] — 2026-04-23
 
-### Fixed
-- **Blank node bodies after the display blanks/resumes** on Linux
-  dual-monitor setups. Each node's parameter editors are hosted by a
-  `QGraphicsProxyWidget`, whose offscreen surface gets invalidated when
-  DPMS kicks in or the screen layout changes — leaving every node with
-  only its painted frame (header, ports, close button, resize grip) and
-  no interior content. `FlowView` now listens for `screenAdded`,
-  `screenRemoved`, `primaryScreenChanged`, the window's `screenChanged`,
-  and the view's `QEvent.ScreenChangeInternal`, and on any of those it
-  clears `QPixmapCache` and forces every proxy widget in the scene to
-  repaint. Every screen-topology event is also logged (screen name,
-  geometry, device-pixel ratio, refresh rate) so post-mortems show
-  exactly what the window system did.
+### Added
+- **Screen-topology logging** in `FlowView`. The initial monitor layout
+  (name, geometry, device-pixel ratio, refresh rate) is written to the
+  log on startup, and every subsequent `screenAdded`, `screenRemoved`,
+  `primaryScreenChanged`, window `screenChanged`, and view
+  `QEvent.ScreenChangeInternal` is logged too. Groundwork for
+  diagnosing render glitches that correlate with brief display
+  blackouts on Linux Mint / X11 / NVIDIA setups.
 
 ## [0.1.4] — 2026-04-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,16 +21,6 @@ once a first tagged release is cut.
   diagnosing render glitches that correlate with brief display
   blackouts on Linux Mint / X11 / NVIDIA setups.
 
-### Fixed
-- **Black, unrecoverable node canvas after opening and cancelling the
-  "Open Flow" dialog on Windows**. The native Windows file dialog
-  (`IFileOpenDialog`) runs its own nested modal loop, which left the
-  `FlowView` viewport stuck in a never-repainting black state — the
-  scene/flow data was intact (save and reload recovered everything),
-  but no runtime interaction could bring the canvas back. Pass
-  `QFileDialog.Option.DontUseNativeDialog` on the Open handler so Qt's
-  own dialog is used instead, sidestepping the bug entirely.
-
 ## [0.1.4] — 2026-04-23
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,16 @@ once a first tagged release is cut.
   diagnosing render glitches that correlate with brief display
   blackouts on Linux Mint / X11 / NVIDIA setups.
 
+### Fixed
+- **Black, unrecoverable node canvas after opening and cancelling the
+  "Open Flow" dialog on Windows**. The native Windows file dialog
+  (`IFileOpenDialog`) runs its own nested modal loop, which left the
+  `FlowView` viewport stuck in a never-repainting black state — the
+  scene/flow data was intact (save and reload recovered everything),
+  but no runtime interaction could bring the canvas back. Pass
+  `QFileDialog.Option.DontUseNativeDialog` on the Open handler so Qt's
+  own dialog is used instead, sidestepping the bug entirely.
+
 ## [0.1.4] — 2026-04-23
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,3 +11,5 @@
 - Track reported bugs and feature requests as GitHub issues in the repo's tracker. When the user describes a bug, open an issue for it (unless one already exists).
 - When opening a PR that addresses an existing issue, include `Fixes #N` (or `Closes #N`) in the PR description so GitHub auto-closes the issue on merge.
 - If a PR that addresses an issue is merged without the auto-close keyword, close the issue manually and link back to the merged PR.
+- Mark every issue you file with a footer line `_Filed by Claude Code._` at the end of the body, so user-filed issues stay visually distinct from Claude-filed ones.
+- Do not pick up or attempt to fix issues that the user created unless the user explicitly asks for it. Claude-filed issues are fair game to work on when in scope.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,10 +2,12 @@
 
 ## Pull Requests
 - When a pull request changes source code, increment the version number as part of the PR. Skip the bump for PRs that only touch docs, config, CI, or similar non-source changes.
+- Keep the PR description and the `CHANGELOG.md` entry in sync with what's actually on the branch. Whenever you add, remove, or rescope commits on a PR branch, update the PR title/body and the CHANGELOG so they reflect the branch's current state — not the PR's original proposal.
 
 ## Branch Hygiene
 - Keep working branches regularly updated from the main branch (fetch + merge/rebase from `main`) while work is in progress.
 - Assume the user may commit changes to the branch while you are working on it. Before editing, fetch and integrate any new commits from the remote, and re-check file contents rather than relying on earlier reads.
+- When a PR is merged, delete its branch (both local and on origin). Any follow-up change — even a closely related one — starts on a new branch cut from the freshly updated `main`. Never push new commits to a branch whose PR has already merged.
 
 ## Issue Tracking
 - Track reported bugs and feature requests as GitHub issues in the repo's tracker. When the user describes a bug, open an issue for it (unless one already exists).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,3 +6,8 @@
 ## Branch Hygiene
 - Keep working branches regularly updated from the main branch (fetch + merge/rebase from `main`) while work is in progress.
 - Assume the user may commit changes to the branch while you are working on it. Before editing, fetch and integrate any new commits from the remote, and re-check file contents rather than relying on earlier reads.
+
+## Issue Tracking
+- Track reported bugs and feature requests as GitHub issues in the repo's tracker. When the user describes a bug, open an issue for it (unless one already exists).
+- When opening a PR that addresses an existing issue, include `Fixes #N` (or `Closes #N`) in the PR description so GitHub auto-closes the issue on merge.
+- If a PR that addresses an issue is merged without the auto-close keyword, close the issue manually and link back to the merged PR.

--- a/src/constants.py
+++ b/src/constants.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 APP_NAME:         str = "Image-Inquest"
 APP_DISPLAY_NAME: str = "Stjörnhorn"
-APP_VERSION:      str = "0.1.4"
+APP_VERSION:      str = "0.1.5"
 API_URL:    str = "https://beltoforion.de"
 
 # Bundled documentation (offline welcome page, screenshots, …)

--- a/src/ui/flow_view.py
+++ b/src/ui/flow_view.py
@@ -5,8 +5,8 @@ import logging
 from typing import TYPE_CHECKING
 
 from PySide6.QtCore import QEvent, QMarginsF, QPoint, Qt
-from PySide6.QtGui import QGuiApplication, QPainter, QPen, QPixmapCache
-from PySide6.QtWidgets import QGraphicsProxyWidget, QGraphicsView
+from PySide6.QtGui import QGuiApplication, QPainter, QPen
+from PySide6.QtWidgets import QGraphicsView
 
 from ui.node_list import NODE_LIST_MIME_TYPE
 from ui.theme import CANVAS_BACKGROUND_COLOR, CANVAS_GRID_COLOR
@@ -49,17 +49,14 @@ class FlowView(QGraphicsView):
         self._screen_hooks_connected: bool = False
         self._connect_screen_hooks()
 
-    # ── Display-change recovery ────────────────────────────────────────────────
+    # ── Screen-topology logging ────────────────────────────────────────────────
     #
-    # Each parameter editor inside a node is hosted by a QGraphicsProxyWidget
-    # that renders the embedded QWidget into an offscreen surface and then
-    # composites it. On Linux (especially dual-monitor setups) that surface
-    # can be invalidated when displays blank (DPMS), suspend, or when the
-    # screen layout changes. The node's own paint() still runs — so headers,
-    # ports, close button, and resize grip remain visible — but the proxy's
-    # contents disappear until something forces a full repaint. We listen
-    # for the application- and window-level screen events and, when one
-    # fires, clear the pixmap cache and force every proxy to repaint.
+    # Record the initial screen layout and every subsequent change Qt reports
+    # so we can correlate render glitches with display events in post-mortems.
+    # No recovery logic lives here — we've seen blank-node reports from brief
+    # OS-initiated screen blackouts (Linux Mint / X11 / NVIDIA) that don't
+    # trigger any of these Qt signals, so relying on them to heal the UI
+    # would be misleading.
 
     def _connect_screen_hooks(self) -> None:
         if self._screen_hooks_connected:
@@ -89,31 +86,29 @@ class FlowView(QGraphicsView):
 
     def changeEvent(self, event) -> None:  # type: ignore[override]
         if event.type() == QEvent.Type.ScreenChangeInternal:
-            self._recover_from_display_change("view ScreenChangeInternal")
+            logger.info("FlowView received ScreenChangeInternal")
         super().changeEvent(event)
 
     def _on_screen_added(self, screen) -> None:
-        name = screen.name() if screen is not None else "<none>"
-        logger.info("Screen added: %s", name)
+        logger.info("Screen added: %s", screen.name() if screen is not None else "<none>")
         self._log_screen_layout("after add")
-        self._recover_from_display_change(f"screen added: {name}")
 
     def _on_screen_removed(self, screen) -> None:
-        name = screen.name() if screen is not None else "<none>"
-        logger.info("Screen removed: %s", name)
+        logger.info("Screen removed: %s", screen.name() if screen is not None else "<none>")
         self._log_screen_layout("after remove")
-        self._recover_from_display_change(f"screen removed: {name}")
 
     def _on_primary_screen_changed(self, screen) -> None:
-        name = screen.name() if screen is not None else "<none>"
-        logger.info("Primary screen changed → %s", name)
+        logger.info(
+            "Primary screen changed → %s",
+            screen.name() if screen is not None else "<none>",
+        )
         self._log_screen_layout("after primary change")
-        self._recover_from_display_change(f"primary screen changed: {name}")
 
     def _on_window_screen_changed(self, screen) -> None:
-        name = screen.name() if screen is not None else "<none>"
-        logger.info("Main window moved to screen: %s", name)
-        self._recover_from_display_change(f"window screen changed: {name}")
+        logger.info(
+            "Main window moved to screen: %s",
+            screen.name() if screen is not None else "<none>",
+        )
 
     def _log_screen_layout(self, reason: str) -> None:
         app = QGuiApplication.instance()
@@ -140,25 +135,6 @@ class FlowView(QGraphicsView):
                 screen.devicePixelRatio(),
                 screen.refreshRate(),
             )
-
-    def _recover_from_display_change(self, reason: str) -> None:
-        logger.info("Repainting nodes after display change (%s)", reason)
-        QPixmapCache.clear()
-        scene = self.scene()
-        if scene is None:
-            return
-        for item in scene.items():
-            proxy = item if isinstance(item, QGraphicsProxyWidget) else getattr(
-                item, "_proxy", None
-            )
-            if not isinstance(proxy, QGraphicsProxyWidget):
-                continue
-            widget = proxy.widget()
-            if widget is not None:
-                widget.repaint()
-            proxy.update()
-        scene.update()
-        self.viewport().update()
 
     # ── Zoom ───────────────────────────────────────────────────────────────────
 

--- a/src/ui/flow_view.py
+++ b/src/ui/flow_view.py
@@ -4,9 +4,9 @@ import json
 import logging
 from typing import TYPE_CHECKING
 
-from PySide6.QtCore import QMarginsF, QPoint, Qt
-from PySide6.QtGui import QPainter, QPen
-from PySide6.QtWidgets import QGraphicsView
+from PySide6.QtCore import QEvent, QMarginsF, QPoint, Qt
+from PySide6.QtGui import QGuiApplication, QPainter, QPen, QPixmapCache
+from PySide6.QtWidgets import QGraphicsProxyWidget, QGraphicsView
 
 from ui.node_list import NODE_LIST_MIME_TYPE
 from ui.theme import CANVAS_BACKGROUND_COLOR, CANVAS_GRID_COLOR
@@ -45,6 +45,120 @@ class FlowView(QGraphicsView):
 
         self._panning: bool = False
         self._pan_last: QPoint | None = None
+
+        self._screen_hooks_connected: bool = False
+        self._connect_screen_hooks()
+
+    # ── Display-change recovery ────────────────────────────────────────────────
+    #
+    # Each parameter editor inside a node is hosted by a QGraphicsProxyWidget
+    # that renders the embedded QWidget into an offscreen surface and then
+    # composites it. On Linux (especially dual-monitor setups) that surface
+    # can be invalidated when displays blank (DPMS), suspend, or when the
+    # screen layout changes. The node's own paint() still runs — so headers,
+    # ports, close button, and resize grip remain visible — but the proxy's
+    # contents disappear until something forces a full repaint. We listen
+    # for the application- and window-level screen events and, when one
+    # fires, clear the pixmap cache and force every proxy to repaint.
+
+    def _connect_screen_hooks(self) -> None:
+        if self._screen_hooks_connected:
+            return
+        app = QGuiApplication.instance()
+        if app is None:
+            return
+        app.screenAdded.connect(self._on_screen_added)
+        app.screenRemoved.connect(self._on_screen_removed)
+        app.primaryScreenChanged.connect(self._on_primary_screen_changed)
+        self._screen_hooks_connected = True
+        self._log_screen_layout("initial")
+
+    def showEvent(self, event) -> None:  # type: ignore[override]
+        super().showEvent(event)
+        window = self.window()
+        handle = window.windowHandle() if window is not None else None
+        if handle is not None:
+            try:
+                handle.screenChanged.connect(
+                    self._on_window_screen_changed,
+                    Qt.ConnectionType.UniqueConnection,
+                )
+            except (RuntimeError, TypeError):
+                # Already connected, or handle has no such signal on this platform.
+                pass
+
+    def changeEvent(self, event) -> None:  # type: ignore[override]
+        if event.type() == QEvent.Type.ScreenChangeInternal:
+            self._recover_from_display_change("view ScreenChangeInternal")
+        super().changeEvent(event)
+
+    def _on_screen_added(self, screen) -> None:
+        name = screen.name() if screen is not None else "<none>"
+        logger.info("Screen added: %s", name)
+        self._log_screen_layout("after add")
+        self._recover_from_display_change(f"screen added: {name}")
+
+    def _on_screen_removed(self, screen) -> None:
+        name = screen.name() if screen is not None else "<none>"
+        logger.info("Screen removed: %s", name)
+        self._log_screen_layout("after remove")
+        self._recover_from_display_change(f"screen removed: {name}")
+
+    def _on_primary_screen_changed(self, screen) -> None:
+        name = screen.name() if screen is not None else "<none>"
+        logger.info("Primary screen changed → %s", name)
+        self._log_screen_layout("after primary change")
+        self._recover_from_display_change(f"primary screen changed: {name}")
+
+    def _on_window_screen_changed(self, screen) -> None:
+        name = screen.name() if screen is not None else "<none>"
+        logger.info("Main window moved to screen: %s", name)
+        self._recover_from_display_change(f"window screen changed: {name}")
+
+    def _log_screen_layout(self, reason: str) -> None:
+        app = QGuiApplication.instance()
+        if app is None:
+            return
+        screens = app.screens()
+        primary = app.primaryScreen()
+        logger.info(
+            "Screen layout (%s): %d screen(s), primary=%s",
+            reason,
+            len(screens),
+            primary.name() if primary is not None else "<none>",
+        )
+        for i, screen in enumerate(screens):
+            geom = screen.geometry()
+            logger.info(
+                "  [%d] %s  geom=%dx%d+%d+%d  dpr=%.2f  refresh=%.1fHz",
+                i,
+                screen.name(),
+                geom.width(),
+                geom.height(),
+                geom.x(),
+                geom.y(),
+                screen.devicePixelRatio(),
+                screen.refreshRate(),
+            )
+
+    def _recover_from_display_change(self, reason: str) -> None:
+        logger.info("Repainting nodes after display change (%s)", reason)
+        QPixmapCache.clear()
+        scene = self.scene()
+        if scene is None:
+            return
+        for item in scene.items():
+            proxy = item if isinstance(item, QGraphicsProxyWidget) else getattr(
+                item, "_proxy", None
+            )
+            if not isinstance(proxy, QGraphicsProxyWidget):
+                continue
+            widget = proxy.widget()
+            if widget is not None:
+                widget.repaint()
+            proxy.update()
+        scene.update()
+        self.viewport().update()
 
     # ── Zoom ───────────────────────────────────────────────────────────────────
 

--- a/src/ui/node_editor_page.py
+++ b/src/ui/node_editor_page.py
@@ -582,8 +582,13 @@ class NodeEditorPage(PageBase):
 
     def _on_open_clicked(self) -> None:
         FLOW_DIR.mkdir(parents=True, exist_ok=True)
+        # Force Qt's own dialog instead of Windows' native IFileOpenDialog:
+        # the native dialog's nested modal loop leaves the FlowView
+        # viewport stuck in a black, unpaintable state that no runtime
+        # interaction (resize, zoom, pan, click) can recover from.
         path_str, _ = QFileDialog.getOpenFileName(
             self, "Open Flow", str(FLOW_DIR), _FLOW_FILE_FILTER,
+            options=QFileDialog.Option.DontUseNativeDialog,
         )
         if path_str:
             self.load_flow(Path(path_str))

--- a/src/ui/node_editor_page.py
+++ b/src/ui/node_editor_page.py
@@ -582,13 +582,8 @@ class NodeEditorPage(PageBase):
 
     def _on_open_clicked(self) -> None:
         FLOW_DIR.mkdir(parents=True, exist_ok=True)
-        # Force Qt's own dialog instead of Windows' native IFileOpenDialog:
-        # the native dialog's nested modal loop leaves the FlowView
-        # viewport stuck in a black, unpaintable state that no runtime
-        # interaction (resize, zoom, pan, click) can recover from.
         path_str, _ = QFileDialog.getOpenFileName(
             self, "Open Flow", str(FLOW_DIR), _FLOW_FILE_FILTER,
-            options=QFileDialog.Option.DontUseNativeDialog,
         )
         if path_str:
             self.load_flow(Path(path_str))


### PR DESCRIPTION
## Summary
- **Observability (Linux):** `FlowView` now logs the initial screen layout on startup (name, geometry, DPR, refresh rate) and every subsequent `screenAdded` / `screenRemoved` / `primaryScreenChanged`, window `screenChanged`, and view `QEvent.ScreenChangeInternal`. Groundwork for diagnosing #124 — the blank-node bug on Linux Mint / X11 / NVIDIA after brief OS-initiated display blackouts. This PR does **not** fix #124; it only adds logging so the next occurrence can be correlated with what Qt saw.
- **Rules:** adds `CLAUDE.md` with three sections of repo rules:
  - *Pull Requests*: bump `APP_VERSION` on source-changing PRs (skip for docs/config/CI); keep the PR description and CHANGELOG entry in sync with the branch's current state.
  - *Branch Hygiene*: keep feature branches synced with `main`; assume the user may commit while Claude is working and re-fetch before editing; delete a branch once its PR is merged and start follow-up work on a fresh branch off `main`.
  - *Issue Tracking*: file user-reported bugs as issues; use `Fixes #N` in PRs so merge auto-closes the issue (or close manually if that keyword is missing); mark every Claude-filed issue with a `_Filed by Claude Code._` footer; don't pick up user-filed issues unless explicitly asked.

The earlier Windows Open-dialog fix was reverted off this PR and will land on its own branch; issue #125 stays open until that PR is merged.

Bumps `APP_VERSION` 0.1.4 → 0.1.5.

## Test plan
- [ ] Start the app on a multi-monitor setup and confirm `~/.image-inquest/logs/image-inquest.log` contains the initial `Screen layout (initial): …` block with one line per monitor.
- [ ] Plug/unplug a monitor while the app is running and confirm `Screen added: …` / `Screen removed: …` and a refreshed layout block appear in the log.
- [ ] Drag the main window between monitors; confirm `Main window moved to screen: …` is logged.
- [ ] Next time the reported blank-node bug (#124) happens after a brief OS-initiated blackout, check the log around that timestamp. If nothing screen-related was recorded, we have evidence the trigger is upstream of Qt's signals.

https://claude.ai/code/session_01PguUXFnF7FLeJequFJ3LU7