### PR TITLE
NCC: convert template from input port to file-path parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ once a first tagged release is cut.
 
 ## [Unreleased]
 
+## [0.1.10] — 2026-04-24
+
+### Changed
+- **NCC node: template is now a file-path parameter, not an input port.**
+  The pattern image is loaded from disk once in `before_run` and
+  converted to greyscale there if the file is colour, so the conversion
+  cost is paid a single time per run rather than per frame. Existing
+  flows that connected a second source into the NCC template port must
+  be re-saved — the bundled `ncc`, `video_ncc` and `debug_ncc_video`
+  flows are updated accordingly.
+
 ## [0.1.9] — 2026-04-24
 
 ### Changed

--- a/flow/debug_ncc_video.flowjs
+++ b/flow/debug_ncc_video.flowjs
@@ -56,6 +56,7 @@
         -1098.1569464234233
       ],
       "params": {
+        "template": "pad.jpg",
         "retain_size": true
       }
     },
@@ -66,28 +67,6 @@
       "position": [
         -2184.071457141125,
         -1059.9647324696782
-      ],
-      "params": {}
-    },
-    {
-      "id": 5,
-      "module": "nodes.sources.image_source",
-      "class": "ImageSource",
-      "position": [
-        -2537.0093685547704,
-        -939.5284632621165
-      ],
-      "params": {
-        "file_path": "pad.jpg"
-      }
-    },
-    {
-      "id": 6,
-      "module": "nodes.filters.grayscale",
-      "class": "Grayscale",
-      "position": [
-        -2169.5270249779187,
-        -886.5825447399395
       ],
       "params": {}
     }
@@ -110,18 +89,6 @@
       "src_output": 0,
       "dst_node": 3,
       "dst_input": 0
-    },
-    {
-      "src_node": 5,
-      "src_output": 0,
-      "dst_node": 6,
-      "dst_input": 0
-    },
-    {
-      "src_node": 6,
-      "src_output": 0,
-      "dst_node": 3,
-      "dst_input": 1
     },
     {
       "src_node": 3,

--- a/flow/ncc.flowjs
+++ b/flow/ncc.flowjs
@@ -11,6 +11,7 @@
         -599.0
       ],
       "params": {
+        "template": "pad.jpg",
         "retain_size": true
       }
     },
@@ -27,34 +28,12 @@
       }
     },
     {
-      "id": 2,
-      "module": "nodes.sources.image_source",
-      "class": "ImageSource",
-      "position": [
-        -1690.0,
-        -500.0
-      ],
-      "params": {
-        "file_path": "pad.jpg"
-      }
-    },
-    {
       "id": 3,
       "module": "nodes.filters.grayscale",
       "class": "Grayscale",
       "position": [
         -1401.0,
         -613.0
-      ],
-      "params": {}
-    },
-    {
-      "id": 4,
-      "module": "nodes.filters.grayscale",
-      "class": "Grayscale",
-      "position": [
-        -1397.0,
-        -476.0
       ],
       "params": {}
     },
@@ -77,18 +56,6 @@
       "src_output": 0,
       "dst_node": 3,
       "dst_input": 0
-    },
-    {
-      "src_node": 2,
-      "src_output": 0,
-      "dst_node": 4,
-      "dst_input": 0
-    },
-    {
-      "src_node": 4,
-      "src_output": 0,
-      "dst_node": 0,
-      "dst_input": 1
     },
     {
       "src_node": 3,

--- a/flow/video_ncc.flowjs
+++ b/flow/video_ncc.flowjs
@@ -56,6 +56,7 @@
         -1022.7142910588416
       ],
       "params": {
+        "template": "pad.jpg",
         "retain_size": true
       }
     },
@@ -66,28 +67,6 @@
       "position": [
         -2279.6932476161055,
         -999.7513369937287
-      ],
-      "params": {}
-    },
-    {
-      "id": 5,
-      "module": "nodes.sources.image_source",
-      "class": "ImageSource",
-      "position": [
-        -2547.0182823301943,
-        -880.0711473173984
-      ],
-      "params": {
-        "file_path": "pad.jpg"
-      }
-    },
-    {
-      "id": 6,
-      "module": "nodes.filters.grayscale",
-      "class": "Grayscale",
-      "position": [
-        -2278.1322105767763,
-        -922.9072311234843
       ],
       "params": {}
     },
@@ -120,18 +99,6 @@
       "src_output": 0,
       "dst_node": 3,
       "dst_input": 0
-    },
-    {
-      "src_node": 5,
-      "src_output": 0,
-      "dst_node": 6,
-      "dst_input": 0
-    },
-    {
-      "src_node": 6,
-      "src_output": 0,
-      "dst_node": 3,
-      "dst_input": 1
     },
     {
       "src_node": 0,

--- a/src/constants.py
+++ b/src/constants.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 APP_NAME:         str = "Image-Inquest"
 APP_DISPLAY_NAME: str = "Stjörnhorn"
-APP_VERSION:      str = "0.1.9"
+APP_VERSION:      str = "0.1.10"
 API_URL:    str = "https://beltoforion.de"
 
 # Bundled documentation (offline welcome page, screenshots, …)

--- a/src/nodes/filters/ncc.py
+++ b/src/nodes/filters/ncc.py
@@ -1,22 +1,28 @@
 from __future__ import annotations
 
+from pathlib import Path
+
 import cv2
 import numpy as np
 from typing_extensions import override
 
+from constants import INPUT_DIR
 from core.io_data import IoData, IoDataType
 from core.node_base import NodeBase, NodeParam, NodeParamType
 from core.port import InputPort, OutputPort
+
+_SUPPORTED_EXTS = {".jpg", ".jpeg", ".png", ".webp", ".bmp", ".tif", ".tiff"}
 
 
 class Ncc(NodeBase):
     """Normalised cross-correlation template matching.
 
     Wraps ``cv2.matchTemplate`` with ``TM_CCORR_NORMED`` and rescales the
-    score map to a ``uint8`` greyscale image. The ``template`` input is
-    the pattern searched for within ``image``. Both inputs must be
-    single-channel greyscale. Ported from the original OCVL
-    ``NccProcessor``.
+    score map to a ``uint8`` greyscale image. The template is loaded from
+    disk via the ``template`` file-path parameter; a colour template is
+    converted to greyscale once at ``before_run`` time so the conversion
+    cost is paid a single time per run, not per frame. The ``image``
+    input is single-channel greyscale and the output is always greyscale.
 
     With ``retain_size=True`` (default) the match map is pasted into a
     canvas the same size as ``image`` and offset by half the template
@@ -29,9 +35,10 @@ class Ncc(NodeBase):
     def __init__(self) -> None:
         super().__init__("NCC", section="Processing")
         self._retain_size: bool = True
+        self._template_path: Path = Path()
+        self._template: np.ndarray | None = None
 
         self._add_input(InputPort("image", {IoDataType.IMAGE_GREY}))
-        self._add_input(InputPort("template", {IoDataType.IMAGE_GREY}))
         self._add_output(OutputPort("image", {IoDataType.IMAGE_GREY}))
 
         self._apply_default_params()
@@ -41,7 +48,10 @@ class Ncc(NodeBase):
     @property
     @override
     def params(self) -> list[NodeParam]:
-        return [NodeParam("retain_size", NodeParamType.BOOL, {"default": True})]
+        return [
+            NodeParam("template", NodeParamType.FILE_PATH, {"default": "pad.jpg", "filter": "Images (*.png *.jpg *.jpeg *.webp *.bmp *.tif *.tiff)", "base_dir": INPUT_DIR}),
+            NodeParam("retain_size", NodeParamType.BOOL, {"default": True}),
+        ]
 
     # ── Properties ─────────────────────────────────────────────────────────────
 
@@ -53,12 +63,35 @@ class Ncc(NodeBase):
     def retain_size(self, value: bool) -> None:
         self._retain_size = bool(value)
 
+    @property
+    def template(self) -> Path:
+        return self._template_path
+
+    @template.setter
+    def template(self, path: str | Path) -> None:
+        p = Path(path)
+        if p.is_absolute():
+            try:
+                p = p.resolve().relative_to(INPUT_DIR.resolve())
+            except (OSError, ValueError):
+                pass  # outside INPUT_DIR — keep absolute
+        self._template_path = p
+
     # ── NodeBase interface ─────────────────────────────────────────────────────
 
     @override
+    def _before_run_impl(self) -> None:
+        super()._before_run_impl()
+        self._template = self._load_template()
+
+    @override
     def process_impl(self) -> None:
+        if self._template is None:
+            # before_run wasn't called (e.g. direct unit-test use); load lazily.
+            self._template = self._load_template()
+
         image: np.ndarray = self.inputs[0].data.image
-        template: np.ndarray = self.inputs[1].data.image
+        template = self._template
 
         res = cv2.matchTemplate(image, template, cv2.TM_CCORR_NORMED)
         res = cv2.normalize(
@@ -84,3 +117,40 @@ class Ncc(NodeBase):
             out = res
 
         self.outputs[0].send(IoData.from_greyscale(out))
+
+    # ── Internals ──────────────────────────────────────────────────────────────
+
+    def _resolved_template_path(self) -> Path:
+        if self._template_path.is_absolute():
+            return self._template_path
+        return INPUT_DIR / self._template_path
+
+    def _load_template(self) -> np.ndarray:
+        resolved = self._resolved_template_path()
+        if not resolved.exists():
+            raise FileNotFoundError(f"NCC template not found: {resolved}")
+
+        ext = resolved.suffix.lower()
+        if ext not in _SUPPORTED_EXTS:
+            raise ValueError(
+                f"Unsupported template file type '{ext}'. "
+                f"Supported: {_SUPPORTED_EXTS}"
+            )
+
+        # cv2.imread() silently fails on Unicode paths on Windows; use
+        # np.fromfile + imdecode to go through Python's wide-char I/O.
+        img_array = np.fromfile(resolved, dtype=np.uint8)
+        template = cv2.imdecode(img_array, cv2.IMREAD_UNCHANGED)
+        if template is None:
+            raise OSError(f"cv2 could not read template: {resolved}")
+
+        if template.ndim == 3:
+            channels = template.shape[2]
+            if channels == 4:
+                template = cv2.cvtColor(template, cv2.COLOR_BGRA2GRAY)
+            elif channels == 3:
+                template = cv2.cvtColor(template, cv2.COLOR_BGR2GRAY)
+            else:
+                template = template[:, :, 0]
+
+        return template

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1,13 +1,13 @@
 """Unit tests for the filter nodes ported from OCVL."""
 from __future__ import annotations
 
+from pathlib import Path
+
 import cv2
 import numpy as np
 import pytest
 
 from core.io_data import IoData
-from core.io_data import IoDataType
-from core.port import OutputPort
 from nodes.filters.adaptive_gaussian_threshold import AdaptiveGaussianThreshold
 from nodes.filters.dither import Dither, DitherMethod
 from nodes.filters.median import Median
@@ -197,30 +197,44 @@ def test_dither_rejects_unknown_method() -> None:
 
 # ── NCC ───────────────────────────────────────────────────────────────────────
 
-def _feed_ncc(node: Ncc, image: np.ndarray, template: np.ndarray) -> np.ndarray:
+def _write_template(path: Path, template: np.ndarray) -> None:
+    assert cv2.imwrite(str(path), template), f"failed to write template to {path}"
+
+
+def _make_ncc(template_path: Path) -> Ncc:
+    node = Ncc()
+    node.template = template_path
+    node.before_run()
+    return node
+
+
+def _feed_ncc(node: Ncc, image: np.ndarray) -> np.ndarray:
     node.inputs[0].receive(IoData.from_greyscale(image))
-    node.inputs[1].receive(IoData.from_greyscale(template))
     out = node.outputs[0].last_emitted
     assert out is not None, "NCC did not emit on output 0"
     return out.image
 
 
-def test_ncc_retain_size_matches_input_shape() -> None:
+def test_ncc_retain_size_matches_input_shape(tmp_path: Path) -> None:
     image = _gradient(h=32, w=32)
     template = image[10:16, 10:16].copy()
+    tpl_path = tmp_path / "template.png"
+    _write_template(tpl_path, template)
 
-    out = _feed_ncc(Ncc(), image, template)
+    out = _feed_ncc(_make_ncc(tpl_path), image)
 
     assert out.shape == image.shape
     assert out.dtype == np.uint8
 
 
-def test_ncc_peaks_at_template_centre_when_retain_size() -> None:
+def test_ncc_peaks_at_template_centre_when_retain_size(tmp_path: Path) -> None:
     image = np.zeros((32, 32), dtype=np.uint8)
     image[12:20, 12:20] = 255
     template = np.full((8, 8), 255, dtype=np.uint8)
+    tpl_path = tmp_path / "template.png"
+    _write_template(tpl_path, template)
 
-    out = _feed_ncc(Ncc(), image, template)
+    out = _feed_ncc(_make_ncc(tpl_path), image)
 
     # The perfect match sits at the top-left of the matchTemplate result
     # (row=12, col=12); with retain_size it's offset by template/2 (=4),
@@ -230,13 +244,18 @@ def test_ncc_peaks_at_template_centre_when_retain_size() -> None:
     assert out[peak] == 255
 
 
-def test_ncc_without_retain_size_returns_raw_match_shape() -> None:
+def test_ncc_without_retain_size_returns_raw_match_shape(tmp_path: Path) -> None:
     image = _gradient(h=32, w=32)
     template = image[0:8, 0:8].copy()
+    tpl_path = tmp_path / "template.png"
+    _write_template(tpl_path, template)
 
     node = Ncc()
+    node.template = tpl_path
     node.retain_size = False
-    out = _feed_ncc(node, image, template)
+    node.before_run()
+
+    out = _feed_ncc(node, image)
 
     # cv2.matchTemplate output: (H - h + 1, W - w + 1)
     assert out.shape == (32 - 8 + 1, 32 - 8 + 1)
@@ -249,32 +268,18 @@ def test_ncc_rejects_colour_image_input() -> None:
         node.inputs[0].receive(IoData.from_image(colour))
 
 
-def test_ncc_matches_when_two_sources_deliver_sequentially_then_finish() -> None:
-    """Emulates how ``Flow.run`` drives NCC with two independent sources:
-    each source delivers its data in turn, and the runner calls
-    ``finish()`` on every source output afterwards. NCC must process the
-    pair once and forward ``finish()`` to its output."""
+def test_ncc_converts_colour_template_to_greyscale_at_before_run(tmp_path: Path) -> None:
+    """Colour templates are reduced to greyscale once at before_run time,
+    so matchTemplate runs on single-channel data per frame."""
+    template_grey = np.full((8, 8), 200, dtype=np.uint8)
+    template_colour = cv2.cvtColor(template_grey, cv2.COLOR_GRAY2BGR)
+    tpl_path = tmp_path / "colour_template.png"
+    _write_template(tpl_path, template_colour)
+
     node = Ncc()
+    node.template = tpl_path
+    node.before_run()
 
-    image_up = OutputPort("image", {IoDataType.IMAGE_GREY})
-    template_up = OutputPort("template", {IoDataType.IMAGE_GREY})
-    image_up.connect(node.inputs[0])
-    template_up.connect(node.inputs[1])
-
-    image = np.zeros((32, 32), dtype=np.uint8)
-    image[12:20, 12:20] = 255
-    template = np.full((8, 8), 255, dtype=np.uint8)
-
-    # Data delivery phase (sequential, like Flow.run starting sources).
-    image_up.send(IoData.from_greyscale(image))
-    template_up.send(IoData.from_greyscale(template))
-
-    # Lifetime phase (runner calls finish() on every source output).
-    image_up.finish()
-    template_up.finish()
-
-    out = node.outputs[0].last_emitted
-    assert out is not None
-    assert out.type == IoDataType.IMAGE_GREY
-    assert out.image.shape == image.shape
-    assert node.outputs[0].finished
+    assert node._template is not None
+    assert node._template.ndim == 2
+    assert node._template.shape == template_grey.shape

--- a/tests/test_video_sink.py
+++ b/tests/test_video_sink.py
@@ -12,7 +12,7 @@ from core.flow import Flow
 from core.io_data import IoData, IoDataType
 from core.node_base import NodeParam, SourceNodeBase
 from core.port import OutputPort
-from nodes.filters.ncc import Ncc
+from nodes.filters.merge import Merge
 from nodes.sinks.video_sink import VideoSink
 
 
@@ -178,22 +178,22 @@ def test_flow_latches_reactive_source_across_streaming_frames(tmp_path: Path) ->
     filter must stay available while a streaming source drives the other
     input — otherwise only one paired frame would reach the sink.
 
-    Regression for the debug_ncc_video flow: Ncc takes (image, template);
-    with VideoSource on ``image`` and ImageSource on ``template``, every
-    video frame must produce an Ncc output, not just the last one."""
-    template = np.full((8, 8), 255, dtype=np.uint8)
+    Drives ``Merge`` with a streaming greyscale source on ``top_left`` and
+    a reactive one-shot source on ``top_right``; every frame of the
+    streaming source must produce a merged output, not just the last one."""
+    fixed = np.full((16, 16), 255, dtype=np.uint8)
     frames: list[np.ndarray] = []
     # Five frames, each with the bright patch in a different spot so the
-    # matching peak differs per-frame — sanity check the flow actually
+    # merged output differs per-frame — sanity check the flow actually
     # processes each one rather than re-emitting the same result.
     for i in range(5):
-        f = np.zeros((32, 32), dtype=np.uint8)
+        f = np.zeros((16, 16), dtype=np.uint8)
         f[4 + i:10 + i, 4 + i:10 + i] = 255
         frames.append(f)
 
-    image_src = _GreyFrameListSource(frames)
-    template_src = _ReactiveImageSource(template)
-    ncc = Ncc()
+    streaming_src = _GreyFrameListSource(frames)
+    reactive_src = _ReactiveImageSource(fixed)
+    merge = Merge()
     sink = VideoSink()
     sink.output_path = tmp_path / "latched.mp4"
     sink.fps = 30.0
@@ -201,13 +201,13 @@ def test_flow_latches_reactive_source_across_streaming_frames(tmp_path: Path) ->
     flow = Flow("latched")
     # Registration order intentionally puts the streaming source first —
     # the runner must still schedule the reactive one-shot source ahead.
-    flow.add_node(image_src)
-    flow.add_node(template_src)
-    flow.add_node(ncc)
+    flow.add_node(streaming_src)
+    flow.add_node(reactive_src)
+    flow.add_node(merge)
     flow.add_node(sink)
-    flow.connect(image_src, 0, ncc, 0)
-    flow.connect(template_src, 0, ncc, 1)
-    flow.connect(ncc, 0, sink, 0)
+    flow.connect(streaming_src, 0, merge, 0)
+    flow.connect(reactive_src, 0, merge, 1)
+    flow.connect(merge, 0, sink, 0)
 
     flow.run()
 


### PR DESCRIPTION
## Summary
The NCC (Normalized Cross-Correlation) node has been refactored to load its template pattern from a file-path parameter instead of accepting it as a second input port. This change improves performance and simplifies the node's interface by eliminating the need for a separate template source in flows.

## Key Changes

- **Template loading**: Template is now loaded from disk once during `before_run()` rather than being supplied via an input port each frame
- **Colour-to-greyscale conversion**: Colour templates are automatically converted to greyscale at `before_run()` time, eliminating per-frame conversion overhead
- **File-path parameter**: Added a new `template` file-path parameter with support for common image formats (.jpg, .jpeg, .png, .webp, .bmp, .tif, .tiff)
- **Removed input port**: The second input port (`template`) has been removed; the node now only accepts `image` as an input
- **Path resolution**: Template paths are resolved relative to `INPUT_DIR`, with support for both relative and absolute paths
- **Error handling**: Added validation for file existence and supported formats, with informative error messages

## Implementation Details

- Template loading is deferred to `_load_template()` method which handles:
  - Path resolution (relative to INPUT_DIR or absolute)
  - File existence validation
  - Format validation against supported extensions
  - Unicode path handling on Windows via `np.fromfile()` + `cv2.imdecode()`
  - Automatic colour-to-greyscale conversion for 3 or 4-channel images
  
- Lazy loading fallback in `process_impl()` for direct unit-test usage without `before_run()`
- Updated test suite to use temporary files and the new `before_run()` workflow
- Updated bundled flows (`ncc.flowjs`, `video_ncc.flowjs`, `debug_ncc_video.flowjs`) to remove template source nodes and set the parameter instead
- Version bumped to 0.1.10

## Breaking Changes
Existing flows that connect a source to the NCC template port must be re-saved; the template should now be specified via the file-path parameter instead.

https://claude.ai/code/session_01BCyWvDxLL8ggDqgWthYXpd