### PR TITLE
Add communication style and meta guidelines to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,3 +19,9 @@
 
 ## Automated Responses
 - The `Claude Issue Assistant` workflow (`.github/workflows/claude-issue.yml`) must only act on events whose `github.actor` is the repository owner. Never remove or loosen that gate — third-party issue/comment activity must not trigger any Claude run, including no reply. If collaborator access is ever needed, switch to an explicit allowlist rather than opening the trigger up.
+
+## Communication Style
+- Keine einleitenden Formulierungen (z. B. "Kurze, ehrliche Antwort:", "Gerne,", "Natürlich,"). Direkt zum Punkt, reine Informationsübertragung, so kurz wie möglich.
+
+## Meta
+- Änderungen an `CLAUDE.md` darf Claude direkt committen und pushen, ohne vorher Rückfrage zu stellen.


### PR DESCRIPTION
## Summary
Updated the CLAUDE.md documentation with additional guidelines for Claude's communication style and permissions for self-managed updates.

## Changes
- **Communication Style**: Added directive to eliminate introductory phrases and focus on direct, concise information delivery
- **Meta Guidelines**: Documented that Claude can directly commit and push changes to CLAUDE.md without prior approval

## Details
These guidelines establish clearer expectations for how Claude should interact (more direct and efficient communication) and clarify the workflow for maintaining this documentation file (allowing autonomous updates to CLAUDE.md itself).

https://claude.ai/code/session_01VLLDBwjhME9CLRaAdpE7Ej