### PR TITLE
fix: use np.fromfile+imdecode to handle Unicode paths on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ once a first tagged release is cut.
 
 ## [Unreleased]
 
+## [0.1.6] — 2026-04-24
+
+### Fixed
+- **Unicode paths on Windows.** `cv2.imread()` silently fails on paths
+  containing non-ASCII characters (e.g. `Stjörnhorn` in the repo path).
+  `ImageSource` now reads image files via `np.fromfile()` +
+  `cv2.imdecode()`, which goes through Python's Unicode-aware file I/O
+  and handles any path correctly (#130).
+
 ## [0.1.5] — 2026-04-23
 
 ### Added

--- a/src/constants.py
+++ b/src/constants.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 APP_NAME:         str = "Image-Inquest"
 APP_DISPLAY_NAME: str = "Stjörnhorn"
-APP_VERSION:      str = "0.1.5"
+APP_VERSION:      str = "0.1.6"
 API_URL:    str = "https://beltoforion.de"
 
 # Bundled documentation (offline welcome page, screenshots, …)

--- a/src/nodes/sources/image_source.py
+++ b/src/nodes/sources/image_source.py
@@ -86,7 +86,10 @@ class ImageSource(SourceNodeBase):
         if ext == ".cr2":
             image: np.ndarray = rawpy.imread(str(resolved)).postprocess()
         else:
-            image = cv2.imread(str(resolved))
+            # cv2.imread() silently fails on Unicode paths on Windows; use
+            # np.fromfile + imdecode to go through Python's wide-char I/O.
+            img_array = np.fromfile(resolved, dtype=np.uint8)
+            image = cv2.imdecode(img_array, cv2.IMREAD_COLOR)
             if image is None:
                 raise OSError(f"cv2 could not read: {resolved}")
 


### PR DESCRIPTION
Replace `cv2.imread()` in `ImageSource` with `np.fromfile() + cv2.imdecode()` so that image loading works even when the file path contains non-ASCII characters (e.g. the `Stjörnhorn` directory name on Windows).

`cv2.imread()` uses the C standard library's narrow-string file I/O on Windows and silently returns `None` for any path containing a non-ASCII character. `np.fromfile()` goes through Python's wide-character Win32 file I/O, which handles Unicode correctly.

Fixes #130

Generated with [Claude Code](https://claude.ai/code)