### PR TITLE
Add Claude Issue Assistant GitHub Action workflow

### DIFF
--- a/.github/workflows/claude-issue.yml
+++ b/.github/workflows/claude-issue.yml
@@ -1,0 +1,27 @@
+name: Claude Issue Assistant
+
+on:
+  issues:
+    types: [opened, edited, reopened]
+  issue_comment:
+    types: [created, edited]
+
+jobs:
+  claude:
+    if: >-
+      (github.event_name == 'issues' && contains(github.event.issue.body, '@claude')) ||
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude'))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}


### PR DESCRIPTION
## Summary
This PR adds a new GitHub Actions workflow that integrates Claude as an issue assistant, enabling automated responses to issues and comments that mention `@claude`.

## Key Changes
- Added `.github/workflows/claude-issue.yml` workflow file that:
  - Triggers on issue creation, editing, and reopening
  - Triggers on issue comment creation and editing
  - Conditionally runs only when `@claude` is mentioned in the issue body or comment
  - Uses the `anthropics/claude-code-action@v1` action to process requests
  - Requires appropriate permissions for reading repository contents and writing to issues/pull requests

## Implementation Details
- The workflow uses conditional logic to filter events, only executing when `@claude` is explicitly mentioned
- Authentication is handled via `CLAUDE_CODE_OAUTH_TOKEN` secret
- Minimal checkout depth (1) is used for efficiency since the action doesn't require full repository history
- Permissions are scoped to the minimum required: read access to contents and write access to issues and pull requests

https://claude.ai/code/session_01JLdLF4n2vBoUHTQxcSFeVE