### PR TITLE
fix: handle Unicode paths in ImageSource and VideoSource on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ once a first tagged release is cut.
 
 ## [Unreleased]
 
+## [0.1.6] — 2026-04-24
+
+### Fixed
+- **Unicode paths in ImageSource** (`src/nodes/sources/image_source.py`):
+  replaced `cv2.imread()` with `np.fromfile() + cv2.imdecode()` so that
+  images load correctly when the repository is cloned under a path containing
+  non-ASCII characters (e.g. `Stjörnhorn`) on Windows.
+- **Unicode paths in VideoSource** (`src/nodes/sources/video_source.py`):
+  `cv2.VideoCapture()` has no memory-buffer equivalent, so the fix uses
+  `GetShortPathNameW` (Windows 8.3 short path, always ASCII) on Windows and
+  passes the path through unchanged on other platforms.
+
 ## [0.1.5] — 2026-04-23
 
 ### Added

--- a/src/constants.py
+++ b/src/constants.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 APP_NAME:         str = "Image-Inquest"
 APP_DISPLAY_NAME: str = "Stjörnhorn"
-APP_VERSION:      str = "0.1.5"
+APP_VERSION:      str = "0.1.6"
 API_URL:    str = "https://beltoforion.de"
 
 # Bundled documentation (offline welcome page, screenshots, …)

--- a/src/nodes/sources/image_source.py
+++ b/src/nodes/sources/image_source.py
@@ -86,7 +86,10 @@ class ImageSource(SourceNodeBase):
         if ext == ".cr2":
             image: np.ndarray = rawpy.imread(str(resolved)).postprocess()
         else:
-            image = cv2.imread(str(resolved))
+            # np.fromfile uses Python's Unicode-aware I/O, bypassing cv2.imread's
+            # narrow-string limitation on Windows (silently fails on non-ASCII paths).
+            img_array = np.fromfile(resolved, dtype=np.uint8)
+            image = cv2.imdecode(img_array, cv2.IMREAD_COLOR)
             if image is None:
                 raise OSError(f"cv2 could not read: {resolved}")
 

--- a/src/nodes/sources/video_source.py
+++ b/src/nodes/sources/video_source.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import sys
 from pathlib import Path
 
 import cv2
@@ -11,6 +12,26 @@ from core.node_base import SourceNodeBase, NodeParam, NodeParamType
 from core.port import OutputPort
 
 _SUPPORTED_EXTS = {".mp4", ".avi", ".mov", ".mkv"}
+
+
+def _win_safe_path(path: Path) -> str:
+    """Return an ASCII-safe path for cv2 on Windows.
+
+    cv2.VideoCapture uses C-runtime narrow-string file I/O on Windows and
+    silently fails for paths containing non-ASCII characters.  The Windows
+    8.3 short path is always ASCII, so we use GetShortPathNameW when running
+    on Windows and fall back to the original string on all other platforms.
+    """
+    if sys.platform != "win32":
+        return str(path)
+    try:
+        import ctypes
+        buf = ctypes.create_unicode_buffer(32768)
+        if ctypes.windll.kernel32.GetShortPathNameW(str(path), buf, len(buf)):  # type: ignore[attr-defined]
+            return buf.value
+    except Exception:
+        pass
+    return str(path)
 
 
 class VideoSource(SourceNodeBase):
@@ -74,7 +95,7 @@ class VideoSource(SourceNodeBase):
                 f"Supported: {_SUPPORTED_EXTS}"
             )
 
-        cap = cv2.VideoCapture(str(self._file_path))
+        cap = cv2.VideoCapture(_win_safe_path(self._file_path))
         try:
             frame_count = 0
             while True:


### PR DESCRIPTION
Replace `cv2.imread()` in `ImageSource` with `np.fromfile() + cv2.imdecode()` and add a `GetShortPathNameW` wrapper in `VideoSource` so that image and video loading both work when the file path contains non-ASCII characters (e.g. the `Stjörnhorn` directory name on Windows).

`cv2.imread()` and `cv2.VideoCapture()` use C-runtime narrow-string file I/O on Windows and silently fail for non-ASCII paths. `np.fromfile()` uses Python's wide-character I/O; `GetShortPathNameW` returns the always-ASCII 8.3 alias.

Fixes #130

Generated with [Claude Code](https://claude.ai/code)