### PR TITLE
Normalise VideoSource paths + re-stamp bundled flow files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,20 @@ once a first tagged release is cut.
 
 ## [Unreleased]
 
+## [0.1.16] — 2026-04-24
+
+### Fixed
+- **`VideoSource` path handling is now consistent with every other
+  file-based node.** Paths under `INPUT_DIR` are stored as bare
+  relative names and resolved against `INPUT_DIR` at run time — same
+  contract `ImageSource` / `FileSink` / `VideoSink` already followed.
+  Previously `VideoSource` persisted the host-absolute path (breaking
+  flow portability across machines) and resolved any relative value
+  against the process's working directory (breaking the default
+  `./input/example.mp4` unless launched from the repo root). The
+  default is also bumped from `./input/example.mp4` to `example.mp4`
+  so it resolves correctly regardless of `cwd`. Fixes #145.
+
 ## [0.1.15] — 2026-04-24
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,16 @@ once a first tagged release is cut.
   flow portability across machines) and resolved any relative value
   against the process's working directory (breaking the default
   `./input/example.mp4` unless launched from the repo root). The
-  default is also bumped from `./input/example.mp4` to `example.mp4`
-  so it resolves correctly regardless of `cwd`. Fixes #145.
+  default is also bumped to `video.mp4`, a file that ships in
+  `input/` — no more "file not found" on a fresh node. Fixes #145.
+
+### Changed
+- **Bundled flow files re-stamped to the current format.** All
+  `*.flowjs` files under `flow/` had their `app_version` field
+  refreshed (previously ranged from v0.1.10 down to a missing field
+  entirely). No semantic changes — node / connection data is
+  untouched; this is purely a metadata refresh so the stamped
+  version doesn't lag behind the app by multiple releases.
 
 ## [0.1.15] — 2026-04-24
 

--- a/doc/welcome.html
+++ b/doc/welcome.html
@@ -164,7 +164,7 @@
   <main class="content-col">
 
     <header class="hero">
-      <h1>Welcome to Stjörnhorn <span class="version">v0.1.15</span></h1>
+      <h1>Welcome to Stjörnhorn <span class="version">v0.1.16</span></h1>
       <div class="tagline">A node-based image- and video-processing playground.</div>
     </header>
 
@@ -197,11 +197,12 @@
     </section>
 
     <section>
-      <h2>What's new in v0.1.15</h2>
+      <h2>What's new in v0.1.16</h2>
       <ul class="tips">
-        <li><strong>Unsaved-changes indicator</strong> — the editor's toolbar shows an amber warning icon with "Unsaved changes" the moment a parameter, node, or connection is edited, and clears it on save, load, or reload.</li>
-        <li><strong>Reload</strong> toolbar action re-reads the current flow from disk, discarding unsaved edits after a confirmation.</li>
-        <li><strong>Python runtime</strong> appears in the toolbar and is written to the log at startup, so bug reports always include which interpreter the app was bound to.</li>
+        <li><strong>Video Source paths are now portable</strong> — flows that reference a video under the <code>input/</code> folder save as short relative names and resolve them the same way as image sources, regardless of the working directory.</li>
+        <li><strong>Unsaved-changes indicator</strong> (v0.1.15) — the editor's toolbar shows an amber warning icon with "Unsaved changes" the moment a parameter, node, or connection is edited, and clears it on save, load, or reload.</li>
+        <li><strong>Reload</strong> toolbar action (v0.1.15) re-reads the current flow from disk, discarding unsaved edits after a confirmation.</li>
+        <li><strong>Python runtime</strong> (v0.1.15) appears in the toolbar and is written to the log at startup, so bug reports always include which interpreter the app was bound to.</li>
         <li><strong>RGBA-aware split/join + per-pixel Overlay alpha</strong> (v0.1.14) — the Overlay node now honours the overlay image's alpha channel as a per-pixel blend mask; <code>RgbaSplit</code> / <code>RgbaJoin</code> supersede the RGB-only nodes, with the alpha port marked optional so old 3-channel flows keep working.</li>
       </ul>
     </section>

--- a/flow/debug_delay.flowjs
+++ b/flow/debug_delay.flowjs
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "app_version": "0.1.10",
+  "app_version": "0.1.16",
   "name": "debug_delay",
   "nodes": [
     {

--- a/flow/debug_error.flowjs
+++ b/flow/debug_error.flowjs
@@ -1,5 +1,6 @@
 {
   "version": 1,
+  "app_version": "0.1.16",
   "name": "debug_error",
   "nodes": [
     {

--- a/flow/dither.flowjs
+++ b/flow/dither.flowjs
@@ -1,5 +1,6 @@
 {
   "version": 1,
+  "app_version": "0.1.16",
   "name": "dither",
   "nodes": [
     {

--- a/flow/mosaic.flowjs
+++ b/flow/mosaic.flowjs
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "app_version": "0.1.10",
+  "app_version": "0.1.16",
   "name": "mosaic",
   "nodes": [
     {

--- a/flow/ncc.flowjs
+++ b/flow/ncc.flowjs
@@ -1,5 +1,6 @@
 {
   "version": 1,
+  "app_version": "0.1.16",
   "name": "ncc",
   "nodes": [
     {

--- a/flow/rgb_dither.flowjs
+++ b/flow/rgb_dither.flowjs
@@ -1,5 +1,6 @@
 {
   "version": 1,
+  "app_version": "0.1.16",
   "name": "rgb_dither",
   "nodes": [
     {

--- a/flow/sample_overlay.flowjs
+++ b/flow/sample_overlay.flowjs
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "app_version": "0.1.14",
+  "app_version": "0.1.16",
   "name": "sample_overlay",
   "nodes": [
     {

--- a/flow/transform.flowjs
+++ b/flow/transform.flowjs
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "app_version": "0.1.10",
+  "app_version": "0.1.16",
   "name": "transform",
   "nodes": [
     {

--- a/flow/video_dither.flowjs
+++ b/flow/video_dither.flowjs
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "app_version": "0.1.10",
+  "app_version": "0.1.16",
   "name": "video_dither",
   "nodes": [
     {

--- a/flow/video_dither_simple.flowjs
+++ b/flow/video_dither_simple.flowjs
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "app_version": "0.1.12",
+  "app_version": "0.1.16",
   "name": "video_dither_simple",
   "nodes": [
     {

--- a/flow/video_ncc.flowjs
+++ b/flow/video_ncc.flowjs
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "app_version": "0.1.10",
+  "app_version": "0.1.16",
   "name": "video_ncc",
   "nodes": [
     {

--- a/src/constants.py
+++ b/src/constants.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 APP_NAME:         str = "Image-Inquest"
 APP_DISPLAY_NAME: str = "Stjörnhorn"
-APP_VERSION:      str = "0.1.15"
+APP_VERSION:      str = "0.1.16"
 API_URL:    str = "https://beltoforion.de"
 
 # Bundled documentation (offline welcome page, screenshots, …)

--- a/src/nodes/sources/video_source.py
+++ b/src/nodes/sources/video_source.py
@@ -18,12 +18,18 @@ class VideoSource(SourceNodeBase):
 
     Supported formats: MP4, AVI, MOV, MKV.
 
+    Paths inside the application's :data:`INPUT_DIR` are stored — and
+    therefore displayed — relative to that folder. Anything outside is
+    kept as an absolute path. Relative paths are resolved against
+    ``INPUT_DIR`` at run time, which keeps saved flows portable across
+    machines that share the same input layout.
+
     Unlike :class:`ImageSource`, this source is **not** reactive — the flow
     only runs when the Run button is pressed.  This avoids restarting a
     potentially long video decode on every keystroke.
 
     Parameters:
-      file_path      -- path to the input video file
+      file_path      -- path to the input video (relative to INPUT_DIR when possible)
       max_num_frames -- maximum number of frames to decode (-1 = all)
     """
 
@@ -40,8 +46,16 @@ class VideoSource(SourceNodeBase):
     @override
     def params(self) -> list[NodeParam]:
         return [
-            NodeParam("file_path",      NodeParamType.FILE_PATH, {"default": "./input/example.mp4", "filter": "Video (*.mp4 *.avi *.mov *.mkv)", "base_dir": INPUT_DIR}),
-            NodeParam("max_num_frames", NodeParamType.INT,       {"default": -1}),
+            NodeParam(
+                "file_path",
+                NodeParamType.FILE_PATH,
+                {
+                    "default": "video.mp4",
+                    "filter": "Video (*.mp4 *.avi *.mov *.mkv)",
+                    "base_dir": INPUT_DIR,
+                },
+            ),
+            NodeParam("max_num_frames", NodeParamType.INT, {"default": -1}),
         ]
 
     @property
@@ -50,7 +64,13 @@ class VideoSource(SourceNodeBase):
 
     @file_path.setter
     def file_path(self, path: str | Path) -> None:
-        self._file_path = Path(path)
+        p = Path(path)
+        if p.is_absolute():
+            try:
+                p = p.resolve().relative_to(INPUT_DIR.resolve())
+            except (OSError, ValueError):
+                pass  # outside INPUT_DIR — keep absolute
+        self._file_path = p
 
     @property
     def max_num_frames(self) -> int:
@@ -64,17 +84,18 @@ class VideoSource(SourceNodeBase):
 
     @override
     def process_impl(self) -> None:
-        if not self._file_path.exists():
-            raise FileNotFoundError(f"Input file not found: {self._file_path}")
+        resolved = self._resolved_path()
+        if not resolved.exists():
+            raise FileNotFoundError(f"Input file not found: {resolved}")
 
-        ext = self._file_path.suffix.lower()
+        ext = resolved.suffix.lower()
         if ext not in _SUPPORTED_EXTS:
             raise ValueError(
                 f"Unsupported file type '{ext}'. "
                 f"Supported: {_SUPPORTED_EXTS}"
             )
 
-        cap = cv2.VideoCapture(str(self._file_path))
+        cap = cv2.VideoCapture(str(resolved))
         try:
             frame_count = 0
             while True:
@@ -87,3 +108,11 @@ class VideoSource(SourceNodeBase):
                     break
         finally:
             cap.release()
+
+    # ── Internals ──────────────────────────────────────────────────────────────
+
+    def _resolved_path(self) -> Path:
+        """Return an absolute path; relative values are joined with INPUT_DIR."""
+        if self._file_path.is_absolute():
+            return self._file_path
+        return INPUT_DIR / self._file_path

--- a/tests/test_source_path_normalization.py
+++ b/tests/test_source_path_normalization.py
@@ -1,0 +1,57 @@
+"""Regression tests for source-node path normalization.
+
+Both :class:`ImageSource` and :class:`VideoSource` are expected to
+store paths under :data:`INPUT_DIR` as bare relative names (so saved
+flows port cleanly across machines) and to resolve those relative
+names against ``INPUT_DIR`` at run time. The two used to diverge —
+``VideoSource`` persisted absolute paths and resolved relatives
+against ``cwd`` — so the behaviour is locked down here for both
+nodes in parallel to keep them from drifting again.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from constants import INPUT_DIR
+from nodes.sources.image_source import ImageSource
+from nodes.sources.video_source import VideoSource
+
+
+@pytest.fixture(params=[ImageSource, VideoSource])
+def source(request):
+    """Run the same behavioural contract against every file-based source."""
+    return request.param()
+
+
+def test_absolute_path_under_input_dir_is_stored_relative(source) -> None:
+    """Picking a file under INPUT_DIR strips the INPUT_DIR prefix so the
+    saved flow carries a short, portable name rather than the host path.
+    """
+    absolute = (INPUT_DIR / "clip.bin").resolve()
+    source.file_path = absolute
+    assert source.file_path == Path("clip.bin")
+    assert not source.file_path.is_absolute()
+
+
+def test_absolute_path_outside_input_dir_is_kept_absolute(
+    tmp_path: Path, source,
+) -> None:
+    """Paths that can't be made relative to INPUT_DIR stay absolute —
+    relative_to() would raise ValueError and should be swallowed.
+    """
+    outside = (tmp_path / "elsewhere.bin").resolve()
+    source.file_path = outside
+    assert source.file_path == outside
+    assert source.file_path.is_absolute()
+
+
+def test_bare_relative_name_resolves_against_input_dir(source) -> None:
+    """A bare filename on the setter is left relative, and the node's
+    internal resolver joins it with INPUT_DIR — never with cwd.
+    """
+    source.file_path = "clip.bin"
+    assert source.file_path == Path("clip.bin")
+    resolved = source._resolved_path()
+    assert resolved == INPUT_DIR / "clip.bin"


### PR DESCRIPTION
## Summary

- **Fix**: align `VideoSource` path handling with `ImageSource` / `FileSink` / `VideoSink`. The setter now strips the `INPUT_DIR` prefix (so saved flows persist a short relative name) and a new `_resolved_path()` helper joins bare relatives onto `INPUT_DIR` at run time. Fixes the two concrete bugs this caused:
  - Paths picked from `INPUT_DIR` were persisted absolute → flows broke when moved between machines.
  - Relative paths (including the default `./input/example.mp4`) were resolved against the process's `cwd`, not `INPUT_DIR` — so the app only worked when launched from the repo root.
- **Default change**: `VideoSource.file_path` default bumped from `./input/example.mp4` to `video.mp4` (a file that actually ships in `input/`), so a freshly-dropped Video Source has a working path out of the box regardless of `cwd`.
- **Metadata refresh**: round-tripped every `*.flowjs` under `flow/` so the informational `app_version` field matches the current release (previously ranged from v0.1.10 down to missing entirely). No semantic changes to node / connection data — purely a metadata refresh.

## Details

The code change mirrors the existing pattern in `src/nodes/sources/image_source.py` line-for-line — setter with `resolve().relative_to(INPUT_DIR)` + `_resolved_path()` at run time.

The flow-file refresh is a pure JSON load-and-save pass: it rewrites `app_version` to `APP_VERSION` and adds a trailing newline so the on-disk shape matches what the editor's save path produces.

## Tests

- New `tests/test_source_path_normalization.py` parametrises over both `ImageSource` and `VideoSource` and locks down the contract:
  - absolute path under `INPUT_DIR` → stored as bare relative
  - absolute path outside → stays absolute
  - bare name on setter → resolves to `INPUT_DIR / name` via `_resolved_path()`
- Running both fixtures in the same tests ensures the two sources can't silently drift apart again.
- Full suite: **133 passed**.

Fixes #145.

## Test plan

- [x] `pytest tests/` — all green locally.
- [ ] Manual: drop a `Video Source`, pick a file under `input/` → saved flow stores bare name, not host-absolute path.
- [ ] Manual: launch the app from a directory other than the repo root → the default `video.mp4` still resolves.
- [ ] Manual: open any of the refreshed flows under `flow/` and run them → no regressions.

https://claude.ai/code/session_01JZ3D7ive83Qrb3NjyZS8dM