### PR TITLE
Require labels on Claude-filed issues

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,7 @@
 - When opening a PR that addresses an existing issue, include `Fixes #N` (or `Closes #N`) in the PR description so GitHub auto-closes the issue on merge.
 - If a PR that addresses an issue is merged without the auto-close keyword, close the issue manually and link back to the merged PR.
 - Mark every issue you file with a footer line `_Filed by Claude Code._` at the end of the body, so user-filed issues stay visually distinct from Claude-filed ones.
+- When filing an issue, always attach appropriate labels from the repo's existing label set (at minimum a kind label such as `bug` or `enhancement`, plus any relevant component/priority label). Do not invent new labels; if nothing fits, note that in the issue body and leave it unlabeled.
 - Do not pick up or attempt to fix issues that the user created unless the user explicitly asks for it. Claude-filed issues are fair game to work on when in scope.
 
 ## Automated Responses


### PR DESCRIPTION
## Summary
- Adds a CLAUDE.md rule that every issue Claude files must carry appropriate labels from the repo's existing label set (at minimum a kind label like `bug` / `enhancement`, plus any relevant component/priority label).
- Explicitly forbids inventing new labels — if nothing fits, note it in the issue body and leave it unlabeled.

## Test plan
- [ ] Next time Claude files an issue, confirm it arrives with labels set.
- [ ] If no existing label fits, confirm the issue body says so.

https://claude.ai/code/session_01JLdLF4n2vBoUHTQxcSFeVE

---
_Generated by [Claude Code](https://claude.ai/code/session_01JLdLF4n2vBoUHTQxcSFeVE)_