### PR TITLE
Use parent=None in per-node file picker to avoid Windows canvas bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ once a first tagged release is cut.
 
 ## [Unreleased]
 
+## [0.1.7] — 2026-04-24
+
+### Fixed
+- **Black, unrecoverable node canvas on Windows after a per-node file
+  picker dialog.** Passing the owning `QLineEdit` as parent to a native
+  `QFileDialog` did not work on windows (#125).
+
 ## [0.1.6] — 2026-04-24
 
 ### Fixed

--- a/src/constants.py
+++ b/src/constants.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 APP_NAME:         str = "Image-Inquest"
 APP_DISPLAY_NAME: str = "Stjörnhorn"
-APP_VERSION:      str = "0.1.6"
+APP_VERSION:      str = "0.1.7"
 API_URL:    str = "https://beltoforion.de"
 
 # Bundled documentation (offline welcome page, screenshots, …)

--- a/src/ui/param_widgets.py
+++ b/src/ui/param_widgets.py
@@ -9,6 +9,7 @@ from typing_extensions import override
 from PySide6.QtCore import Qt, QUrl, Signal
 from PySide6.QtGui import QDesktopServices
 from PySide6.QtWidgets import (
+    QApplication,
     QCheckBox,
     QDoubleSpinBox,
     QFileDialog,
@@ -434,7 +435,12 @@ class FilePathParamWidget(ParamWidgetBase):
         else:
             dialog.setAcceptMode(QFileDialog.AcceptMode.AcceptOpen)
             dialog.setFileMode(QFileDialog.FileMode.ExistingFile)
-        top = self._line.window()
+        # self._line.window() doesn't reach MainWindow because the param
+        # widget is embedded in a QGraphicsProxyWidget, which severs the
+        # widget-parent chain. activeWindow() returns the top-level
+        # window with focus, which is MainWindow when a node's browse
+        # button is clicked.
+        top = QApplication.activeWindow()
         if top is not None:
             geo = dialog.frameGeometry()
             geo.moveCenter(top.frameGeometry().center())

--- a/src/ui/param_widgets.py
+++ b/src/ui/param_widgets.py
@@ -418,15 +418,32 @@ class FilePathParamWidget(ParamWidgetBase):
         folder = path_obj.parent.resolve()
         initial = str(folder) if folder.is_dir() else str(self._base_dir)
 
+        # Parent is None on purpose: on Windows, passing any widget as
+        # parent to a native QFileDialog corrupts QGraphicsView paint
+        # state so the node canvas stays black after the dialog returns
+        # (#125). Centering is restored manually against the top-level
+        # window.
+        caption = self._param.metadata.get(
+            "caption", "Save File As" if self._is_save else "Select File",
+        )
+        dialog = QFileDialog(None, caption)
+        dialog.setNameFilter(self._filter)
+        dialog.setDirectory(initial)
         if self._is_save:
-            path, _ = QFileDialog.getSaveFileName(
-                self._line, "Save File As", initial, self._filter,
-            )
+            dialog.setAcceptMode(QFileDialog.AcceptMode.AcceptSave)
         else:
-            path, _ = QFileDialog.getOpenFileName(
-                self._line, "Select File", initial, self._filter,
-            )
-        
+            dialog.setAcceptMode(QFileDialog.AcceptMode.AcceptOpen)
+            dialog.setFileMode(QFileDialog.FileMode.ExistingFile)
+        top = self._line.window()
+        if top is not None:
+            geo = dialog.frameGeometry()
+            geo.moveCenter(top.frameGeometry().center())
+            dialog.move(geo.topLeft())
+        if dialog.exec() != QFileDialog.DialogCode.Accepted:
+            return
+        files = dialog.selectedFiles()
+        path = files[0] if files else ""
+
         if path:
 
 #            self._write_to_node(path)


### PR DESCRIPTION
## Summary
- `FilePathParamWidget._open_file_dialog` now builds `QFileDialog` with `parent=None` and centers it on the top-level window manually. Passing the owning `QLineEdit` as parent corrupts `QGraphicsView` paint state on Windows so the node canvas stays black after the dialog returns.
- Dialog caption reads from `param.metadata["caption"]`, falling back to the previous `"Save File As"` / `"Select File"` defaults so existing nodes keep their current captions.
- Version bump `0.1.6` → `0.1.7` and a CHANGELOG entry.

Only `src/ui/param_widgets.py`, `src/constants.py`, and `CHANGELOG.md` are touched. No other files.

Fixes #125

## Test plan
- [ ] On Windows: click a file param's browse button, cancel the dialog → node canvas stays visible.
- [ ] On Windows: pick a file → path updates, canvas intact.
- [ ] On Windows: dialog appears centered over the main window.
- [ ] On Linux/macOS: no regression.

https://claude.ai/code/session_01JLdLF4n2vBoUHTQxcSFeVE