### PR TITLE
Add skip (pass-through) toggle for eligible nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ once a first tagged release is cut.
 
 ## [Unreleased]
 
+## [0.1.10] — 2026-04-24
+
+### Added
+- **Skip (pass-through) toggle on eligible nodes.** Nodes whose inputs
+  and outputs match one-to-one by type now render an extra `»` button
+  in the header. Clicking it bypasses `process_impl` and forwards each
+  input payload straight to the matching output. Skipped nodes are
+  visually distinct — grey header, strike-through title — and the
+  flag round-trips through the flow file.
+
 ## [0.1.9] — 2026-04-24
 
 ### Changed

--- a/src/constants.py
+++ b/src/constants.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 APP_NAME:         str = "Image-Inquest"
 APP_DISPLAY_NAME: str = "Stjörnhorn"
-APP_VERSION:      str = "0.1.9"
+APP_VERSION:      str = "0.1.10"
 API_URL:    str = "https://beltoforion.de"
 
 # Bundled documentation (offline welcome page, screenshots, …)

--- a/src/core/node_base.py
+++ b/src/core/node_base.py
@@ -83,6 +83,7 @@ class NodeBase(ABC):
         self._section = section if section is not None else self.DEFAULT_SECTION
         self._inputs: list[InputPort] = []
         self._outputs: list[OutputPort] = []
+        self._skipped: bool = False
 
     # ── Port registration (called from subclass __init__) ──────────────────────
 
@@ -150,6 +151,40 @@ class NodeBase(ABC):
     def outputs(self) -> list[OutputPort]:
         return self._outputs
 
+    # ── Skip (pass-through) state ──────────────────────────────────────────────
+
+    @property
+    def is_skippable(self) -> bool:
+        """True if this node can be bypassed without breaking type safety.
+
+        A node is skippable when its inputs and outputs line up one-to-one
+        with identical type sets, so forwarding ``inputs[i].data`` to
+        ``outputs[i].send()`` is always valid. Sources (no inputs) and
+        sinks (no outputs) are never skippable.
+        """
+        if not self._inputs or not self._outputs:
+            return False
+        if len(self._inputs) != len(self._outputs):
+            return False
+        return all(
+            inp.accepted_types == out.emits
+            for inp, out in zip(self._inputs, self._outputs)
+        )
+
+    @property
+    def skipped(self) -> bool:
+        """True if this node is currently bypassed (inputs forwarded to outputs)."""
+        return self._skipped
+
+    @skipped.setter
+    def skipped(self, value: bool) -> None:
+        flag = bool(value)
+        if flag and not self.is_skippable:
+            raise ValueError(
+                f"{type(self).__name__} ({self._display_name}) is not skippable"
+            )
+        self._skipped = flag
+
     # ── Internal signal handling ───────────────────────────────────────────────
 
     def _signal_input_ready(self) -> None:
@@ -192,10 +227,23 @@ class NodeBase(ABC):
                 logger.exception("Process observer raised; ignoring")
 
         try:
-            self.process_impl()
+            if self._skipped:
+                self._process_skipped()
+            else:
+                self.process_impl()
         except Exception:
             logger.exception(f"Exception in {type(self).__name__}.process_impl ({self._display_name})")
             raise
+
+    def _process_skipped(self) -> None:
+        """Forward each input payload to the matching output unchanged.
+
+        Called in lieu of :meth:`process_impl` when :attr:`skipped` is True.
+        Relies on :attr:`is_skippable` having been verified at the time
+        ``skipped`` was set, so the type pairing is safe.
+        """
+        for inp, out in zip(self._inputs, self._outputs):
+            out.send(inp.data)
 
     @abstractmethod
     def process_impl(self) -> None:

--- a/src/ui/flow_io.py
+++ b/src/ui/flow_io.py
@@ -47,6 +47,8 @@ def serialize_flow(scene: FlowScene, flow: Flow) -> dict:
             # Persist both axes even when only one is user-set so the
             # load side can round-trip without needing null sentinels.
             entry["size"] = [float(item.width), float(item.body_height)]
+        if node.skipped:
+            entry["skipped"] = True
         nodes_out.append(entry)
 
     connections_out: list[dict] = []
@@ -173,7 +175,13 @@ def _instantiate_node(entry: dict) -> NodeBase | None:
             setattr(node, name, value)
         except Exception:
             logger.warning(f"Ignoring param {name} on {module_name}.{class_name} ({value!r})")
-    
+
+    if entry.get("skipped"):
+        try:
+            node.skipped = True
+        except Exception:
+            logger.warning(f"Ignoring skipped flag on {module_name}.{class_name}")
+
     return node
 
 

--- a/src/ui/node_item.py
+++ b/src/ui/node_item.py
@@ -7,6 +7,7 @@ from PySide6.QtCore import QObject, QPointF, QRectF, Qt, QTimer, Signal
 from PySide6.QtGui import (
     QBrush,
     QColor,
+    QFont,
     QFontMetricsF,
     QPainter,
     QPainterPath,
@@ -31,6 +32,7 @@ from ui.theme import (
     NODE_BORDER_COLOR,
     NODE_BORDER_SELECTED,
     NODE_PARAM_LABEL_COLOR,
+    NODE_SKIPPED_HEADER_COLOR,
     NODE_TITLE_TEXT_COLOR,
     SINK_HEADER_COLOR,
     SOURCE_HEADER_COLOR,
@@ -194,6 +196,95 @@ class _CloseButtonItem(QGraphicsItem):
         super().mouseReleaseEvent(event)
 
 
+class _SkipButtonItem(QGraphicsItem):
+    """Toggle button rendered on the left of the close button in a node header.
+
+    Only attached to nodes whose :attr:`NodeBase.is_skippable` is True.
+    Clicking it toggles :attr:`NodeBase.skipped`; while skipped, the
+    owning node forwards each input to the matching output in place of
+    its normal ``process_impl``, the header is painted grey and the
+    title is struck through.
+
+    Draws a simple double-chevron (``»``) glyph so the affordance reads
+    as "pass through / skip forward" without needing a separate icon
+    font.
+    """
+
+    SIZE: float = 14.0
+    Z_VALUE = 2
+
+    def __init__(self, node_item: "NodeItem") -> None:
+        super().__init__(parent=node_item)
+        self._node_item = node_item
+        self._hovered = False
+        self._pressed = False
+        self.setZValue(self.Z_VALUE)
+        self.setAcceptHoverEvents(True)
+        self.setAcceptedMouseButtons(Qt.MouseButton.LeftButton)
+        self.setCursor(Qt.CursorShape.ArrowCursor)
+        self.setToolTip("Skip this node (pass inputs straight through)")
+
+    def boundingRect(self) -> QRectF:  # type: ignore[override]
+        return QRectF(0, 0, self.SIZE, self.SIZE)
+
+    def paint(self, painter: QPainter, option, widget=None) -> None:  # type: ignore[override]
+        painter.setRenderHint(QPainter.RenderHint.Antialiasing, True)
+        active = self._node_item.node.skipped
+        if self._hovered or self._pressed or active:
+            painter.setPen(Qt.NoPen)
+            alpha = 120 if active else 70
+            painter.setBrush(QBrush(QColor(255, 255, 255, alpha)))
+            painter.drawRoundedRect(self.boundingRect(), 2, 2)
+
+        pen = QPen(NODE_TITLE_TEXT_COLOR, 1.6)
+        pen.setCapStyle(Qt.PenCapStyle.RoundCap)
+        pen.setJoinStyle(Qt.PenJoinStyle.RoundJoin)
+        painter.setPen(pen)
+        s = self.SIZE
+        # Two right-pointing chevrons, rendered as thin V shapes, echoing
+        # the ``»`` symbol.
+        mid_y = s / 2
+        tip_dx = 3.0
+        half_h = 3.0
+        for x_tip in (s * 0.58, s * 0.86):
+            painter.drawLine(
+                QPointF(x_tip - tip_dx, mid_y - half_h),
+                QPointF(x_tip, mid_y),
+            )
+            painter.drawLine(
+                QPointF(x_tip, mid_y),
+                QPointF(x_tip - tip_dx, mid_y + half_h),
+            )
+
+    def hoverEnterEvent(self, event) -> None:  # type: ignore[override]
+        self._hovered = True
+        self.update()
+        super().hoverEnterEvent(event)
+
+    def hoverLeaveEvent(self, event) -> None:  # type: ignore[override]
+        self._hovered = False
+        self.update()
+        super().hoverLeaveEvent(event)
+
+    def mousePressEvent(self, event) -> None:  # type: ignore[override]
+        if event.button() == Qt.MouseButton.LeftButton:
+            self._pressed = True
+            self.update()
+            event.accept()
+            return
+        super().mousePressEvent(event)
+
+    def mouseReleaseEvent(self, event) -> None:  # type: ignore[override]
+        if event.button() == Qt.MouseButton.LeftButton and self._pressed:
+            self._pressed = False
+            if self.boundingRect().contains(event.pos()):
+                self._node_item.toggle_skipped()
+            self.update()
+            event.accept()
+            return
+        super().mouseReleaseEvent(event)
+
+
 class NodeItem(QGraphicsItem):
     """A single node drawn on the flow canvas.
 
@@ -223,6 +314,8 @@ class NodeItem(QGraphicsItem):
     PADDING: float = 8.0
     PARAM_GAP: float = 4.0
     CLOSE_BUTTON_SIZE: float = 14.0
+    SKIP_BUTTON_SIZE: float = 14.0
+    HEADER_BUTTON_GAP: float = 4.0
     RESIZE_GRIP_SIZE: float = 12.0
     PORT_LABEL_GAP: float = 12.0  # min gap between paired input/output labels
 
@@ -252,6 +345,9 @@ class NodeItem(QGraphicsItem):
         self.setFlag(QGraphicsItem.GraphicsItemFlag.ItemSendsScenePositionChanges, True)
 
         self._close_button = _CloseButtonItem(self)
+        self._skip_button: _SkipButtonItem | None = (
+            _SkipButtonItem(self) if node.is_skippable else None
+        )
         self._resize_grip = _ResizeGripItem(self)
 
         self._build_params_widget()
@@ -362,7 +458,11 @@ class NodeItem(QGraphicsItem):
 
         # ── title text ──
         painter.setPen(QPen(NODE_TITLE_TEXT_COLOR))
-        title_right_reserve = self.CLOSE_BUTTON_SIZE + self.PADDING
+        title_right_reserve = self._title_right_reserve()
+        if self._node.skipped:
+            title_font = QFont(painter.font())
+            title_font.setStrikeOut(True)
+            painter.setFont(title_font)
         painter.drawText(
             QRectF(
                 self.PADDING,
@@ -407,12 +507,28 @@ class NodeItem(QGraphicsItem):
     # ── Internals ──────────────────────────────────────────────────────────────
 
     def _header_color(self):
+        if self._node.skipped:
+            return NODE_SKIPPED_HEADER_COLOR
         if isinstance(self._node, SourceNodeBase):
             return SOURCE_HEADER_COLOR
         if isinstance(self._node, SinkNodeBase):
             return SINK_HEADER_COLOR
-        
+
         return FILTER_HEADER_COLOR
+
+    def _title_right_reserve(self) -> float:
+        """Horizontal space reserved in the header for right-aligned buttons."""
+        reserve = self.CLOSE_BUTTON_SIZE + self.PADDING
+        if self._skip_button is not None:
+            reserve += self.SKIP_BUTTON_SIZE + self.HEADER_BUTTON_GAP
+        return reserve
+
+    def toggle_skipped(self) -> None:
+        """Flip the node's skipped state and refresh the visual."""
+        self._node.skipped = not self._node.skipped
+        if self._skip_button is not None:
+            self._skip_button.update()
+        self.update()
 
     def _header_path(self) -> QPainterPath:
         """Path for the header: top corners rounded, bottom corners square."""
@@ -444,7 +560,7 @@ class NodeItem(QGraphicsItem):
         metrics = QFontMetricsF(QApplication.font())
 
         title_w = metrics.horizontalAdvance(self._node.display_name)
-        header_need = 2 * padding + title_w + padding + self.CLOSE_BUTTON_SIZE
+        header_need = 2 * padding + title_w + self._title_right_reserve()
 
         port_margin = PortItem.RADIUS + 6.0
         port_need = 0.0
@@ -588,6 +704,12 @@ class NodeItem(QGraphicsItem):
             self._width - self.PADDING - self.CLOSE_BUTTON_SIZE,
             (self.HEADER_HEIGHT - self.CLOSE_BUTTON_SIZE) / 2,
         )
+        if self._skip_button is not None:
+            self._skip_button.setPos(
+                self._width - self.PADDING - self.CLOSE_BUTTON_SIZE
+                - self.HEADER_BUTTON_GAP - self.SKIP_BUTTON_SIZE,
+                (self.HEADER_HEIGHT - self.SKIP_BUTTON_SIZE) / 2,
+            )
         self._resize_grip.setPos(
             self._width - self.RESIZE_GRIP_SIZE - 1,
             self._body_height - self.RESIZE_GRIP_SIZE - 1,

--- a/src/ui/node_item.py
+++ b/src/ui/node_item.py
@@ -458,6 +458,7 @@ class NodeItem(QGraphicsItem):
 
         # ── title text ──
         painter.setPen(QPen(NODE_TITLE_TEXT_COLOR))
+        title_left = self._title_left()
         title_right_reserve = self._title_right_reserve()
         if self._node.skipped:
             title_font = QFont(painter.font())
@@ -465,9 +466,9 @@ class NodeItem(QGraphicsItem):
             painter.setFont(title_font)
         painter.drawText(
             QRectF(
-                self.PADDING,
+                title_left,
                 0,
-                self._width - 2 * self.PADDING - title_right_reserve,
+                self._width - title_left - self.PADDING - title_right_reserve,
                 self.HEADER_HEIGHT,
             ),
             Qt.AlignmentFlag.AlignVCenter | Qt.AlignmentFlag.AlignLeft,
@@ -517,11 +518,15 @@ class NodeItem(QGraphicsItem):
         return FILTER_HEADER_COLOR
 
     def _title_right_reserve(self) -> float:
-        """Horizontal space reserved in the header for right-aligned buttons."""
-        reserve = self.CLOSE_BUTTON_SIZE + self.PADDING
+        """Horizontal space reserved on the header's right edge for buttons."""
+        return self.CLOSE_BUTTON_SIZE + self.PADDING
+
+    def _title_left(self) -> float:
+        """X offset where the title text starts, accounting for the left-side
+        skip button when the node is skippable."""
         if self._skip_button is not None:
-            reserve += self.SKIP_BUTTON_SIZE + self.HEADER_BUTTON_GAP
-        return reserve
+            return self.PADDING + self.SKIP_BUTTON_SIZE + self.HEADER_BUTTON_GAP
+        return self.PADDING
 
     def toggle_skipped(self) -> None:
         """Flip the node's skipped state and refresh the visual."""
@@ -560,7 +565,8 @@ class NodeItem(QGraphicsItem):
         metrics = QFontMetricsF(QApplication.font())
 
         title_w = metrics.horizontalAdvance(self._node.display_name)
-        header_need = 2 * padding + title_w + self._title_right_reserve()
+        left_reserve = self._title_left()
+        header_need = left_reserve + title_w + padding + self._title_right_reserve()
 
         port_margin = PortItem.RADIUS + 6.0
         port_need = 0.0
@@ -706,8 +712,7 @@ class NodeItem(QGraphicsItem):
         )
         if self._skip_button is not None:
             self._skip_button.setPos(
-                self._width - self.PADDING - self.CLOSE_BUTTON_SIZE
-                - self.HEADER_BUTTON_GAP - self.SKIP_BUTTON_SIZE,
+                self.PADDING,
                 (self.HEADER_HEIGHT - self.SKIP_BUTTON_SIZE) / 2,
             )
         self._resize_grip.setPos(

--- a/src/ui/theme.py
+++ b/src/ui/theme.py
@@ -11,6 +11,11 @@ SOURCE_HEADER_COLOR = QColor(30, 100, 180)
 FILTER_HEADER_COLOR = QColor(30, 140,  60)
 SINK_HEADER_COLOR   = QColor(180, 100, 20)
 
+#: Header colour used when a node is skipped (bypassed). Muted grey so
+#: the node visually recedes and the user can see at a glance that it's
+#: no longer doing work.
+NODE_SKIPPED_HEADER_COLOR = QColor(110, 110, 115)
+
 NODE_BODY_COLOR           = QColor(48, 48, 52)
 NODE_BORDER_COLOR         = QColor(20, 20, 22)
 NODE_BORDER_SELECTED      = QColor(240, 200,  60)

--- a/tests/test_skip_node.py
+++ b/tests/test_skip_node.py
@@ -1,0 +1,91 @@
+"""Unit tests for the node skip (pass-through) feature."""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from core.io_data import IoData, IoDataType
+from core.port import InputPort, OutputPort
+from nodes.filters.dither import Dither
+from nodes.filters.grayscale import Grayscale
+from nodes.filters.median import Median
+from nodes.filters.ncc import Ncc
+from nodes.filters.rgb_join import RgbJoin
+from nodes.filters.shift import Shift
+from nodes.sinks.file_sink import FileSink
+from nodes.sources.image_source import ImageSource
+
+
+def test_median_is_skippable() -> None:
+    """Median has a single in/out port pair with identical accepted/emit types."""
+    assert Median().is_skippable is True
+
+
+def test_shift_is_skippable() -> None:
+    assert Shift().is_skippable is True
+
+
+def test_dither_is_not_skippable() -> None:
+    """Dither accepts colour or greyscale but only emits greyscale — bypassing
+    could forward a colour image onto a greyscale-only downstream port."""
+    assert Dither().is_skippable is False
+
+
+def test_grayscale_is_not_skippable() -> None:
+    assert Grayscale().is_skippable is False
+
+
+def test_ncc_is_not_skippable() -> None:
+    """Two inputs, one output — no one-to-one mapping."""
+    assert Ncc().is_skippable is False
+
+
+def test_rgb_join_is_not_skippable() -> None:
+    """Three inputs, one output — cannot forward pairwise."""
+    assert RgbJoin().is_skippable is False
+
+
+def test_source_and_sink_are_not_skippable() -> None:
+    assert ImageSource().is_skippable is False
+    assert FileSink().is_skippable is False
+
+
+def test_setting_skipped_on_non_skippable_raises() -> None:
+    node = Dither()
+    with pytest.raises(ValueError):
+        node.skipped = True
+
+
+def test_skipped_node_forwards_input_to_output_unchanged() -> None:
+    """A skipped node's outputs emit the input payload by reference."""
+    node = Median()
+    node.size = 7  # would otherwise blur the image
+    node.skipped = True
+
+    out_capture = InputPort("cap", {IoDataType.IMAGE})
+    node.outputs[0].connect(out_capture)
+
+    image = np.arange(16, dtype=np.uint8).reshape(4, 4)
+    image = np.stack([image, image, image], axis=-1)
+    node.inputs[0].receive(IoData.from_image(image))
+
+    assert out_capture.has_data
+    np.testing.assert_array_equal(out_capture.data.image, image)
+
+
+def test_unskipping_restores_normal_processing() -> None:
+    node = Median()
+    node.size = 3
+    node.skipped = True
+    node.skipped = False
+
+    out_capture = InputPort("cap", {IoDataType.IMAGE})
+    node.outputs[0].connect(out_capture)
+
+    image = np.zeros((8, 8, 3), dtype=np.uint8)
+    image[0, 0] = (255, 255, 255)
+    node.inputs[0].receive(IoData.from_image(image))
+
+    # Median with a 3×3 kernel erases a single-pixel spike.
+    assert out_capture.has_data
+    assert out_capture.data.image[0, 0].tolist() == [0, 0, 0]


### PR DESCRIPTION
## Summary
Implements a node skip/bypass feature that allows users to toggle eligible nodes to forward their inputs directly to outputs without processing. This is useful for temporarily disabling filter operations while preserving the node in the graph.

## Key Changes

- **Node skip logic** (`src/core/node_base.py`):
  - Added `is_skippable` property that determines if a node can be safely bypassed (one-to-one input/output mapping with matching types)
  - Added `skipped` property with getter/setter that validates the node is skippable before allowing the flag to be set
  - Added `_process_skipped()` method that forwards input payloads directly to matching outputs when `skipped` is True
  - Modified `process()` to call `_process_skipped()` instead of `process_impl()` when the node is skipped

- **UI skip button** (`src/ui/node_item.py`):
  - New `_SkipButtonItem` class that renders a double-chevron (`»`) glyph button in the node header
  - Button appears only on skippable nodes, positioned left of the close button
  - Supports hover/press states with visual feedback
  - Clicking toggles the node's skipped state
  - Added `toggle_skipped()` method to `NodeItem` to handle the toggle and refresh visuals

- **Visual feedback**:
  - Skipped nodes display a grey header (`NODE_SKIPPED_HEADER_COLOR`) instead of their normal color
  - Node title text is struck through when skipped
  - Button highlights on hover or when node is actively skipped

- **Persistence** (`src/ui/flow_io.py`):
  - Skip state is serialized to flow files via `"skipped": true` entry
  - Skip state is restored when loading flows, with graceful error handling for non-skippable nodes

- **Theme** (`src/ui/theme.py`):
  - Added `NODE_SKIPPED_HEADER_COLOR` constant for visual distinction of skipped nodes

- **Tests** (`tests/test_skip_node.py`):
  - Comprehensive test suite covering skippability detection for various node types
  - Tests for skip state toggling and pass-through behavior
  - Validates that non-skippable nodes reject the skip flag

## Implementation Details

- Skippability is determined at node definition time based on port structure, not runtime state
- The skip button is only instantiated for skippable nodes, avoiding unnecessary UI overhead
- Type safety is guaranteed by validating the one-to-one type mapping at the time `skipped` is set
- Visual changes (header color, strike-through) are applied during paint, keeping the UI responsive

https://claude.ai/code/session_012N7wpfyfKyNkRW84imoJEU