### PR TITLE
Add unsaved-changes indicator + Python version to status widget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,26 @@ once a first tagged release is cut.
 
 ## [Unreleased]
 
+## [0.1.15] — 2026-04-24
+
+### Added
+- **Unsaved-changes indicator** in the Node Editor's toolbar status
+  widget. An amber "● Unsaved changes" row appears the moment the
+  user edits a parameter, adds/removes a node or connection, toggles
+  a node's skip state, or rearranges via V-Stack / H-Stack. The row
+  clears on a successful save and when a flow is loaded or cleared.
+  Implemented via a new `FlowScene.is_dirty` property and
+  `dirty_changed(bool)` signal.
+- **Python runtime version** on the toolbar status widget — a muted
+  `Python X.Y.Z` line below the application version, surfacing which
+  interpreter the running app is bound to.
+
+### Changed
+- Extracted `AppVersionStatusWidget` from `ui.page` into its own
+  module `ui.app_version_status_widget` for symmetry with
+  `FlowStatusWidget`. The editor's idle status view now embeds that
+  widget directly instead of re-implementing the same label stack.
+
 ## [0.1.14] — 2026-04-24
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,11 @@ once a first tagged release is cut.
   interpreter the running app is bound to. The same version plus the
   interpreter's path is logged at startup so bug reports include it
   without having to ask.
+- **Reload** toolbar / menu action in the Node Editor. Re-reads the
+  current flow's file from disk, discarding unsaved edits after a
+  confirmation prompt. Reconstructs the path from `flow.name` the
+  same way Save does; surfaces a status error if the flow has never
+  been saved or the file has been removed.
 
 ### Changed
 - Extracted `AppVersionStatusWidget` from `ui.page` into its own

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,9 @@ once a first tagged release is cut.
   `dirty_changed(bool)` signal.
 - **Python runtime version** on the toolbar status widget — a muted
   `Python X.Y.Z` line below the application version, surfacing which
-  interpreter the running app is bound to.
+  interpreter the running app is bound to. The same version plus the
+  interpreter's path is logged at startup so bug reports include it
+  without having to ask.
 
 ### Changed
 - Extracted `AppVersionStatusWidget` from `ui.page` into its own

--- a/src/constants.py
+++ b/src/constants.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 APP_NAME:         str = "Image-Inquest"
 APP_DISPLAY_NAME: str = "Stjörnhorn"
-APP_VERSION:      str = "0.1.14"
+APP_VERSION:      str = "0.1.15"
 API_URL:    str = "https://beltoforion.de"
 
 # Bundled documentation (offline welcome page, screenshots, …)

--- a/src/main.py
+++ b/src/main.py
@@ -266,6 +266,14 @@ def main(argv: list[str]) -> int:
 
     setup_logging(LOG_DIR)
     logger.info("Starting %s v%s", APP_NAME, APP_VERSION)
+    # Record the interpreter the app is bound to — handy when triaging
+    # bug reports where behaviour depends on the Python version (e.g.
+    # typing.override, tomllib, exception-group stack traces).
+    py = sys.version_info
+    logger.info(
+        "Python %d.%d.%d (%s)",
+        py.major, py.minor, py.micro, sys.executable,
+    )
 
     # Must happen before QApplication so Windows associates our icon with
     # the process's taskbar entry from the very first window.

--- a/src/ui/app_version_status_widget.py
+++ b/src/ui/app_version_status_widget.py
@@ -1,18 +1,27 @@
 from __future__ import annotations
 
+import sys
+
 from PySide6.QtCore import Qt
 from PySide6.QtWidgets import QHBoxLayout, QLabel, QVBoxLayout, QWidget
 
 from constants import APP_DISPLAY_NAME, APP_VERSION
 
 
-class AppVersionStatusWidget(QWidget):
-    """Default page status widget: app name on top, version beneath.
+def _python_version_label() -> str:
+    """Return the running Python version as ``Python X.Y.Z`` for display."""
+    v = sys.version_info
+    return f"Python {v.major}.{v.minor}.{v.micro}"
 
-    Two stacked right-aligned labels — the app name rendered at a
-    larger size so it reads as the primary label, and the version
-    muted underneath. The pair is vertically centred in the widget so
-    it looks balanced next to the toolbar's 72 px action buttons.
+
+class AppVersionStatusWidget(QWidget):
+    """Default page status widget: app name on top, version + runtime beneath.
+
+    Three stacked right-aligned labels — the app name rendered at a
+    larger size so it reads as the primary label, the application
+    version muted beneath, and the active Python runtime muted below
+    that. The triplet is vertically centred in the widget so it looks
+    balanced next to the toolbar's 72 px action buttons.
 
     Kept as a small standalone class so every page can instantiate its
     own — two pages must not share the same QWidget instance, because
@@ -38,7 +47,12 @@ class AppVersionStatusWidget(QWidget):
         version.setAlignment(Qt.AlignmentFlag.AlignRight | Qt.AlignmentFlag.AlignVCenter)
         version.setProperty("muted", True)
 
+        python = QLabel(_python_version_label())
+        python.setAlignment(Qt.AlignmentFlag.AlignRight | Qt.AlignmentFlag.AlignVCenter)
+        python.setProperty("muted", True)
+
         column.addWidget(name)
         column.addWidget(version)
+        column.addWidget(python)
         column.addStretch(1)
         outer.addLayout(column)

--- a/src/ui/flow_scene.py
+++ b/src/ui/flow_scene.py
@@ -50,6 +50,9 @@ class FlowScene(QGraphicsScene):
     #: error (e.g. incompatible port types). Carries the exception's message so
     #: the host page can surface it in the error banner.
     connection_error = Signal(str)
+    #: Emitted when the scene's unsaved-changes state transitions. Carries the
+    #: new value of :attr:`is_dirty` so listeners can update UI without polling.
+    dirty_changed = Signal(bool)
 
     def __init__(self) -> None:
         super().__init__()
@@ -59,15 +62,26 @@ class FlowScene(QGraphicsScene):
         self._pending_link: PendingLinkItem | None = None
         self._pending_src_port: PortItem | None = None
         self._last_emitted_selected: NodeBase | None = None
+        self._dirty: bool = False
 
         self.selectionChanged.connect(self._on_selection_changed)
+        # Every param-widget edit is an unsaved change. Structural edits
+        # (add/remove node, add/remove link, layout stack, flow rename)
+        # call _mark_dirty directly from the method that performs them.
+        self.param_changed.connect(self._mark_dirty)
 
     # ── Flow binding ───────────────────────────────────────────────────────────
 
     def set_flow(self, flow: Flow) -> None:
-        """Replace the current flow and wipe the canvas."""
+        """Replace the current flow and wipe the canvas.
+
+        A freshly-set flow starts clean: whatever the caller just loaded
+        (or created) is, by definition, "saved" — any subsequent edit
+        will flip the scene back to dirty.
+        """
         self.clear_scene()
         self._flow = flow
+        self._set_dirty(False)
 
     @property
     def flow(self) -> Flow | None:
@@ -97,6 +111,7 @@ class FlowScene(QGraphicsScene):
         self._node_items[id(node)] = item
         if self._flow is not None:
             self._flow.add_node(node)
+        self._mark_dirty()
         return item
 
     def instantiate_and_add(self, entry: NodeEntry, scene_pos: QPointF | None = None) -> NodeItem | None:
@@ -143,6 +158,7 @@ class FlowScene(QGraphicsScene):
             item.setPos(x, y)
             item.refresh_all_links()
             y += item.boundingRect().height() + self.STACK_GAP
+        self._mark_dirty()
         return len(items)
 
     def stack_selected_horizontally(self) -> int:
@@ -166,6 +182,7 @@ class FlowScene(QGraphicsScene):
             item.setPos(x, y)
             item.refresh_all_links()
             x += item.boundingRect().width() + self.STACK_GAP
+        self._mark_dirty()
         return len(items)
 
     def _delete_node_item(self, item: NodeItem) -> None:
@@ -176,6 +193,7 @@ class FlowScene(QGraphicsScene):
                 pass
         self._node_items.pop(id(item.node), None)
         self.removeItem(item)
+        self._mark_dirty()
 
     # ── Link operations ────────────────────────────────────────────────────────
 
@@ -205,6 +223,7 @@ class FlowScene(QGraphicsScene):
         link = LinkItem(src, dst)
         self.addItem(link)
         self._links.append(link)
+        self._mark_dirty()
         return link
 
     def _delete_link_item(self, link: LinkItem) -> None:
@@ -220,6 +239,7 @@ class FlowScene(QGraphicsScene):
         if link in self._links:
             self._links.remove(link)
         self.removeItem(link)
+        self._mark_dirty()
 
     # ── Pending-link drag ──────────────────────────────────────────────────────
 
@@ -319,6 +339,36 @@ class FlowScene(QGraphicsScene):
 
     def iter_links(self) -> list[LinkItem]:
         return list(self._links)
+
+    # ── Dirty tracking ─────────────────────────────────────────────────────────
+
+    @property
+    def is_dirty(self) -> bool:
+        """True if the scene has been modified since the last save/load."""
+        return self._dirty
+
+    def mark_saved(self) -> None:
+        """Reset the dirty flag. Called by the editor after a successful save."""
+        self._set_dirty(False)
+
+    def mark_dirty(self) -> None:
+        """Flag the scene as modified.
+
+        Exposed for edits the scene can't observe on its own — most
+        notably renaming the underlying :class:`Flow` from the host
+        page. Structural edits performed via scene methods already
+        call this internally.
+        """
+        self._mark_dirty()
+
+    def _mark_dirty(self) -> None:
+        self._set_dirty(True)
+
+    def _set_dirty(self, value: bool) -> None:
+        if self._dirty == value:
+            return
+        self._dirty = value
+        self.dirty_changed.emit(value)
 
     # ── Keyboard ───────────────────────────────────────────────────────────────
 

--- a/src/ui/flow_status_widget.py
+++ b/src/ui/flow_status_widget.py
@@ -9,8 +9,9 @@ from PySide6.QtWidgets import (
     QWidget,
 )
 
-from constants import APP_DISPLAY_NAME, APP_VERSION
+from ui.app_version_status_widget import AppVersionStatusWidget
 from ui.spinner import SpinnerWidget
+from ui.theme import STATUS_WARN_COLOR
 
 
 _RUNNING_SPINNER_SIZE = 28
@@ -21,16 +22,19 @@ class FlowStatusWidget(QWidget):
 
     Has two modes selected via :class:`QStackedLayout`:
 
-    * **Idle** — a single ``AppName vX.Y.Z`` label, visually identical
-      to the default :class:`ui.app_version_status_widget.AppVersionStatusWidget`
-      so the toolbar looks the same whether the editor is open or not.
+    * **Idle** — the default :class:`AppVersionStatusWidget` (app name,
+      version and Python runtime), with an amber "● Unsaved changes" row
+      that appears only when the editor has uncommitted edits. So the
+      toolbar looks the same as other pages while the flow is clean,
+      and surfaces unsaved state the moment it arises.
     * **Running** — a spinner on the right; on the left, two stacked
       labels: the flow name in bold on top, the currently-executing
       node name muted beneath.
 
-    The page drives the widget via :meth:`show_idle`, :meth:`show_running`
-    and :meth:`set_current_node`. The widget owns no timers besides its
-    spinner, so leaving it mounted while idle costs effectively nothing.
+    The page drives the widget via :meth:`show_idle`, :meth:`show_running`,
+    :meth:`set_current_node` and :meth:`set_unsaved`. The widget owns no
+    timers besides its spinner, so leaving it mounted while idle costs
+    effectively nothing.
     """
 
     def __init__(self, parent: QWidget | None = None) -> None:
@@ -41,31 +45,32 @@ class FlowStatusWidget(QWidget):
         self._stack.setSpacing(0)
 
         # ── Idle page ──────────────────────────────────────────────────
+        # Reuse AppVersionStatusWidget so the idle view is pixel-identical
+        # to every other page's default status widget; the unsaved row is
+        # tacked on below it and hidden until the editor marks dirty.
         self._idle_page = QWidget()
         idle_layout = QHBoxLayout(self._idle_page)
-        idle_layout.setContentsMargins(8, 0, 8, 0)
+        idle_layout.setContentsMargins(0, 0, 0, 0)
         idle_layout.setSpacing(0)
 
         idle_column = QVBoxLayout()
         idle_column.setContentsMargins(0, 0, 0, 0)
         idle_column.setSpacing(0)
-        idle_column.addStretch(1)
 
-        self._idle_name_label = QLabel(APP_DISPLAY_NAME)
-        self._idle_name_label.setAlignment(
+        self._app_version_widget = AppVersionStatusWidget()
+        idle_column.addWidget(self._app_version_widget)
+
+        self._unsaved_label = QLabel("● Unsaved changes")
+        self._unsaved_label.setAlignment(
             Qt.AlignmentFlag.AlignRight | Qt.AlignmentFlag.AlignVCenter
         )
-        self._idle_name_label.setStyleSheet("font-size: 14pt;")
-
-        self._idle_version_label = QLabel(f"v{APP_VERSION}")
-        self._idle_version_label.setAlignment(
-            Qt.AlignmentFlag.AlignRight | Qt.AlignmentFlag.AlignVCenter
+        self._unsaved_label.setContentsMargins(8, 0, 8, 4)
+        self._unsaved_label.setStyleSheet(
+            f"color: {STATUS_WARN_COLOR.name()};"
         )
-        self._idle_version_label.setProperty("muted", True)
+        self._unsaved_label.hide()
+        idle_column.addWidget(self._unsaved_label)
 
-        idle_column.addWidget(self._idle_name_label)
-        idle_column.addWidget(self._idle_version_label)
-        idle_column.addStretch(1)
         idle_layout.addLayout(idle_column)
         self._stack.addWidget(self._idle_page)
 
@@ -114,7 +119,12 @@ class FlowStatusWidget(QWidget):
     # ── Public API ─────────────────────────────────────────────────────────────
 
     def show_idle(self) -> None:
-        """Switch back to the app-name/version display and stop the spinner."""
+        """Switch back to the app-name/version display and stop the spinner.
+
+        The unsaved-changes row stays in whatever state
+        :meth:`set_unsaved` last put it — leaving a run doesn't clean
+        the flow.
+        """
         self._spinner.stop()
         self._flow_label.clear()
         self._node_label.clear()
@@ -134,3 +144,7 @@ class FlowStatusWidget(QWidget):
     def set_current_node(self, display_name: str) -> None:
         """Update the muted "current node" label shown under the flow name."""
         self._node_label.setText(display_name)
+
+    def set_unsaved(self, unsaved: bool) -> None:
+        """Show or hide the amber "● Unsaved changes" row in idle mode."""
+        self._unsaved_label.setVisible(unsaved)

--- a/src/ui/flow_status_widget.py
+++ b/src/ui/flow_status_widget.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from PySide6.QtCore import Qt
+from PySide6.QtCore import QSize, Qt
 from PySide6.QtWidgets import (
     QHBoxLayout,
     QLabel,
@@ -10,11 +10,13 @@ from PySide6.QtWidgets import (
 )
 
 from ui.app_version_status_widget import AppVersionStatusWidget
+from ui.icons import material_icon
 from ui.spinner import SpinnerWidget
 from ui.theme import STATUS_WARN_COLOR
 
 
 _RUNNING_SPINNER_SIZE = 28
+_UNSAVED_ICON_SIZE = 24
 
 
 class FlowStatusWidget(QWidget):
@@ -22,11 +24,12 @@ class FlowStatusWidget(QWidget):
 
     Has two modes selected via :class:`QStackedLayout`:
 
-    * **Idle** — the default :class:`AppVersionStatusWidget` (app name,
-      version and Python runtime), with an amber "● Unsaved changes" row
-      that appears only when the editor has uncommitted edits. So the
-      toolbar looks the same as other pages while the flow is clean,
-      and surfaces unsaved state the moment it arises.
+    * **Idle** — on the right, the default :class:`AppVersionStatusWidget`
+      (app name, version and Python runtime); on the left, a left-aligned
+      amber warning icon with "Unsaved changes" underneath, shown only
+      when the editor has uncommitted edits. So the toolbar looks the
+      same as other pages while the flow is clean, and surfaces unsaved
+      state the moment it arises.
     * **Running** — a spinner on the right; on the left, two stacked
       labels: the flow name in bold on top, the currently-executing
       node name muted beneath.
@@ -45,33 +48,23 @@ class FlowStatusWidget(QWidget):
         self._stack.setSpacing(0)
 
         # ── Idle page ──────────────────────────────────────────────────
-        # Reuse AppVersionStatusWidget so the idle view is pixel-identical
-        # to every other page's default status widget; the unsaved row is
-        # tacked on below it and hidden until the editor marks dirty.
+        # Two columns: a left-aligned unsaved-changes affordance (hidden
+        # until the editor marks dirty), and the standard right-aligned
+        # AppVersionStatusWidget that every page shows. Reusing the
+        # widget keeps the idle view pixel-identical to other pages.
         self._idle_page = QWidget()
         idle_layout = QHBoxLayout(self._idle_page)
-        idle_layout.setContentsMargins(0, 0, 0, 0)
+        idle_layout.setContentsMargins(8, 0, 0, 0)
         idle_layout.setSpacing(0)
 
-        idle_column = QVBoxLayout()
-        idle_column.setContentsMargins(0, 0, 0, 0)
-        idle_column.setSpacing(0)
-
-        self._app_version_widget = AppVersionStatusWidget()
-        idle_column.addWidget(self._app_version_widget)
-
-        self._unsaved_label = QLabel("● Unsaved changes")
-        self._unsaved_label.setAlignment(
-            Qt.AlignmentFlag.AlignRight | Qt.AlignmentFlag.AlignVCenter
+        self._unsaved_widget = self._build_unsaved_widget()
+        self._unsaved_widget.hide()
+        idle_layout.addWidget(
+            self._unsaved_widget, 0, Qt.AlignmentFlag.AlignVCenter
         )
-        self._unsaved_label.setContentsMargins(8, 0, 8, 4)
-        self._unsaved_label.setStyleSheet(
-            f"color: {STATUS_WARN_COLOR.name()};"
-        )
-        self._unsaved_label.hide()
-        idle_column.addWidget(self._unsaved_label)
+        idle_layout.addStretch(1)
+        idle_layout.addWidget(AppVersionStatusWidget())
 
-        idle_layout.addLayout(idle_column)
         self._stack.addWidget(self._idle_page)
 
         # ── Running page ───────────────────────────────────────────────
@@ -121,7 +114,7 @@ class FlowStatusWidget(QWidget):
     def show_idle(self) -> None:
         """Switch back to the app-name/version display and stop the spinner.
 
-        The unsaved-changes row stays in whatever state
+        The unsaved-changes affordance stays in whatever state
         :meth:`set_unsaved` last put it — leaving a run doesn't clean
         the flow.
         """
@@ -146,5 +139,40 @@ class FlowStatusWidget(QWidget):
         self._node_label.setText(display_name)
 
     def set_unsaved(self, unsaved: bool) -> None:
-        """Show or hide the amber "● Unsaved changes" row in idle mode."""
-        self._unsaved_label.setVisible(unsaved)
+        """Show or hide the left-aligned unsaved-changes icon + caption."""
+        self._unsaved_widget.setVisible(unsaved)
+
+    # ── Internals ──────────────────────────────────────────────────────────────
+
+    def _build_unsaved_widget(self) -> QWidget:
+        """Build the icon-over-caption "Unsaved changes" affordance.
+
+        Standalone helper so __init__ reads as layout wiring rather
+        than pixel math. Centres a 24 px amber warning glyph over a
+        muted amber caption; the column is centred inside whichever
+        height the toolbar hands us.
+        """
+        container = QWidget()
+        column = QVBoxLayout(container)
+        column.setContentsMargins(0, 0, 0, 0)
+        column.setSpacing(2)
+
+        icon = QLabel()
+        icon.setPixmap(
+            material_icon("warning", color=STATUS_WARN_COLOR).pixmap(
+                QSize(_UNSAVED_ICON_SIZE, _UNSAVED_ICON_SIZE)
+            )
+        )
+        icon.setAlignment(Qt.AlignmentFlag.AlignHCenter | Qt.AlignmentFlag.AlignBottom)
+
+        caption = QLabel("Unsaved changes")
+        caption.setAlignment(
+            Qt.AlignmentFlag.AlignHCenter | Qt.AlignmentFlag.AlignTop
+        )
+        caption.setStyleSheet(
+            f"color: {STATUS_WARN_COLOR.name()}; font-size: 9pt;"
+        )
+
+        column.addWidget(icon)
+        column.addWidget(caption)
+        return container

--- a/src/ui/icons.py
+++ b/src/ui/icons.py
@@ -46,6 +46,7 @@ _CODEPOINTS: Final[dict[str, str]] = {
     "view_column": "e8ec",
     "description":  "e873",
     "visibility":   "e8f4",
+    "warning":      "e002",
 }
 
 

--- a/src/ui/icons.py
+++ b/src/ui/icons.py
@@ -47,6 +47,7 @@ _CODEPOINTS: Final[dict[str, str]] = {
     "description":  "e873",
     "visibility":   "e8f4",
     "warning":      "e002",
+    "refresh":      "e5d5",
 }
 
 

--- a/src/ui/node_editor_page.py
+++ b/src/ui/node_editor_page.py
@@ -202,6 +202,7 @@ class NodeEditorPage(PageBase):
                 self._actions["save"],
                 self._actions["save_as"],
                 self._actions["open"],
+                self._actions["reload"],
                 self._actions["clear"],
             ]),
             ToolbarSection("View", [
@@ -229,6 +230,7 @@ class NodeEditorPage(PageBase):
         menu.addAction(self._actions["save"])
         menu.addAction(self._actions["save_as"])
         menu.addAction(self._actions["open"])
+        menu.addAction(self._actions["reload"])
         menu.addSeparator()
         menu.addAction(self._actions["clear"])
         menu.addSeparator()
@@ -330,6 +332,7 @@ class NodeEditorPage(PageBase):
             "save":    mk("Save",     "save",        self._on_save_clicked),
             "save_as": mk("Save As…", "save_as",     self._on_save_as_clicked),
             "open":    mk("Open",     "folder_open", self._on_open_clicked),
+            "reload":  mk("Reload",   "refresh",     self._on_reload_clicked),
             "clear":   mk("Clear",    "delete",      self._on_clear_clicked),
             "fit":     mk("Fit",      "zoom_out_map",    self._view.fit_to_contents),
             "reset_zoom": mk("1:1", "fullscreen_exit", self._view.reset_zoom),
@@ -598,6 +601,37 @@ class NodeEditorPage(PageBase):
         )
         if path_str:
             self.load_flow(Path(path_str))
+
+    def _on_reload_clicked(self) -> None:
+        """Re-read the current flow from disk, discarding unsaved edits.
+
+        Path is reconstructed from ``flow.name`` the same way ``Save``
+        does, so Reload is only meaningful for flows that actually live
+        in :data:`FLOW_DIR`. A flow that has never been saved (still
+        ``Untitled_flow``) or whose file has been removed gets a clear
+        error in the status line instead of silently wiping the canvas.
+        """
+        if self._flow is None:
+            self._set_status("No flow to reload", kind="fail")
+            return
+        path = FLOW_DIR / f"{self._flow.name}{_FLOW_FILE_EXTENSION}"
+        if not path.is_file():
+            self._set_status(
+                f"No saved file to reload at {_display_path(path)}",
+                kind="fail",
+            )
+            return
+        # Only nag when there's something to lose. A clean canvas can
+        # reload silently — the button doubles as a cheap "refresh from
+        # disk" when the file was edited externally.
+        if self._scene.is_dirty and QMessageBox.question(
+            self, "Discard unsaved changes?",
+            f"Reload {path.name} from disk? Unsaved edits will be lost.",
+            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+            QMessageBox.StandardButton.No,
+        ) != QMessageBox.StandardButton.Yes:
+            return
+        self.load_flow(path)
 
     def _on_clear_clicked(self) -> None:
         if self._flow is None:

--- a/src/ui/node_editor_page.py
+++ b/src/ui/node_editor_page.py
@@ -161,6 +161,10 @@ class NodeEditorPage(PageBase):
         # Surface interactive-connection errors (type mismatches) in the
         # error banner instead of swallowing them inside FlowScene.
         self._scene.connection_error.connect(self._on_connection_error)
+        # Propagate the scene's unsaved-changes state into the toolbar
+        # status widget so the user sees "● Unsaved changes" the moment
+        # an edit happens, and the row clears on load/save.
+        self._scene.dirty_changed.connect(self._flow_status_widget.set_unsaved)
 
         # Debounce timer for reactive (auto-run) flows.  A 300 ms single-shot
         # timer is restarted on every param change; it fires _on_run_clicked
@@ -278,16 +282,21 @@ class NodeEditorPage(PageBase):
     def load_flow(self, path: Path) -> bool:
         """Load a flow from disk. Returns True on success, False on failure
         (status line shows the reason)."""
-        
+
         try:
             flow = load_flow_into(path, self._scene)
         except FlowIoError as err:
             logger.warning(f"Failed to load flow from {path}: {err}")
             self._set_status(f"Open failed ({err})", kind="fail")
             return False
-        
+
         self._flow = flow
         self._viewer.show_node(None)
+        # load_flow_into calls set_flow (clears dirty) but then every
+        # node/link it re-creates goes through add_node / connect_ports,
+        # which flip dirty back on. Reset once the rebuild is done so
+        # a freshly-loaded flow starts clean.
+        self._scene.mark_saved()
         self.title_changed.emit(self.page_title())
         
         # Fit the freshly-loaded graph into the view. Deferred so it runs
@@ -533,6 +542,7 @@ class NodeEditorPage(PageBase):
             detail = err.strerror or str(err) or err.__class__.__name__
             self._set_status(f"Save failed: {detail}", kind="fail")
             return
+        self._scene.mark_saved()
         self._set_status(
             f"Saved to {_display_path(path)} at {datetime.now().strftime('%H:%M:%S')}",
             kind="ok",
@@ -572,6 +582,7 @@ class NodeEditorPage(PageBase):
             detail = err.strerror or str(err) or err.__class__.__name__
             self._set_status(f"Save failed: {detail}", kind="fail")
             return
+        self._scene.mark_saved()
         self.title_changed.emit(self.page_title())
         self._set_status(
             f"Saved to {_display_path(path)} at {datetime.now().strftime('%H:%M:%S')}",

--- a/src/ui/node_item.py
+++ b/src/ui/node_item.py
@@ -534,6 +534,10 @@ class NodeItem(QGraphicsItem):
         if self._skip_button is not None:
             self._skip_button.update()
         self.update()
+        # Skip-state flips behave like param edits from the user's
+        # perspective (they change what the flow does on the next run),
+        # so piggy-back on param_changed to drive auto-run + dirty.
+        self._signals.param_changed.emit()
 
     def _header_path(self) -> QPainterPath:
         """Path for the header: top corners rounded, bottom corners square."""

--- a/src/ui/theme.py
+++ b/src/ui/theme.py
@@ -36,6 +36,9 @@ CANVAS_GRID_COLOR         = QColor(56, 56, 60)
 STATUS_OK_COLOR    = QColor( 90, 200, 100)
 STATUS_FAIL_COLOR  = QColor(220,  80,  80)
 STATUS_MUTED_COLOR = QColor(140, 140, 140)
+#: Amber used for transient "attention, but not an error" affordances —
+#: e.g. the unsaved-changes dot in the editor status widget.
+STATUS_WARN_COLOR  = QColor(230, 170,  50)
 
 
 _DARK_QSS = """

--- a/tests/test_flow_scene_dirty.py
+++ b/tests/test_flow_scene_dirty.py
@@ -1,0 +1,121 @@
+"""Unit tests for FlowScene's dirty-tracking state.
+
+The editor's "● Unsaved changes" affordance is driven by
+:attr:`FlowScene.is_dirty` + :attr:`FlowScene.dirty_changed`. These
+tests lock down the transitions: a fresh scene is clean, every
+structural or parameter edit flips it to dirty, and only
+:meth:`mark_saved` / :meth:`set_flow` clear it.
+"""
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+# Headless Qt: must be set before PySide6 is imported anywhere.
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+pytest.importorskip("PySide6")
+
+from PySide6.QtCore import QPointF
+from PySide6.QtWidgets import QApplication
+
+from core.flow import Flow
+from nodes.filters.grayscale import Grayscale
+from nodes.sources.image_source import ImageSource
+from ui.flow_scene import FlowScene
+
+
+@pytest.fixture(scope="module")
+def qapp() -> QApplication:
+    return QApplication.instance() or QApplication(sys.argv)
+
+
+def _fresh_scene() -> FlowScene:
+    scene = FlowScene()
+    scene.set_flow(Flow(name="dirty_test"))
+    return scene
+
+
+def test_fresh_scene_is_clean(qapp: QApplication) -> None:
+    scene = _fresh_scene()
+    assert scene.is_dirty is False
+
+
+def test_add_node_marks_dirty(qapp: QApplication) -> None:
+    scene = _fresh_scene()
+    scene.add_node(ImageSource(), QPointF(0, 0))
+    assert scene.is_dirty is True
+
+
+def test_remove_node_marks_dirty(qapp: QApplication) -> None:
+    scene = _fresh_scene()
+    item = scene.add_node(ImageSource(), QPointF(0, 0))
+    scene.mark_saved()
+    assert scene.is_dirty is False
+    scene.remove_node_item(item)
+    assert scene.is_dirty is True
+
+
+def test_connect_ports_marks_dirty(qapp: QApplication) -> None:
+    scene = _fresh_scene()
+    src_item = scene.add_node(ImageSource(), QPointF(0, 0))
+    dst_item = scene.add_node(Grayscale(), QPointF(200, 0))
+    scene.mark_saved()
+    assert scene.is_dirty is False
+    scene.connect_ports(src_item.output_ports[0], dst_item.input_ports[0])
+    assert scene.is_dirty is True
+
+
+def test_disconnect_link_marks_dirty(qapp: QApplication) -> None:
+    scene = _fresh_scene()
+    src_item = scene.add_node(ImageSource(), QPointF(0, 0))
+    dst_item = scene.add_node(Grayscale(), QPointF(200, 0))
+    link = scene.connect_ports(
+        src_item.output_ports[0], dst_item.input_ports[0]
+    )
+    assert link is not None
+    scene.mark_saved()
+    assert scene.is_dirty is False
+    scene._delete_link_item(link)
+    assert scene.is_dirty is True
+
+
+def test_param_changed_marks_dirty(qapp: QApplication) -> None:
+    """A param-widget edit anywhere in the scene flips dirty on."""
+    scene = _fresh_scene()
+    scene.add_node(ImageSource(), QPointF(0, 0))
+    scene.mark_saved()
+    assert scene.is_dirty is False
+    scene.param_changed.emit()
+    assert scene.is_dirty is True
+
+
+def test_set_flow_clears_dirty(qapp: QApplication) -> None:
+    """Loading / creating a new flow starts a fresh clean slate."""
+    scene = _fresh_scene()
+    scene.add_node(ImageSource(), QPointF(0, 0))
+    assert scene.is_dirty is True
+    scene.set_flow(Flow(name="another"))
+    assert scene.is_dirty is False
+
+
+def test_dirty_changed_emits_only_on_transitions(qapp: QApplication) -> None:
+    """Back-to-back edits must not spam dirty_changed with True."""
+    scene = _fresh_scene()
+    events: list[bool] = []
+    scene.dirty_changed.connect(events.append)
+
+    # Two structural edits in a row: only the first should emit.
+    scene.add_node(ImageSource(), QPointF(0, 0))
+    scene.add_node(Grayscale(), QPointF(200, 0))
+    assert events == [True]
+
+    scene.mark_saved()
+    assert events == [True, False]
+
+    # Saving a clean scene is a no-op on the signal.
+    scene.mark_saved()
+    assert events == [True, False]


### PR DESCRIPTION
## Summary

- Surfaces dirty state in the Node Editor's toolbar status widget as an amber `● Unsaved changes` row. Driven by a new `FlowScene.is_dirty` property and `dirty_changed(bool)` signal — structural edits (add/remove node, add/remove link, V-/H-Stack, skip toggle) and param-widget edits flip it on; `set_flow` / `mark_saved` clear it.
- Shows the running Python runtime (`Python X.Y.Z`) as a muted third line on `AppVersionStatusWidget`, so users can see at a glance which interpreter the app is bound to.
- Refactors `FlowStatusWidget`'s idle view to embed `AppVersionStatusWidget` directly instead of duplicating its label stack.

### Details

- `FlowScene` gains `is_dirty` + `mark_saved()` + `dirty_changed` signal. `toggle_skipped` on `NodeItem` now emits `param_changed` so the skip button participates in dirty tracking (and reactive auto-run) exactly like a parameter edit would.
- `NodeEditorPage` wires the signal into `FlowStatusWidget.set_unsaved`, calls `mark_saved()` after a successful `Save` / `Save As` / `load_flow` (the loader rebuilds nodes + links via `add_node` / `connect_ports`, which flip dirty on — so the reset has to happen after the rebuild completes).
- `STATUS_WARN_COLOR` (amber) added to `ui.theme` for the indicator and future "attention" affordances.
- `Clear` intentionally resets dirty (confirmed behaviour): it starts a fresh empty flow, so the scene matches what the user sees; the old file on disk is untouched.

### Tests

- 8 new tests in `tests/test_flow_scene_dirty.py` cover: fresh-scene cleanliness, dirty flips on every mutation path, `mark_saved` / `set_flow` reset, and `dirty_changed` emitting only on real transitions (not on back-to-back edits).
- Full suite: **127 passed**.

## Test plan

- [x] `pytest tests/` — 127 passed locally.
- [ ] Manual: open a flow, verify no indicator; edit any parameter → amber row appears; Save → row clears.
- [ ] Manual: new flow → edit → Save As with a new name → row clears.
- [ ] Manual: Clear on a modified flow → row clears (confirmed behaviour).
- [ ] Manual: switch pages while dirty → indicator is editor-only; other pages' `AppVersionStatusWidget` shows the Python version but no warning row.

https://claude.ai/code/session_01JZ3D7ive83Qrb3NjyZS8dM

---
_Generated by [Claude Code](https://claude.ai/code/session_01JZ3D7ive83Qrb3NjyZS8dM)_