### PR TITLE
Dither node now preserves input image type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ once a first tagged release is cut.
 
 ## [Unreleased]
 
+## [0.1.12] — 2026-04-24
+
+### Changed
+- **Dither node preserves the input type.** Greyscale inputs still
+  emit a single-channel binary image, but colour (BGR) inputs are now
+  dithered per channel and emit a colour image of the same shape
+  instead of being greyscaled first. The output port now accepts both
+  `IMAGE` and `IMAGE_GREY`, which also makes the node eligible for the
+  skip (pass-through) toggle.
+
 ## [0.1.11] — 2026-04-24
 
 ### Changed

--- a/src/constants.py
+++ b/src/constants.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 APP_NAME:         str = "Image-Inquest"
 APP_DISPLAY_NAME: str = "Stjörnhorn"
-APP_VERSION:      str = "0.1.11"
+APP_VERSION:      str = "0.1.12"
 API_URL:    str = "https://beltoforion.de"
 
 # Bundled documentation (offline welcome page, screenshots, …)

--- a/src/nodes/filters/dither.py
+++ b/src/nodes/filters/dither.py
@@ -8,7 +8,7 @@ import numba
 import numpy as np
 from typing_extensions import override
 
-from core.io_data import IMAGE_TYPES, IoData, IoDataType
+from core.io_data import IMAGE_TYPES
 from core.node_base import NodeBase, NodeParam, NodeParamType
 from core.port import InputPort, OutputPort
 
@@ -101,10 +101,10 @@ _BAYER_MATRICES: dict[DitherMethod, np.ndarray] = {
 class Dither(NodeBase):
     """Binary (black/white) dithering with a configurable algorithm.
 
-    Reduces an image to two levels (0 / 255) using one of the classic
-    ordered or error-diffusion schemes. Colour inputs are converted to
-    greyscale first; the output is always a single-channel
-    :data:`IoDataType.IMAGE_GREY` payload.
+    Reduces an image to two levels (0 / 255) per channel using one of the
+    classic ordered or error-diffusion schemes. Greyscale inputs produce
+    greyscale outputs; colour inputs are dithered per channel and produce
+    a colour output of the same shape.
 
     The error-diffusion inner loop is JIT-compiled by numba on first use
     (``@njit(cache=True)``), making it comparable in speed to the
@@ -116,7 +116,7 @@ class Dither(NodeBase):
         self._method: DitherMethod = DitherMethod.STUCKI
 
         self._add_input(InputPort("image", set(IMAGE_TYPES)))
-        self._add_output(OutputPort("image", {IoDataType.IMAGE_GREY}))
+        self._add_output(OutputPort("image", set(IMAGE_TYPES)))
 
         self._apply_default_params()
 
@@ -152,22 +152,26 @@ class Dither(NodeBase):
 
     @override
     def process_impl(self) -> None:
-        image: np.ndarray = self.inputs[0].data.image
+        in_data = self.inputs[0].data
+        image: np.ndarray = in_data.image
 
         if image.ndim == 3:
-            gray = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)
+            # cv2.split yields a list of contiguous single-channel
+            # planes, which cv2.randn and numba both prefer.
+            planes = [self._dither_plane(c) for c in cv2.split(image)]
+            out = cv2.merge(planes)
         else:
-            gray = image
+            out = self._dither_plane(image)
 
+        self.outputs[0].send(in_data.with_image(out))
+
+    def _dither_plane(self, plane: np.ndarray) -> np.ndarray:
         method = self._method
         if method == DitherMethod.NOISE:
-            out = _dither_noise(gray)
-        elif method in _BAYER_MATRICES:
-            out = _dither_bayer(gray, _BAYER_MATRICES[method])
-        else:
-            out = _dither_diffusion(gray, _DIFFUSION_KERNELS[method])
-
-        self.outputs[0].send(IoData.from_greyscale(out))
+            return _dither_noise(plane)
+        if method in _BAYER_MATRICES:
+            return _dither_bayer(plane, _BAYER_MATRICES[method])
+        return _dither_diffusion(plane, _DIFFUSION_KERNELS[method])
 
 
 # ── Dithering kernels ─────────────────────────────────────────────────────────

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -171,21 +171,28 @@ def test_dither_produces_greyscale_binary_output(method: DitherMethod) -> None:
     node.method = int(method)
     out = _run(node, image)
 
-    # Dither emits a single-channel IMAGE_GREY payload.
+    # Greyscale input -> single-channel binary output.
     assert out.shape == (8, 8)
     assert set(np.unique(out).tolist()).issubset({0, 255})
 
 
-def test_dither_accepts_bgr_input() -> None:
-    # Gradient broadcast to 3 channels — the node should greyscale it.
-    gray = _gradient(h=8, w=8)
-    bgr = cv2.cvtColor(gray, cv2.COLOR_GRAY2BGR)
+@pytest.mark.parametrize("method", list(DitherMethod))
+def test_dither_preserves_colour_channels(method: DitherMethod) -> None:
+    # Distinct per-channel gradients so a greyscale conversion would
+    # erase the channel differences and let the test catch a regression.
+    h, w = 8, 8
+    bgr = np.stack([
+        _gradient(h=h, w=w),
+        np.flipud(_gradient(h=h, w=w)),
+        np.fliplr(_gradient(h=h, w=w)),
+    ], axis=-1)
 
     node = Dither()
-    node.method = int(DitherMethod.BAYER4)
+    node.method = int(method)
     out = _run(node, bgr)
 
-    assert out.shape == (8, 8)
+    # Colour input -> colour output, still binary per channel.
+    assert out.shape == (h, w, 3)
     assert set(np.unique(out).tolist()).issubset({0, 255})
 
 

--- a/tests/test_skip_node.py
+++ b/tests/test_skip_node.py
@@ -25,10 +25,10 @@ def test_shift_is_skippable() -> None:
     assert Shift().is_skippable is True
 
 
-def test_dither_is_not_skippable() -> None:
-    """Dither accepts colour or greyscale but only emits greyscale — bypassing
-    could forward a colour image onto a greyscale-only downstream port."""
-    assert Dither().is_skippable is False
+def test_dither_is_skippable() -> None:
+    """Dither now preserves the input type (greyscale stays greyscale,
+    colour stays colour) so its in/out port types line up pairwise."""
+    assert Dither().is_skippable is True
 
 
 def test_grayscale_is_not_skippable() -> None:
@@ -51,7 +51,7 @@ def test_source_and_sink_are_not_skippable() -> None:
 
 
 def test_setting_skipped_on_non_skippable_raises() -> None:
-    node = Dither()
+    node = Grayscale()
     with pytest.raises(ValueError):
         node.skipped = True
 


### PR DESCRIPTION
## Summary
The Dither node has been refactored to preserve the input image type instead of always converting to greyscale. Greyscale inputs continue to produce single-channel binary output, while colour (BGR) inputs are now dithered per channel and produce colour output of the same shape.

## Key Changes
- **Output type flexibility**: Changed output port from `IMAGE_GREY` only to accepting both `IMAGE_TYPES`, making the node skippable
- **Per-channel dithering**: Colour images are now split into individual planes, dithered independently, and merged back instead of being converted to greyscale first
- **Refactored processing logic**: Extracted dithering logic into a new `_dither_plane()` method to handle both greyscale and per-channel colour processing
- **Updated tests**: 
  - Modified `test_dither_accepts_bgr_input()` to `test_dither_preserves_colour_channels()` with distinct per-channel gradients to verify colour preservation
  - Updated `test_dither_is_not_skippable()` to `test_dither_is_skippable()` reflecting the node's new eligibility for skip toggle
- **Documentation**: Updated docstring to clarify that the node now dithers per channel for colour inputs rather than converting to greyscale
- **Version bump**: Updated to 0.1.12 with changelog entry

## Implementation Details
- Uses `cv2.split()` to decompose colour images into contiguous single-channel planes (preferred by cv2 and numba)
- Uses `cv2.merge()` to recombine dithered planes
- Preserves input `IoData` metadata via `in_data.with_image(out)` instead of creating new greyscale data
- Simplified conditional logic in `_dither_plane()` using early returns

https://claude.ai/code/session_01W3NEygpnrTJSdiyC8mLqT7