### PR TITLE
Restrict Claude issue workflow to the repository owner

### DIFF
--- a/.github/workflows/claude-issue.yml
+++ b/.github/workflows/claude-issue.yml
@@ -9,8 +9,9 @@ on:
 jobs:
   claude:
     if: >-
-      (github.event_name == 'issues' && contains(github.event.issue.body, '@claude')) ||
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude'))
+      github.actor == github.repository_owner &&
+      ((github.event_name == 'issues' && contains(github.event.issue.body, '@claude')) ||
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')))
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,3 +15,6 @@
 - If a PR that addresses an issue is merged without the auto-close keyword, close the issue manually and link back to the merged PR.
 - Mark every issue you file with a footer line `_Filed by Claude Code._` at the end of the body, so user-filed issues stay visually distinct from Claude-filed ones.
 - Do not pick up or attempt to fix issues that the user created unless the user explicitly asks for it. Claude-filed issues are fair game to work on when in scope.
+
+## Automated Responses
+- The `Claude Issue Assistant` workflow (`.github/workflows/claude-issue.yml`) must only act on events whose `github.actor` is the repository owner. Never remove or loosen that gate — third-party issue/comment activity must not trigger any Claude run, including no reply. If collaborator access is ever needed, switch to an explicit allowlist rather than opening the trigger up.


### PR DESCRIPTION
## Summary
- Adds `github.actor == github.repository_owner` to the `Claude Issue Assistant` job's `if:` gate so third-party `@claude` mentions cannot start a run.
- Documents the owner-only rule in `CLAUDE.md` so the gate can't be silently loosened later.

## Context
These two commits were originally pushed onto `claude/add-scheduled-tasks-aqdxS` after PR #126 had already merged, so they never made it into `main`. The live workflow on `main` currently has no actor gate — any third party could burn the Max quota by opening an issue containing `@claude`. This PR lands the fix on a fresh branch cut from updated `main`.

## Test plan
- [ ] Merge and confirm the `Claude Issue Assistant` workflow still triggers when the repo owner opens or comments on an issue with `@claude`.
- [ ] Open a test issue from a non-owner account containing `@claude`; confirm no workflow run is queued.
- [ ] Delete the stale `claude/add-scheduled-tasks-aqdxS` branch (local + origin) after this PR merges.

https://claude.ai/code/session_01JLdLF4n2vBoUHTQxcSFeVE

---
_Generated by [Claude Code](https://claude.ai/code/session_01JLdLF4n2vBoUHTQxcSFeVE)_