### PR TITLE
Add Overlay node for image compositing with alpha blending

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,10 +15,11 @@ once a first tagged release is cut.
 ### Added
 - **Overlay node** (palette section *Composit*) — composites an
   overlay image onto a base image. The overlay is optionally resized
-  by a `scale` factor, placed at `(xpos, ypos)`, and alpha-blended
-  with opacity `alpha`. Parts of the overlay that fall outside the
-  base are clipped; mixed greyscale/colour inputs are promoted to
-  colour, otherwise the output stays greyscale.
+  by a `scale` factor, rotated by `angle` degrees (bounding box
+  expanded so no pixels are lost), placed at `(xpos, ypos)`, and
+  alpha-blended with opacity `alpha`. Parts of the overlay that fall
+  outside the base are clipped; mixed greyscale/colour inputs are
+  promoted to colour, otherwise the output stays greyscale.
 
 ## [0.1.12] — 2026-04-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ once a first tagged release is cut.
 
 ## [Unreleased]
 
+## [0.1.13] — 2026-04-24
+
+### Added
+- **Overlay node** (palette section *Composit*) — composites an
+  overlay image onto a base image. The overlay is optionally resized
+  by a `scale` factor, placed at `(xpos, ypos)`, and alpha-blended
+  with opacity `alpha`. Parts of the overlay that fall outside the
+  base are clipped; mixed greyscale/colour inputs are promoted to
+  colour, otherwise the output stays greyscale.
+
 ## [0.1.12] — 2026-04-24
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,12 @@ once a first tagged release is cut.
   outside the base are clipped; mixed greyscale/colour inputs are
   promoted to colour, otherwise the output stays greyscale.
 
+### Fixed
+- **Image Source: WebP files now show up in the file picker.** The
+  name-filter string had a stray comma after `*.webp`, which Qt
+  parsed as a literal glob pattern and caused the dialog to hide
+  every WebP file. Docstring now lists WebP alongside JPEG/PNG/CR2.
+
 ## [0.1.12] — 2026-04-24
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,9 @@
 ## Automated Responses
 - The `Claude Issue Assistant` workflow (`.github/workflows/claude-issue.yml`) must only act on events whose `github.actor` is the repository owner. Never remove or loosen that gate — third-party issue/comment activity must not trigger any Claude run, including no reply. If collaborator access is ever needed, switch to an explicit allowlist rather than opening the trigger up.
 
+## Implementation
+- Keep performance in mind when writing code, especially on hot paths (per-frame video processing, image ops). Proactively surface non-trivial optimisation opportunities — skippable work, redundant copies, per-frame allocations in streaming paths — but do not spend effort on micro-optimisations (enum lookups, local variable binding, attribute lookup caching) that do not move the needle on real workloads.
+
 ## Communication Style
 - Keine einleitenden Formulierungen (z. B. "Kurze, ehrliche Antwort:", "Gerne,", "Natürlich,"). Direkt zum Punkt, reine Informationsübertragung, so kurz wie möglich.
 

--- a/flow/sample_overlay.flowjs
+++ b/flow/sample_overlay.flowjs
@@ -1,0 +1,102 @@
+{
+  "version": 1,
+  "app_version": "0.1.13",
+  "name": "sample_overlay",
+  "nodes": [
+    {
+      "id": 0,
+      "module": "nodes.sources.video_source",
+      "class": "VideoSource",
+      "position": [
+        -1718.0,
+        -802.0
+      ],
+      "params": {
+        "file_path": "/home/user/Dokumente/GitHub/image-inquest/input/video.mp4",
+        "max_num_frames": -1
+      }
+    },
+    {
+      "id": 1,
+      "module": "nodes.sinks.video_sink",
+      "class": "VideoSink",
+      "position": [
+        -452.0,
+        -415.0
+      ],
+      "params": {
+        "output_path": "out.mp4",
+        "fps": 30.0,
+        "codec": 0
+      }
+    },
+    {
+      "id": 2,
+      "module": "nodes.filters.overlay",
+      "class": "Overlay",
+      "position": [
+        -1356.0,
+        -878.0
+      ],
+      "params": {
+        "scale": 2.0,
+        "angle": 0.0,
+        "xpos": 0,
+        "ypos": 0,
+        "alpha": 0.3
+      }
+    },
+    {
+      "id": 3,
+      "module": "nodes.sources.image_source",
+      "class": "ImageSource",
+      "position": [
+        -1667.0,
+        -588.0
+      ],
+      "params": {
+        "file_path": "pad.jpg"
+      }
+    },
+    {
+      "id": 4,
+      "module": "nodes.filters.display",
+      "class": "Display",
+      "position": [
+        -1078.0,
+        -913.0
+      ],
+      "params": {},
+      "size": [
+        537.0,
+        404.0
+      ]
+    }
+  ],
+  "connections": [
+    {
+      "src_node": 0,
+      "src_output": 0,
+      "dst_node": 2,
+      "dst_input": 0
+    },
+    {
+      "src_node": 3,
+      "src_output": 0,
+      "dst_node": 2,
+      "dst_input": 1
+    },
+    {
+      "src_node": 2,
+      "src_output": 0,
+      "dst_node": 4,
+      "dst_input": 0
+    },
+    {
+      "src_node": 4,
+      "src_output": 0,
+      "dst_node": 1,
+      "dst_input": 0
+    }
+  ]
+}

--- a/src/constants.py
+++ b/src/constants.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 APP_NAME:         str = "Image-Inquest"
 APP_DISPLAY_NAME: str = "Stjörnhorn"
-APP_VERSION:      str = "0.1.12"
+APP_VERSION:      str = "0.1.13"
 API_URL:    str = "https://beltoforion.de"
 
 # Bundled documentation (offline welcome page, screenshots, …)

--- a/src/nodes/filters/overlay.py
+++ b/src/nodes/filters/overlay.py
@@ -119,64 +119,81 @@ class Overlay(NodeBase):
                 return cv2.cvtColor(d.image, cv2.COLOR_GRAY2BGR)
             return d.image
 
-        base    = to_canvas(base_data).copy()
-        overlay = to_canvas(overlay_data)
+        # ── Skip path 1: alpha == 0 ───────────────────────────────────────
+        # Overlay is invisible — no warp, no copy, no blend. Forward the
+        # (possibly grey→BGR promoted) base straight through.
+        if self._alpha == 0.0:
+            self._emit(to_canvas(base_data), any_color)
+            return
 
-        # When rotation is active, fold scale into the same affine warp
-        # so the overlay is resampled only once. Pure scaling (no
-        # rotation) uses cv2.resize instead — warpAffine with
-        # BORDER_CONSTANT would darken the outer pixels toward zero,
-        # while cv2.resize preserves sharp edges.
+        overlay_src = to_canvas(overlay_data)
+        src_h, src_w = overlay_src.shape[:2]
+
+        # ── Predict the transformed overlay's bounding box (no warp yet) ──
+        # cheap enough to always compute, so we can decide whether to
+        # bother with the expensive warpAffine / resize / base.copy().
         rotates = self._angle % 360.0 != 0.0
         if rotates:
-            ov_h, ov_w = overlay.shape[:2]
-            center = (ov_w / 2.0, ov_h / 2.0)
+            center = (src_w / 2.0, src_h / 2.0)
             M = cv2.getRotationMatrix2D(center, self._angle, self._scale)
-            # Expand the output bounding box so the scaled + rotated
-            # image fits without being cropped, and shift the matrix
-            # accordingly. cos/sin here already include the scale
-            # factor from getRotationMatrix2D.
             cos = abs(M[0, 0])
             sin = abs(M[0, 1])
-            out_w = max(1, int(round(ov_h * sin + ov_w * cos)))
-            out_h = max(1, int(round(ov_h * cos + ov_w * sin)))
-            M[0, 2] += (out_w / 2.0) - center[0]
-            M[1, 2] += (out_h / 2.0) - center[1]
-            overlay = cv2.warpAffine(
-                overlay, M, (out_w, out_h), flags=cv2.INTER_LINEAR
-            )
+            out_w = max(1, int(round(src_h * sin + src_w * cos)))
+            out_h = max(1, int(round(src_h * cos + src_w * sin)))
         elif self._scale != 1.0:
-            ov_h, ov_w = overlay.shape[:2]
-            new_w = max(1, int(round(ov_w * self._scale)))
-            new_h = max(1, int(round(ov_h * self._scale)))
-            overlay = cv2.resize(
-                overlay, (new_w, new_h), interpolation=cv2.INTER_LINEAR
-            )
+            out_w = max(1, int(round(src_w * self._scale)))
+            out_h = max(1, int(round(src_h * self._scale)))
+        else:
+            out_w, out_h = src_w, src_h
 
-        base_h, base_w = base.shape[:2]
-        ov_h,   ov_w   = overlay.shape[:2]
+        base_src = to_canvas(base_data)
+        base_h, base_w = base_src.shape[:2]
 
         # Destination rectangle on the base, clipped to the base bounds.
         x0 = max(self._xpos, 0)
         y0 = max(self._ypos, 0)
-        x1 = min(self._xpos + ov_w, base_w)
-        y1 = min(self._ypos + ov_h, base_h)
+        x1 = min(self._xpos + out_w, base_w)
+        y1 = min(self._ypos + out_h, base_h)
 
-        if x0 < x1 and y0 < y1:
-            # Matching rectangle inside the overlay (accounts for negative
-            # xpos/ypos shifting the overlay off the top-left edge).
-            ox0 = x0 - self._xpos
-            oy0 = y0 - self._ypos
-            ox1 = ox0 + (x1 - x0)
-            oy1 = oy0 + (y1 - y0)
+        # ── Skip path 2: transformed overlay misses the base entirely ─────
+        # Same deal — pass the base through without warping or copying.
+        if x0 >= x1 or y0 >= y1:
+            self._emit(base_src, any_color)
+            return
 
-            roi     = base[y0:y1, x0:x1]
-            ov_crop = overlay[oy0:oy1, ox0:ox1]
-
-            blended = cv2.addWeighted(ov_crop, self._alpha, roi, 1.0 - self._alpha, 0.0)
-            base[y0:y1, x0:x1] = blended
-
-        if any_color:
-            self.outputs[0].send(IoData.from_image(base))
+        # ── Execute the transform + composite ─────────────────────────────
+        if rotates:
+            M[0, 2] += (out_w / 2.0) - center[0]
+            M[1, 2] += (out_h / 2.0) - center[1]
+            overlay = cv2.warpAffine(
+                overlay_src, M, (out_w, out_h), flags=cv2.INTER_LINEAR
+            )
+        elif self._scale != 1.0:
+            overlay = cv2.resize(
+                overlay_src, (out_w, out_h), interpolation=cv2.INTER_LINEAR
+            )
         else:
-            self.outputs[0].send(IoData.from_greyscale(base))
+            overlay = overlay_src
+
+        base = base_src.copy()
+
+        # Matching rectangle inside the overlay (accounts for negative
+        # xpos/ypos shifting the overlay off the top-left edge).
+        ox0 = x0 - self._xpos
+        oy0 = y0 - self._ypos
+        ox1 = ox0 + (x1 - x0)
+        oy1 = oy0 + (y1 - y0)
+
+        roi     = base[y0:y1, x0:x1]
+        ov_crop = overlay[oy0:oy1, ox0:ox1]
+
+        blended = cv2.addWeighted(ov_crop, self._alpha, roi, 1.0 - self._alpha, 0.0)
+        base[y0:y1, x0:x1] = blended
+
+        self._emit(base, any_color)
+
+    def _emit(self, image: np.ndarray, any_color: bool) -> None:
+        if any_color:
+            self.outputs[0].send(IoData.from_image(image))
+        else:
+            self.outputs[0].send(IoData.from_greyscale(image))

--- a/src/nodes/filters/overlay.py
+++ b/src/nodes/filters/overlay.py
@@ -122,26 +122,35 @@ class Overlay(NodeBase):
         base    = to_canvas(base_data).copy()
         overlay = to_canvas(overlay_data)
 
-        if self._scale != 1.0:
+        # When rotation is active, fold scale into the same affine warp
+        # so the overlay is resampled only once. Pure scaling (no
+        # rotation) uses cv2.resize instead — warpAffine with
+        # BORDER_CONSTANT would darken the outer pixels toward zero,
+        # while cv2.resize preserves sharp edges.
+        rotates = self._angle % 360.0 != 0.0
+        if rotates:
+            ov_h, ov_w = overlay.shape[:2]
+            center = (ov_w / 2.0, ov_h / 2.0)
+            M = cv2.getRotationMatrix2D(center, self._angle, self._scale)
+            # Expand the output bounding box so the scaled + rotated
+            # image fits without being cropped, and shift the matrix
+            # accordingly. cos/sin here already include the scale
+            # factor from getRotationMatrix2D.
+            cos = abs(M[0, 0])
+            sin = abs(M[0, 1])
+            out_w = max(1, int(round(ov_h * sin + ov_w * cos)))
+            out_h = max(1, int(round(ov_h * cos + ov_w * sin)))
+            M[0, 2] += (out_w / 2.0) - center[0]
+            M[1, 2] += (out_h / 2.0) - center[1]
+            overlay = cv2.warpAffine(
+                overlay, M, (out_w, out_h), flags=cv2.INTER_LINEAR
+            )
+        elif self._scale != 1.0:
             ov_h, ov_w = overlay.shape[:2]
             new_w = max(1, int(round(ov_w * self._scale)))
             new_h = max(1, int(round(ov_h * self._scale)))
-            overlay = cv2.resize(overlay, (new_w, new_h), interpolation=cv2.INTER_LINEAR)
-
-        if self._angle % 360.0 != 0.0:
-            ov_h, ov_w = overlay.shape[:2]
-            center = (ov_w / 2.0, ov_h / 2.0)
-            M = cv2.getRotationMatrix2D(center, self._angle, 1.0)
-            # Expand the bounding box so the rotated image fits without
-            # being cropped, and shift the rotation matrix accordingly.
-            cos = abs(M[0, 0])
-            sin = abs(M[0, 1])
-            rot_w = max(1, int(round(ov_h * sin + ov_w * cos)))
-            rot_h = max(1, int(round(ov_h * cos + ov_w * sin)))
-            M[0, 2] += (rot_w / 2.0) - center[0]
-            M[1, 2] += (rot_h / 2.0) - center[1]
-            overlay = cv2.warpAffine(
-                overlay, M, (rot_w, rot_h), flags=cv2.INTER_LINEAR
+            overlay = cv2.resize(
+                overlay, (new_w, new_h), interpolation=cv2.INTER_LINEAR
             )
 
         base_h, base_w = base.shape[:2]

--- a/src/nodes/filters/overlay.py
+++ b/src/nodes/filters/overlay.py
@@ -12,10 +12,12 @@ from core.port import InputPort, OutputPort
 class Overlay(NodeBase):
     """Composite an overlay image onto a base image.
 
-    The overlay input is optionally resized by ``scale`` and then blended
-    onto the base at ``(xpos, ypos)`` with opacity ``alpha``. The output
-    canvas always matches the base image — any part of the (scaled)
-    overlay that falls outside the base is clipped.
+    The overlay input is optionally resized by ``scale``, rotated by
+    ``angle`` degrees (counter-clockwise, around the overlay's centre,
+    with the bounding box expanded so no pixels are lost) and then
+    blended onto the base at ``(xpos, ypos)`` with opacity ``alpha``.
+    The output canvas always matches the base image — any part of the
+    transformed overlay that falls outside the base is clipped.
 
     Type strategy:
       If either input is colour (:data:`IoDataType.IMAGE`), any
@@ -29,6 +31,7 @@ class Overlay(NodeBase):
         super().__init__("Overlay", section="Composit")
 
         self._scale: float = 1.0
+        self._angle: float = 0.0
         self._xpos:  int   = 0
         self._ypos:  int   = 0
         self._alpha: float = 1.0
@@ -46,6 +49,7 @@ class Overlay(NodeBase):
     def params(self) -> list[NodeParam]:
         return [
             NodeParam("scale", NodeParamType.FLOAT, {"default": 1.0}),
+            NodeParam("angle", NodeParamType.FLOAT, {"default": 0.0}),
             NodeParam("xpos",  NodeParamType.INT,   {"default": 0}),
             NodeParam("ypos",  NodeParamType.INT,   {"default": 0}),
             NodeParam("alpha", NodeParamType.FLOAT, {"default": 1.0}),
@@ -63,6 +67,14 @@ class Overlay(NodeBase):
         if v <= 0.0:
             raise ValueError(f"scale must be > 0 (got {v})")
         self._scale = v
+
+    @property
+    def angle(self) -> float:
+        return self._angle
+
+    @angle.setter
+    def angle(self, value: float) -> None:
+        self._angle = float(value)
 
     @property
     def xpos(self) -> int:
@@ -115,6 +127,22 @@ class Overlay(NodeBase):
             new_w = max(1, int(round(ov_w * self._scale)))
             new_h = max(1, int(round(ov_h * self._scale)))
             overlay = cv2.resize(overlay, (new_w, new_h), interpolation=cv2.INTER_LINEAR)
+
+        if self._angle % 360.0 != 0.0:
+            ov_h, ov_w = overlay.shape[:2]
+            center = (ov_w / 2.0, ov_h / 2.0)
+            M = cv2.getRotationMatrix2D(center, self._angle, 1.0)
+            # Expand the bounding box so the rotated image fits without
+            # being cropped, and shift the rotation matrix accordingly.
+            cos = abs(M[0, 0])
+            sin = abs(M[0, 1])
+            rot_w = max(1, int(round(ov_h * sin + ov_w * cos)))
+            rot_h = max(1, int(round(ov_h * cos + ov_w * sin)))
+            M[0, 2] += (rot_w / 2.0) - center[0]
+            M[1, 2] += (rot_h / 2.0) - center[1]
+            overlay = cv2.warpAffine(
+                overlay, M, (rot_w, rot_h), flags=cv2.INTER_LINEAR
+            )
 
         base_h, base_w = base.shape[:2]
         ov_h,   ov_w   = overlay.shape[:2]

--- a/src/nodes/filters/overlay.py
+++ b/src/nodes/filters/overlay.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+import cv2
+import numpy as np
+from typing_extensions import override
+
+from core.io_data import IMAGE_TYPES, IoData, IoDataType
+from core.node_base import NodeBase, NodeParam, NodeParamType
+from core.port import InputPort, OutputPort
+
+
+class Overlay(NodeBase):
+    """Composite an overlay image onto a base image.
+
+    The overlay input is optionally resized by ``scale`` and then blended
+    onto the base at ``(xpos, ypos)`` with opacity ``alpha``. The output
+    canvas always matches the base image — any part of the (scaled)
+    overlay that falls outside the base is clipped.
+
+    Type strategy:
+      If either input is colour (:data:`IoDataType.IMAGE`), any
+      greyscale input is promoted to BGR via
+      ``cv2.cvtColor(..., COLOR_GRAY2BGR)`` and the output is emitted
+      as ``IMAGE``. If both inputs are greyscale, the output stays
+      greyscale.
+    """
+
+    def __init__(self) -> None:
+        super().__init__("Overlay", section="Composit")
+
+        self._scale: float = 1.0
+        self._xpos:  int   = 0
+        self._ypos:  int   = 0
+        self._alpha: float = 1.0
+
+        self._add_input(InputPort("image", set(IMAGE_TYPES)))
+        self._add_input(InputPort("overlay", set(IMAGE_TYPES)))
+        self._add_output(OutputPort("image", set(IMAGE_TYPES)))
+
+        self._apply_default_params()
+
+    # ── Parameters ─────────────────────────────────────────────────────────────
+
+    @property
+    @override
+    def params(self) -> list[NodeParam]:
+        return [
+            NodeParam("scale", NodeParamType.FLOAT, {"default": 1.0}),
+            NodeParam("xpos",  NodeParamType.INT,   {"default": 0}),
+            NodeParam("ypos",  NodeParamType.INT,   {"default": 0}),
+            NodeParam("alpha", NodeParamType.FLOAT, {"default": 1.0}),
+        ]
+
+    # ── Properties ─────────────────────────────────────────────────────────────
+
+    @property
+    def scale(self) -> float:
+        return self._scale
+
+    @scale.setter
+    def scale(self, value: float) -> None:
+        v = float(value)
+        if v <= 0.0:
+            raise ValueError(f"scale must be > 0 (got {v})")
+        self._scale = v
+
+    @property
+    def xpos(self) -> int:
+        return self._xpos
+
+    @xpos.setter
+    def xpos(self, value: int) -> None:
+        self._xpos = int(value)
+
+    @property
+    def ypos(self) -> int:
+        return self._ypos
+
+    @ypos.setter
+    def ypos(self, value: int) -> None:
+        self._ypos = int(value)
+
+    @property
+    def alpha(self) -> float:
+        return self._alpha
+
+    @alpha.setter
+    def alpha(self, value: float) -> None:
+        v = float(value)
+        # Clamp to [0, 1] so cv2.addWeighted stays well-defined.
+        self._alpha = max(0.0, min(1.0, v))
+
+    # ── NodeBase interface ─────────────────────────────────────────────────────
+
+    @override
+    def process_impl(self) -> None:
+        base_data    = self.inputs[0].data
+        overlay_data = self.inputs[1].data
+
+        any_color = (
+            base_data.type == IoDataType.IMAGE
+            or overlay_data.type == IoDataType.IMAGE
+        )
+
+        def to_canvas(d: IoData) -> np.ndarray:
+            if any_color and d.type == IoDataType.IMAGE_GREY:
+                return cv2.cvtColor(d.image, cv2.COLOR_GRAY2BGR)
+            return d.image
+
+        base    = to_canvas(base_data).copy()
+        overlay = to_canvas(overlay_data)
+
+        if self._scale != 1.0:
+            ov_h, ov_w = overlay.shape[:2]
+            new_w = max(1, int(round(ov_w * self._scale)))
+            new_h = max(1, int(round(ov_h * self._scale)))
+            overlay = cv2.resize(overlay, (new_w, new_h), interpolation=cv2.INTER_LINEAR)
+
+        base_h, base_w = base.shape[:2]
+        ov_h,   ov_w   = overlay.shape[:2]
+
+        # Destination rectangle on the base, clipped to the base bounds.
+        x0 = max(self._xpos, 0)
+        y0 = max(self._ypos, 0)
+        x1 = min(self._xpos + ov_w, base_w)
+        y1 = min(self._ypos + ov_h, base_h)
+
+        if x0 < x1 and y0 < y1:
+            # Matching rectangle inside the overlay (accounts for negative
+            # xpos/ypos shifting the overlay off the top-left edge).
+            ox0 = x0 - self._xpos
+            oy0 = y0 - self._ypos
+            ox1 = ox0 + (x1 - x0)
+            oy1 = oy0 + (y1 - y0)
+
+            roi     = base[y0:y1, x0:x1]
+            ov_crop = overlay[oy0:oy1, ox0:ox1]
+
+            blended = cv2.addWeighted(ov_crop, self._alpha, roi, 1.0 - self._alpha, 0.0)
+            base[y0:y1, x0:x1] = blended
+
+        if any_color:
+            self.outputs[0].send(IoData.from_image(base))
+        else:
+            self.outputs[0].send(IoData.from_greyscale(base))

--- a/src/nodes/sources/image_source.py
+++ b/src/nodes/sources/image_source.py
@@ -12,7 +12,7 @@ from core.io_data import IoData, IoDataType
 from core.node_base import SourceNodeBase, NodeParam, NodeParamType
 from core.port import OutputPort
 
-_SUPPORTED_EXTS = {".jpg", ".jpeg", ".png", ".cr2"}
+_SUPPORTED_EXTS = {".jpg", ".jpeg", ".png", ".webp", ".cr2"}
 
 
 class ImageSource(SourceNodeBase):
@@ -46,7 +46,14 @@ class ImageSource(SourceNodeBase):
     @override
     def params(self) -> list[NodeParam]:
         return [
-            NodeParam("file_path", NodeParamType.FILE_PATH, {"default": "example.jpg", "filter": "Images (*.webp, *.png *.jpg *.jpeg *.cr2)", "base_dir": INPUT_DIR}),
+            NodeParam(
+                "file_path", 
+                NodeParamType.FILE_PATH, 
+                {
+                    "default": "example.jpg", 
+                    "filter": "Images (*.webp, *.png *.jpg *.jpeg *.cr2)", 
+                    "base_dir": INPUT_DIR
+                }),
         ]
 
     @property

--- a/src/nodes/sources/image_source.py
+++ b/src/nodes/sources/image_source.py
@@ -18,7 +18,7 @@ _SUPPORTED_EXTS = {".jpg", ".jpeg", ".png", ".webp", ".cr2"}
 class ImageSource(SourceNodeBase):
     """Source node that reads a single still image from disk.
 
-    Supported formats: JPEG, PNG, CR2 (RAW).
+    Supported formats: JPEG, PNG, WebP, CR2 (RAW).
 
     Paths inside the application's :data:`INPUT_DIR` are stored — and
     therefore displayed — relative to that folder. Anything outside is kept
@@ -51,7 +51,7 @@ class ImageSource(SourceNodeBase):
                 NodeParamType.FILE_PATH, 
                 {
                     "default": "example.jpg", 
-                    "filter": "Images (*.webp, *.png *.jpg *.jpeg *.cr2)", 
+                    "filter": "Images (*.webp *.png *.jpg *.jpeg *.cr2)",
                     "base_dir": INPUT_DIR
                 }),
         ]

--- a/tests/test_overlay.py
+++ b/tests/test_overlay.py
@@ -274,6 +274,57 @@ def test_overlay_angle_and_scale_combine_into_single_warp() -> None:
     assert footprint_nonzero >= 20  # out of 6x4 = 24 pixels
 
 
+def test_overlay_zero_alpha_skips_warp(monkeypatch) -> None:
+    """With alpha=0 the overlay is invisible — warpAffine must not run."""
+    import cv2 as _cv2
+    calls = {"warp": 0, "resize": 0}
+    monkeypatch.setattr(_cv2, "warpAffine",
+                        lambda *a, **kw: (_ for _ in ()).throw(AssertionError("warpAffine called")))
+    monkeypatch.setattr(_cv2, "resize",
+                        lambda *a, **kw: (_ for _ in ()).throw(AssertionError("resize called")))
+
+    node = Overlay()
+    node.alpha = 0.0
+    node.scale = 2.5
+    node.angle = 37.0  # would normally force a warpAffine
+    base = _bgr(8, 8, 42)
+    _wire(
+        node,
+        IoData.from_image(base),
+        IoData.from_image(_bgr(3, 3, 255)),
+    )
+
+    out = node.outputs[0].last_emitted
+    assert out is not None
+    np.testing.assert_array_equal(out.image, base)
+
+
+def test_overlay_fully_outside_base_skips_warp(monkeypatch) -> None:
+    """Overlay positioned off-canvas must not trigger the warp pipeline."""
+    import cv2 as _cv2
+    monkeypatch.setattr(_cv2, "warpAffine",
+                        lambda *a, **kw: (_ for _ in ()).throw(AssertionError("warpAffine called")))
+    monkeypatch.setattr(_cv2, "resize",
+                        lambda *a, **kw: (_ for _ in ()).throw(AssertionError("resize called")))
+
+    node = Overlay()
+    node.alpha = 1.0
+    node.scale = 2.0
+    node.angle = 45.0
+    node.xpos = 500  # far outside the 10x10 base
+    node.ypos = 500
+    base = _bgr(10, 10, 99)
+    _wire(
+        node,
+        IoData.from_image(base),
+        IoData.from_image(_bgr(4, 4, 255)),
+    )
+
+    out = node.outputs[0].last_emitted
+    assert out is not None
+    np.testing.assert_array_equal(out.image, base)
+
+
 def test_overlay_defaults_match_declared_params() -> None:
     node = Overlay()
     assert node.scale == 1.0

--- a/tests/test_overlay.py
+++ b/tests/test_overlay.py
@@ -195,9 +195,64 @@ def test_overlay_does_not_mutate_base_input() -> None:
     np.testing.assert_array_equal(base_img, _bgr(4, 4, 50))
 
 
+def test_overlay_angle_zero_is_no_op() -> None:
+    node = Overlay()
+    node.alpha = 1.0
+    node.angle = 0.0
+    _wire(
+        node,
+        IoData.from_image(_bgr(8, 8, 0)),
+        IoData.from_image(_bgr(3, 3, 200)),
+    )
+
+    out = node.outputs[0].last_emitted
+    assert out is not None
+    # With no rotation the overlay is placed as a plain 3x3 block.
+    np.testing.assert_array_equal(out.image[0:3, 0:3], _bgr(3, 3, 200))
+
+
+def test_overlay_angle_90_swaps_bounding_box_dimensions() -> None:
+    node = Overlay()
+    node.alpha = 1.0
+    node.angle = 90.0
+    # Non-square overlay so the rotation is observable in the output shape.
+    base = _bgr(20, 20, 0)
+    overlay = _bgr(2, 6, 255)  # 2 rows, 6 cols
+    _wire(node, IoData.from_image(base), IoData.from_image(overlay))
+
+    out = node.outputs[0].last_emitted
+    assert out is not None
+    # A 90° rotation maps a 2x6 block to a 6x2 footprint on the base —
+    # the rotated overlay occupies rows 0..6, cols 0..2 with interpolation
+    # artifacts on the outer edges. We only check that *most* of that
+    # region is non-black and that pixels fully outside it are still black.
+    footprint_nonzero = (out.image[0:6, 0:2] > 0).any(axis=2).sum()
+    assert footprint_nonzero >= 10  # out of a 6x2 = 12-pixel region
+    # Pixels strictly outside the rotated bounding box stay black.
+    assert out.image[0:6, 2:20].sum() == 0
+    assert out.image[6:20, 0:20].sum() == 0
+
+
+def test_overlay_angle_360_matches_angle_zero() -> None:
+    node = Overlay()
+    node.alpha = 1.0
+    node.angle = 360.0
+    _wire(
+        node,
+        IoData.from_image(_bgr(8, 8, 0)),
+        IoData.from_image(_bgr(3, 3, 200)),
+    )
+
+    out = node.outputs[0].last_emitted
+    assert out is not None
+    # 360° rotation is treated as identity (skips the warp entirely).
+    np.testing.assert_array_equal(out.image[0:3, 0:3], _bgr(3, 3, 200))
+
+
 def test_overlay_defaults_match_declared_params() -> None:
     node = Overlay()
     assert node.scale == 1.0
+    assert node.angle == 0.0
     assert node.xpos == 0
     assert node.ypos == 0
     assert node.alpha == 1.0

--- a/tests/test_overlay.py
+++ b/tests/test_overlay.py
@@ -249,6 +249,31 @@ def test_overlay_angle_360_matches_angle_zero() -> None:
     np.testing.assert_array_equal(out.image[0:3, 0:3], _bgr(3, 3, 200))
 
 
+def test_overlay_angle_and_scale_combine_into_single_warp() -> None:
+    node = Overlay()
+    node.alpha = 1.0
+    node.angle = 90.0
+    node.scale = 2.0
+    # 2x3 overlay, rotated 90° and scaled 2x, should land as a 6x4
+    # bounding box on the base (height 2*3 = 6 rows, width 2*2 = 4 cols).
+    _wire(
+        node,
+        IoData.from_image(_bgr(20, 20, 0)),
+        IoData.from_image(_bgr(2, 3, 255)),
+    )
+
+    out = node.outputs[0].last_emitted
+    assert out is not None
+    # Expected footprint is 6x4 starting at (0, 0); everything outside
+    # it must remain black.
+    assert out.image[0:6, 4:20].sum() == 0
+    assert out.image[6:20, 0:20].sum() == 0
+    # Most pixels inside the bounding box are non-black (edge pixels may
+    # be partially blended with the BORDER_CONSTANT=0 background).
+    footprint_nonzero = (out.image[0:6, 0:4] > 0).any(axis=2).sum()
+    assert footprint_nonzero >= 20  # out of 6x4 = 24 pixels
+
+
 def test_overlay_defaults_match_declared_params() -> None:
     node = Overlay()
     assert node.scale == 1.0

--- a/tests/test_overlay.py
+++ b/tests/test_overlay.py
@@ -1,0 +1,220 @@
+"""Unit tests for the Overlay (composite with alpha) node."""
+from __future__ import annotations
+
+import numpy as np
+
+from core.io_data import IoData, IoDataType
+from core.port import OutputPort
+from nodes.filters.overlay import Overlay
+
+
+def _bgr(h: int, w: int, value: int) -> np.ndarray:
+    return np.full((h, w, 3), value, dtype=np.uint8)
+
+
+def _grey(h: int, w: int, value: int) -> np.ndarray:
+    return np.full((h, w), value, dtype=np.uint8)
+
+
+def _wire(node: Overlay, base: IoData, overlay: IoData) -> None:
+    """Connect upstreams for both inputs, then push data into each."""
+    up_base = OutputPort("base", {base.type})
+    up_ov   = OutputPort("overlay", {overlay.type})
+    up_base.connect(node.inputs[0])
+    up_ov.connect(node.inputs[1])
+    up_base.send(base)
+    up_ov.send(overlay)
+
+
+def test_overlay_full_alpha_replaces_pixels_in_roi() -> None:
+    node = Overlay()
+    node.alpha = 1.0
+    node.xpos = 2
+    node.ypos = 3
+    node.scale = 1.0
+    _wire(
+        node,
+        IoData.from_image(_bgr(10, 10, 50)),
+        IoData.from_image(_bgr(4, 5, 200)),
+    )
+
+    out = node.outputs[0].last_emitted
+    assert out is not None
+    assert out.type == IoDataType.IMAGE
+    assert out.image.shape == (10, 10, 3)
+    # ROI at (y=3..7, x=2..7) is fully replaced by overlay.
+    np.testing.assert_array_equal(out.image[3:7, 2:7], _bgr(4, 5, 200))
+    # A pixel outside the ROI keeps the base value.
+    assert out.image[0, 0, 0] == 50
+
+
+def test_overlay_zero_alpha_keeps_base() -> None:
+    node = Overlay()
+    node.alpha = 0.0
+    _wire(
+        node,
+        IoData.from_image(_bgr(6, 6, 80)),
+        IoData.from_image(_bgr(3, 3, 255)),
+    )
+
+    out = node.outputs[0].last_emitted
+    assert out is not None
+    np.testing.assert_array_equal(out.image, _bgr(6, 6, 80))
+
+
+def test_overlay_half_alpha_blends_50_50() -> None:
+    node = Overlay()
+    node.alpha = 0.5
+    node.xpos = 0
+    node.ypos = 0
+    _wire(
+        node,
+        IoData.from_image(_bgr(4, 4, 100)),
+        IoData.from_image(_bgr(4, 4, 200)),
+    )
+
+    out = node.outputs[0].last_emitted
+    assert out is not None
+    # 0.5*200 + 0.5*100 = 150.
+    assert out.image[0, 0, 0] == 150
+
+
+def test_overlay_scale_resizes_overlay_before_compositing() -> None:
+    node = Overlay()
+    node.scale = 2.0
+    node.alpha = 1.0
+    _wire(
+        node,
+        IoData.from_image(_bgr(10, 10, 0)),
+        IoData.from_image(_bgr(2, 2, 255)),
+    )
+
+    out = node.outputs[0].last_emitted
+    assert out is not None
+    # Overlay was 2x2, scale=2 -> 4x4 drawn at (0,0).
+    np.testing.assert_array_equal(out.image[0:4, 0:4], _bgr(4, 4, 255))
+    # Rest of the canvas untouched.
+    assert out.image[5:, 5:].sum() == 0
+
+
+def test_overlay_clips_when_partially_outside_base() -> None:
+    node = Overlay()
+    node.alpha = 1.0
+    node.xpos = 8
+    node.ypos = 8
+    _wire(
+        node,
+        IoData.from_image(_bgr(10, 10, 0)),
+        IoData.from_image(_bgr(4, 4, 255)),
+    )
+
+    out = node.outputs[0].last_emitted
+    assert out is not None
+    # Only the 2x2 top-left corner of the overlay lands on the base.
+    np.testing.assert_array_equal(out.image[8:10, 8:10], _bgr(2, 2, 255))
+
+
+def test_overlay_negative_position_clips_top_left() -> None:
+    node = Overlay()
+    node.alpha = 1.0
+    node.xpos = -2
+    node.ypos = -3
+    _wire(
+        node,
+        IoData.from_image(_bgr(10, 10, 0)),
+        IoData.from_image(_bgr(6, 6, 255)),
+    )
+
+    out = node.outputs[0].last_emitted
+    assert out is not None
+    # Visible chunk: overlay rows 3..6, cols 2..6 land at base (0..3, 0..4).
+    np.testing.assert_array_equal(out.image[0:3, 0:4], _bgr(3, 4, 255))
+
+
+def test_overlay_fully_outside_base_is_noop() -> None:
+    node = Overlay()
+    node.alpha = 1.0
+    node.xpos = 100
+    node.ypos = 100
+    base = _bgr(10, 10, 42)
+    _wire(
+        node,
+        IoData.from_image(base.copy()),
+        IoData.from_image(_bgr(4, 4, 255)),
+    )
+
+    out = node.outputs[0].last_emitted
+    assert out is not None
+    np.testing.assert_array_equal(out.image, base)
+
+
+def test_overlay_greyscale_base_and_overlay_stays_greyscale() -> None:
+    node = Overlay()
+    node.alpha = 1.0
+    _wire(
+        node,
+        IoData.from_greyscale(_grey(5, 5, 20)),
+        IoData.from_greyscale(_grey(2, 2, 200)),
+    )
+
+    out = node.outputs[0].last_emitted
+    assert out is not None
+    assert out.type == IoDataType.IMAGE_GREY
+    assert out.image.shape == (5, 5)
+    assert out.image[0, 0] == 200
+    assert out.image[4, 4] == 20
+
+
+def test_overlay_mixed_types_promotes_output_to_color() -> None:
+    node = Overlay()
+    node.alpha = 1.0
+    _wire(
+        node,
+        IoData.from_image(_bgr(4, 4, 10)),
+        IoData.from_greyscale(_grey(2, 2, 99)),
+    )
+
+    out = node.outputs[0].last_emitted
+    assert out is not None
+    assert out.type == IoDataType.IMAGE
+    # Greyscale overlay is promoted to BGR, so every channel reads 99.
+    np.testing.assert_array_equal(out.image[0:2, 0:2], _bgr(2, 2, 99))
+
+
+def test_overlay_does_not_mutate_base_input() -> None:
+    node = Overlay()
+    node.alpha = 1.0
+    base_img = _bgr(4, 4, 50)
+    _wire(
+        node,
+        IoData.from_image(base_img),
+        IoData.from_image(_bgr(2, 2, 200)),
+    )
+
+    # Input image object must be left intact for downstream consumers.
+    np.testing.assert_array_equal(base_img, _bgr(4, 4, 50))
+
+
+def test_overlay_defaults_match_declared_params() -> None:
+    node = Overlay()
+    assert node.scale == 1.0
+    assert node.xpos == 0
+    assert node.ypos == 0
+    assert node.alpha == 1.0
+
+
+def test_overlay_alpha_is_clamped_to_unit_interval() -> None:
+    node = Overlay()
+    node.alpha = 2.5
+    assert node.alpha == 1.0
+    node.alpha = -0.3
+    assert node.alpha == 0.0
+
+
+def test_overlay_rejects_non_positive_scale() -> None:
+    node = Overlay()
+    import pytest
+    with pytest.raises(ValueError):
+        node.scale = 0.0
+    with pytest.raises(ValueError):
+        node.scale = -1.0


### PR DESCRIPTION
## Summary
Introduces a new **Overlay** node that composites an overlay image onto a base image with support for scaling, rotation, positioning, and alpha blending.

## Key Changes
- **New Overlay node** (`src/nodes/filters/overlay.py`):
  - Composites overlay onto base image at specified `(xpos, ypos)` position
  - Supports `scale` factor to resize overlay before compositing
  - Supports `angle` parameter for counter-clockwise rotation (with expanded bounding box to prevent pixel loss)
  - Supports `alpha` parameter for opacity control (0.0–1.0, clamped)
  - Automatically clips overlay regions that fall outside base image bounds
  - Type promotion: greyscale inputs are promoted to BGR if either input is colour; otherwise output stays greyscale
  - Preserves input base image (creates a copy before modification)

- **Comprehensive test suite** (`tests/test_overlay.py`):
  - 18 unit tests covering core functionality: alpha blending, scaling, rotation, clipping, type handling, parameter validation, and edge cases
  - Tests verify correct ROI replacement, 50/50 blending at 0.5 alpha, rotation dimension swaps, negative positioning, out-of-bounds handling, and parameter clamping

- **Version and documentation updates**:
  - Bumped version to 0.1.13
  - Added CHANGELOG entry describing the new node and its features

## Notable Implementation Details
- Uses `cv2.addWeighted()` for alpha blending
- Rotation uses `cv2.getRotationMatrix2D()` with bounding box expansion to preserve all pixels
- Clipping logic handles both positive and negative overlay positions
- Parameter validation: `scale` must be > 0; `alpha` is clamped to [0, 1]
- Node placed in "Composit" palette section

https://claude.ai/code/session_01CaqjrGEfXT1zmDoUFXiGsy