### PR TITLE
Move log directory from user config to app folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -151,3 +151,4 @@ cython_debug/
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
 output/*
+logs/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ once a first tagged release is cut.
 
 ## [Unreleased]
 
+## [0.1.9] — 2026-04-24
+
+### Changed
+- **Log folder moved out of the user config dir.** `LOG_DIR` now resolves
+  to `<app-folder>/logs/` (alongside `input/`, `output/`, `flow/`)
+  instead of `~/.image-inquest/logs/`, so logs and faulthandler dumps
+  stay visible next to the rest of the bundled app folders. `logs/` is
+  added to `.gitignore`.
+
 ## [0.1.8] — 2026-04-24
 
 ### Added

--- a/src/constants.py
+++ b/src/constants.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 APP_NAME:         str = "Image-Inquest"
 APP_DISPLAY_NAME: str = "Stjörnhorn"
-APP_VERSION:      str = "0.1.8"
+APP_VERSION:      str = "0.1.9"
 API_URL:    str = "https://beltoforion.de"
 
 # Bundled documentation (offline welcome page, screenshots, …)
@@ -41,5 +41,9 @@ FLOW_DIR:   Path = Path(__file__).parent.parent / "flow"
 # User-defined nodes (~/.image-inquest/user_nodes/)
 USER_CONFIG_DIR: Path = Path.home() / ".image-inquest"
 USER_NODES_DIR:  Path = USER_CONFIG_DIR / "user_nodes"
-LOG_DIR:  Path = USER_CONFIG_DIR / "logs"
+
+# Logs live next to the application sources rather than in the user
+# config dir so they stay visible alongside the rest of the bundled app
+# folders (input/, output/, flow/, …).
+LOG_DIR:  Path = Path(__file__).parent.parent / "logs"
 LOG_FILE: Path = LOG_DIR / "image-inquest.log"

--- a/src/log.py
+++ b/src/log.py
@@ -4,7 +4,7 @@ Call ``setup_logging()`` once at startup before creating any other objects.
 All modules then obtain their own logger with ``logging.getLogger(__name__)``.
 
 Log destinations:
-  - File  : ~/.image-inquest/image-inquest.log  (DEBUG and above, rotating)
+  - File  : <app-folder>/logs/image-inquest.log  (DEBUG and above, rotating)
   - Console: WARNING and above
 """
 from __future__ import annotations


### PR DESCRIPTION
## Summary
Relocates the log directory from the user's home config directory (`~/.image-inquest/logs/`) to the application folder (`<app-folder>/logs/`), making logs more discoverable alongside other bundled app directories.

## Changes
- **Updated `LOG_DIR` path resolution** in `src/constants.py`: Changed from `USER_CONFIG_DIR / "logs"` to `Path(__file__).parent.parent / "logs"`, placing logs in the application root directory instead of the user's home config folder
- **Updated version** to 0.1.9 in `src/constants.py`
- **Updated documentation** in `src/log.py`: Changed log file path reference in docstring to reflect new location
- **Updated `.gitignore`**: Added `logs/` to prevent log files from being committed to version control
- **Updated CHANGELOG.md**: Documented the change in the 0.1.9 release notes

## Implementation Details
The log directory now resolves relative to the application source location rather than the user's home directory. This keeps logs visible and organized alongside other bundled app folders (`input/`, `output/`, `flow/`, etc.), improving discoverability and making the application structure more cohesive.

https://claude.ai/code/session_01VLLDBwjhME9CLRaAdpE7Ej