### PR TITLE
Reroutes + Backdrops: visual grouping for dense flows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,26 @@ once a first tagged release is cut.
 
 ## [Unreleased]
 
+## [0.1.17] — 2026-04-24
+
+### Added
+- **Reroute pass-through nodes.** Double-click on any link to insert
+  a small dot at the cursor that re-routes the link around dense
+  pipelines without changing the graph semantics. Deleting a reroute
+  re-joins its upstream and downstream automatically. Bezier
+  tangents at reroute-owned ports aim at the other endpoint, so
+  mäandrierende Flows render as smooth S-curves instead of 180°
+  loops. Reroutes are hidden from the palette (section sentinel
+  `__hidden__`) — the editor's double-click flow is the only way to
+  create one.
+- **Backdrops.** Coloured frames drawn behind groups of nodes so
+  dense pipelines can be annotated as loose chapters. Right-click
+  on empty canvas to add one; title / colour are editable via the
+  backdrop's own context menu; resize via the bottom-right grip.
+  Persisted alongside nodes and connections in the flow file under
+  a new `backdrops` entry (old flows without the field load as
+  before).
+
 ## [0.1.16] — 2026-04-24
 
 ### Fixed

--- a/doc/welcome.html
+++ b/doc/welcome.html
@@ -164,7 +164,7 @@
   <main class="content-col">
 
     <header class="hero">
-      <h1>Welcome to Stjörnhorn <span class="version">v0.1.16</span></h1>
+      <h1>Welcome to Stjörnhorn <span class="version">v0.1.17</span></h1>
       <div class="tagline">A node-based image- and video-processing playground.</div>
     </header>
 
@@ -197,13 +197,13 @@
     </section>
 
     <section>
-      <h2>What's new in v0.1.16</h2>
+      <h2>What's new in v0.1.17</h2>
       <ul class="tips">
-        <li><strong>Video Source paths are now portable</strong> — flows that reference a video under the <code>input/</code> folder save as short relative names and resolve them the same way as image sources, regardless of the working directory.</li>
+        <li><strong>Reroute dots</strong> — double-click any link to pin a small dot at the cursor that bends the connection around dense node clusters. Deleting a reroute re-joins its upstream and downstream so nothing breaks.</li>
+        <li><strong>Backdrops</strong> — right-click empty canvas to drop a coloured frame behind a group of nodes. Use them as loose chapter headings ("Colour prep", "Alpha mask") so large flows stay readable.</li>
+        <li><strong>Video Source paths are now portable</strong> (v0.1.16) — video references under the <code>input/</code> folder save as short relative names and resolve them the same way as image sources, regardless of the working directory.</li>
         <li><strong>Unsaved-changes indicator</strong> (v0.1.15) — the editor's toolbar shows an amber warning icon with "Unsaved changes" the moment a parameter, node, or connection is edited, and clears it on save, load, or reload.</li>
         <li><strong>Reload</strong> toolbar action (v0.1.15) re-reads the current flow from disk, discarding unsaved edits after a confirmation.</li>
-        <li><strong>Python runtime</strong> (v0.1.15) appears in the toolbar and is written to the log at startup, so bug reports always include which interpreter the app was bound to.</li>
-        <li><strong>RGBA-aware split/join + per-pixel Overlay alpha</strong> (v0.1.14) — the Overlay node now honours the overlay image's alpha channel as a per-pixel blend mask; <code>RgbaSplit</code> / <code>RgbaJoin</code> supersede the RGB-only nodes, with the alpha port marked optional so old 3-channel flows keep working.</li>
       </ul>
     </section>
 

--- a/src/constants.py
+++ b/src/constants.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 APP_NAME:         str = "Image-Inquest"
 APP_DISPLAY_NAME: str = "Stjörnhorn"
-APP_VERSION:      str = "0.1.16"
+APP_VERSION:      str = "0.1.17"
 API_URL:    str = "https://beltoforion.de"
 
 # Bundled documentation (offline welcome page, screenshots, …)

--- a/src/nodes/util/reroute.py
+++ b/src/nodes/util/reroute.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from typing_extensions import override
+
+from core.io_data import IMAGE_TYPES
+from core.node_base import NodeBase, NodeParam
+from core.port import InputPort, OutputPort
+
+
+class Reroute(NodeBase):
+    """Zero-logic pass-through used to route links around other nodes.
+
+    A ``Reroute`` has one input and one output, both accepting the same
+    image types the rest of the pipeline does. It does no processing:
+    every frame that arrives on the input is forwarded verbatim to the
+    output. The value of a reroute is purely visual — it lets the user
+    pin a knick-point on an otherwise straight link so the graph can
+    meander around densely packed nodes.
+
+    Reroutes are created implicitly by the editor (double-click on a
+    link → insert reroute at the cursor) and never appear in the node
+    palette, so the section name is intentionally sentinel-valued to
+    keep them out of ``NodeList`` listings.
+    """
+
+    #: Sentinel section name. ``NodeList`` filters against this literal
+    #: so reroutes never show up in the palette — they can only be
+    #: instantiated by the editor itself. Must be a string literal in
+    #: the super().__init__() call because :class:`NodeRegistry` scans
+    #: the section via AST and only recognises literals.
+    HIDDEN_SECTION: str = "__hidden__"
+
+    def __init__(self) -> None:
+        super().__init__("Reroute", section="__hidden__")
+        self._add_input(InputPort("in", set(IMAGE_TYPES)))
+        self._add_output(OutputPort("out", set(IMAGE_TYPES)))
+
+    @property
+    @override
+    def params(self) -> list[NodeParam]:
+        return []
+
+    @override
+    def process_impl(self) -> None:
+        self.outputs[0].send(self.inputs[0].data)

--- a/src/ui/backdrop_item.py
+++ b/src/ui/backdrop_item.py
@@ -1,0 +1,236 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from PySide6.QtCore import QPointF, QRectF, Qt
+from PySide6.QtGui import (
+    QBrush,
+    QColor,
+    QFont,
+    QPainter,
+    QPainterPath,
+    QPen,
+)
+from PySide6.QtWidgets import QGraphicsItem
+
+from ui.theme import NODE_BORDER_SELECTED
+
+if TYPE_CHECKING:
+    pass
+
+
+#: Default fill when a backdrop is first dropped — a subtle, muted
+#: amber so the frame reads as a loose grouping affordance without
+#: fighting the nodes inside for attention.
+DEFAULT_BACKDROP_COLOR: QColor = QColor(70, 60, 40, 140)
+
+#: Default dimensions used when the user drops a fresh backdrop.
+DEFAULT_BACKDROP_WIDTH: float = 320.0
+DEFAULT_BACKDROP_HEIGHT: float = 220.0
+
+#: Minimum size when the user drags the resize grip. Small enough that
+#: a backdrop can frame a single node, but not so small it collapses
+#: into an invisible square.
+MIN_BACKDROP_WIDTH: float = 80.0
+MIN_BACKDROP_HEIGHT: float = 60.0
+
+#: Built-in palette offered through the context menu. Kept deliberately
+#: small — this is a "hint at intent" affordance, not a full colour
+#: picker. Values mirror the muted dark-theme palette so backdrops
+#: read as loose grouping rather than as primary UI.
+BACKDROP_PRESETS: dict[str, QColor] = {
+    "Amber":   QColor( 70,  60,  40, 140),
+    "Azure":   QColor( 40,  60,  80, 140),
+    "Forest":  QColor( 40,  70,  50, 140),
+    "Plum":    QColor( 70,  45,  70, 140),
+    "Slate":   QColor( 55,  55,  60, 140),
+}
+
+
+class BackdropItem(QGraphicsItem):
+    """Rectangular frame drawn behind a group of nodes.
+
+    A backdrop is a pure visual affordance: it has no connection to
+    the flow model, no execution semantics, and does not appear in the
+    node palette. Use it as a "chapter heading" on the canvas —
+    e.g. "Colour prep", "Alpha mask" — so dense pipelines stay
+    readable.
+
+    Sits on a lower Z than nodes (:attr:`Z_VALUE`) so mouse events on
+    the interior of a framed group still reach the node on top. Drag
+    the title to move the backdrop; drag the bottom-right grip to
+    resize.
+    """
+
+    Z_VALUE: int = -10
+    HEADER_HEIGHT: float = 22.0
+    CORNER_RADIUS: float = 6.0
+    RESIZE_GRIP_SIZE: float = 12.0
+    TITLE_PADDING: float = 8.0
+
+    def __init__(
+        self,
+        title: str = "Backdrop",
+        width: float = DEFAULT_BACKDROP_WIDTH,
+        height: float = DEFAULT_BACKDROP_HEIGHT,
+        color: QColor | None = None,
+    ) -> None:
+        super().__init__()
+        self._title: str = title
+        self._width: float = float(width)
+        self._height: float = float(height)
+        self._color: QColor = QColor(color if color is not None else DEFAULT_BACKDROP_COLOR)
+
+        self.setZValue(self.Z_VALUE)
+        self.setFlag(QGraphicsItem.GraphicsItemFlag.ItemIsMovable, True)
+        self.setFlag(QGraphicsItem.GraphicsItemFlag.ItemIsSelectable, True)
+        self.setFlag(
+            QGraphicsItem.GraphicsItemFlag.ItemSendsScenePositionChanges, True,
+        )
+
+        self._resize_grip = _BackdropResizeGrip(self)
+        self._position_resize_grip()
+
+    # ── Public API ─────────────────────────────────────────────────────────────
+
+    @property
+    def title(self) -> str:
+        return self._title
+
+    def set_title(self, title: str) -> None:
+        self._title = str(title)
+        self.update()
+
+    @property
+    def color(self) -> QColor:
+        return QColor(self._color)
+
+    def set_color(self, color: QColor) -> None:
+        self._color = QColor(color)
+        self.update()
+
+    @property
+    def width(self) -> float:
+        return self._width
+
+    @property
+    def height(self) -> float:
+        return self._height
+
+    def set_size(self, width: float, height: float) -> None:
+        """Update the backdrop rectangle. Enforces the minimum so the
+        resize grip can't collapse the frame out of existence."""
+        new_w = max(MIN_BACKDROP_WIDTH, float(width))
+        new_h = max(MIN_BACKDROP_HEIGHT, float(height))
+        if (new_w, new_h) == (self._width, self._height):
+            return
+        self.prepareGeometryChange()
+        self._width = new_w
+        self._height = new_h
+        self._position_resize_grip()
+        self.update()
+
+    # ── Qt overrides ───────────────────────────────────────────────────────────
+
+    def boundingRect(self) -> QRectF:  # type: ignore[override]
+        return QRectF(0, 0, self._width, self._height)
+
+    def paint(self, painter: QPainter, option, widget=None) -> None:  # type: ignore[override]
+        painter.setRenderHint(QPainter.RenderHint.Antialiasing, True)
+
+        # Body
+        body_path = QPainterPath()
+        body_path.addRoundedRect(
+            self.boundingRect(), self.CORNER_RADIUS, self.CORNER_RADIUS,
+        )
+        painter.fillPath(body_path, QBrush(self._color))
+
+        # Border: amber when selected, subtle darker tint otherwise.
+        if self.isSelected():
+            painter.setPen(QPen(NODE_BORDER_SELECTED, 1.5))
+        else:
+            border = QColor(self._color)
+            border.setAlpha(230)
+            border.setRed(max(0, border.red() - 25))
+            border.setGreen(max(0, border.green() - 25))
+            border.setBlue(max(0, border.blue() - 25))
+            painter.setPen(QPen(border, 1.0))
+        painter.setBrush(Qt.BrushStyle.NoBrush)
+        painter.drawPath(body_path)
+
+        # Title bar text — rendered directly onto the header strip.
+        if self._title:
+            title_rect = QRectF(
+                self.TITLE_PADDING,
+                0.0,
+                self._width - 2 * self.TITLE_PADDING,
+                self.HEADER_HEIGHT,
+            )
+            font = QFont(painter.font())
+            font.setBold(True)
+            painter.setFont(font)
+            painter.setPen(QColor(230, 230, 230))
+            painter.drawText(
+                title_rect,
+                Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignVCenter,
+                self._title,
+            )
+
+    # ── Internals ──────────────────────────────────────────────────────────────
+
+    def _position_resize_grip(self) -> None:
+        self._resize_grip.setPos(
+            self._width - self.RESIZE_GRIP_SIZE,
+            self._height - self.RESIZE_GRIP_SIZE,
+        )
+
+
+class _BackdropResizeGrip(QGraphicsItem):
+    """Bottom-right drag handle that resizes its owning backdrop."""
+
+    SIZE: float = 12.0
+
+    def __init__(self, backdrop: BackdropItem) -> None:
+        super().__init__(parent=backdrop)
+        self._backdrop = backdrop
+        self.setFlag(QGraphicsItem.GraphicsItemFlag.ItemStacksBehindParent, False)
+        self.setCursor(Qt.CursorShape.SizeFDiagCursor)
+        self.setZValue(1)
+        self._drag_start_scene: QPointF | None = None
+        self._drag_start_size: tuple[float, float] | None = None
+
+    def boundingRect(self) -> QRectF:  # type: ignore[override]
+        return QRectF(0, 0, self.SIZE, self.SIZE)
+
+    def paint(self, painter: QPainter, option, widget=None) -> None:  # type: ignore[override]
+        painter.setRenderHint(QPainter.RenderHint.Antialiasing, True)
+        painter.setPen(QPen(QColor(200, 200, 200, 180), 1))
+        # Three short diagonal tick marks — enough to telegraph
+        # "resize handle" without looking like a button.
+        for i in (2, 5, 8):
+            painter.drawLine(
+                QPointF(self.SIZE - i, self.SIZE - 1),
+                QPointF(self.SIZE - 1, self.SIZE - i),
+            )
+
+    def mousePressEvent(self, event) -> None:  # type: ignore[override]
+        if event.button() == Qt.MouseButton.LeftButton:
+            self._drag_start_scene = event.scenePos()
+            self._drag_start_size = (self._backdrop.width, self._backdrop.height)
+            event.accept()
+            return
+        super().mousePressEvent(event)
+
+    def mouseMoveEvent(self, event) -> None:  # type: ignore[override]
+        if self._drag_start_scene is not None and self._drag_start_size is not None:
+            delta = event.scenePos() - self._drag_start_scene
+            w0, h0 = self._drag_start_size
+            self._backdrop.set_size(w0 + delta.x(), h0 + delta.y())
+            event.accept()
+            return
+        super().mouseMoveEvent(event)
+
+    def mouseReleaseEvent(self, event) -> None:  # type: ignore[override]
+        self._drag_start_scene = None
+        self._drag_start_size = None
+        super().mouseReleaseEvent(event)

--- a/src/ui/flow_io.py
+++ b/src/ui/flow_io.py
@@ -74,12 +74,24 @@ def serialize_flow(scene: FlowScene, flow: Flow) -> dict:
             "dst_input":  link.dst_port.index,
         })
 
+    backdrops_out: list[dict] = []
+    for backdrop in scene.iter_backdrops():
+        pos = backdrop.pos()
+        colour = backdrop.color
+        backdrops_out.append({
+            "position": [float(pos.x()), float(pos.y())],
+            "size":     [float(backdrop.width), float(backdrop.height)],
+            "title":    backdrop.title,
+            "color":    [colour.red(), colour.green(), colour.blue(), colour.alpha()],
+        })
+
     return {
         "version":     FLOW_FORMAT_VERSION,
         "app_version": APP_VERSION,
         "name":        flow.name,
         "nodes":       nodes_out,
         "connections": connections_out,
+        "backdrops":   backdrops_out,
     }
 
 
@@ -136,7 +148,7 @@ def load_flow_into(path: Path, scene: FlowScene) -> Flow:
     for conn in data.get("connections", []):
         src = id_to_node.get(conn.get("src_node"))
         dst = id_to_node.get(conn.get("dst_node"))
-        
+
         if src is None or dst is None:
             logger.debug(f"Skipping connection with unknown endpoint: {conn}")
             continue
@@ -145,7 +157,7 @@ def load_flow_into(path: Path, scene: FlowScene) -> Flow:
         dst_item = scene.node_item_for(dst)
         if src_item is None or dst_item is None:
             continue
-        
+
         try:
             src_port = src_item.output_port(conn["src_output"])
             dst_port = dst_item.input_port(conn["dst_input"])
@@ -158,6 +170,25 @@ def load_flow_into(path: Path, scene: FlowScene) -> Flow:
             # into an IMAGE-only port). Log and continue so the rest of the
             # flow still loads rather than aborting the whole file.
             logger.warning(f"Skipping incompatible connection {conn}: {err}")
+
+    for entry in data.get("backdrops", []):
+        pos = entry.get("position") or [0.0, 0.0]
+        size = entry.get("size") or [None, None]
+        col_rgba = entry.get("color")
+        colour = None
+        if col_rgba and len(col_rgba) >= 3:
+            from PySide6.QtGui import QColor
+            alpha = col_rgba[3] if len(col_rgba) >= 4 else 255
+            colour = QColor(
+                int(col_rgba[0]), int(col_rgba[1]), int(col_rgba[2]), int(alpha),
+            )
+        scene.add_backdrop(
+            QPointF(float(pos[0]), float(pos[1])),
+            title=str(entry.get("title", "Backdrop")),
+            width=float(size[0]) if size[0] is not None else None,
+            height=float(size[1]) if size[1] is not None else None,
+            color=colour,
+        )
 
     return flow
 

--- a/src/ui/flow_scene.py
+++ b/src/ui/flow_scene.py
@@ -17,6 +17,7 @@ from PySide6.QtWidgets import (
 from core.flow import Flow
 from core.node_base import NodeBase
 from nodes.util.reroute import Reroute
+from ui.backdrop_item import BACKDROP_PRESETS, BackdropItem
 from ui.link_item import LinkItem, PendingLinkItem
 from ui.node_item import NodeItem
 from ui.port_item import PortItem
@@ -61,6 +62,7 @@ class FlowScene(QGraphicsScene):
         self._flow: Flow | None = None
         self._node_items: dict[int, NodeItem] = {}          # id(node_base) → NodeItem
         self._links: list[LinkItem] = []
+        self._backdrops: list[BackdropItem] = []
         self._pending_link: PendingLinkItem | None = None
         self._pending_src_port: PortItem | None = None
         self._last_emitted_selected: NodeBase | None = None
@@ -96,8 +98,11 @@ class FlowScene(QGraphicsScene):
             self._delete_link_item(link)
         for item in list(self._node_items.values()):
             self._delete_node_item(item)
+        for backdrop in list(self._backdrops):
+            self.removeItem(backdrop)
         self._node_items.clear()
         self._links.clear()
+        self._backdrops.clear()
         self._pending_link = None
         self._pending_src_port = None
         self._last_emitted_selected = None
@@ -275,13 +280,61 @@ class FlowScene(QGraphicsScene):
         self.removeItem(link)
         self._mark_dirty()
 
+    # ── Backdrops ──────────────────────────────────────────────────────────────
+
+    def add_backdrop(
+        self,
+        scene_pos: QPointF | None = None,
+        *,
+        title: str = "Backdrop",
+        width: float | None = None,
+        height: float | None = None,
+        color=None,
+    ) -> BackdropItem:
+        """Add a :class:`BackdropItem` to the scene and mark dirty.
+
+        Keyword arguments with ``None`` defaults let the caller pass
+        explicit geometry (e.g. from a deserialised flow) without
+        forcing every call site to re-import the defaults module.
+        """
+        kwargs: dict = {"title": title}
+        if width is not None:
+            kwargs["width"] = width
+        if height is not None:
+            kwargs["height"] = height
+        if color is not None:
+            kwargs["color"] = color
+        backdrop = BackdropItem(**kwargs)
+        self.addItem(backdrop)
+        if scene_pos is not None:
+            backdrop.setPos(scene_pos)
+        self._backdrops.append(backdrop)
+        self._mark_dirty()
+        return backdrop
+
+    def remove_backdrop(self, backdrop: BackdropItem) -> None:
+        if backdrop in self._backdrops:
+            self._backdrops.remove(backdrop)
+        self.removeItem(backdrop)
+        self._mark_dirty()
+
+    def iter_backdrops(self) -> list[BackdropItem]:
+        """Return a snapshot of every backdrop currently in the scene."""
+        return list(self._backdrops)
+
     # ── Pending-link drag ──────────────────────────────────────────────────────
 
     def mousePressEvent(self, event: QGraphicsSceneMouseEvent) -> None:  # type: ignore[override]
         from PySide6.QtCore import Qt
         if event.button() == Qt.MouseButton.LeftButton:
             port = self._port_at(event.scenePos())
-            if port is not None:
+            # A reroute's ports sit at the dot's centre, so they sit
+            # right where the user would click to drag the dot. Skip
+            # them as link-start targets so the press falls through to
+            # Qt's default ItemIsMovable handling and moves the reroute.
+            # (Drops *onto* a reroute port are still accepted — see
+            # mouseReleaseEvent — so new links can land on a reroute.)
+            if port is not None and not getattr(port.node_item, "is_reroute", False):
                 # Start a pending link from this port. Swallow the press
                 # so that neither the port nor the underlying node grabs
                 # the mouse — we want subsequent move / release events to
@@ -336,13 +389,25 @@ class FlowScene(QGraphicsScene):
         from PySide6.QtGui import QTransform
         views = self.views()
         xform = views[0].transform() if views else QTransform()
-        item = self.itemAt(event.scenePos(), xform)
-        # Walk up to a LinkItem if a label was clicked.
-        while item is not None and not isinstance(item, LinkItem):
+        raw_item = self.itemAt(event.scenePos(), xform)
+        # Walk up the parent chain so right-clicking a title / grip
+        # on a backdrop hits the BackdropItem, and right-clicking a
+        # link label hits the LinkItem.
+        item = raw_item
+        while item is not None:
+            if isinstance(item, (LinkItem, BackdropItem)):
+                break
             item = item.parentItem()
 
         if isinstance(item, LinkItem):
             self._link_context_menu(item, event)
+            return
+        if isinstance(item, BackdropItem):
+            self._backdrop_context_menu(item, event)
+            return
+        # Empty canvas → offer Add Backdrop.
+        if raw_item is None:
+            self._canvas_context_menu(event)
             return
         super().contextMenuEvent(event)
 
@@ -352,6 +417,59 @@ class FlowScene(QGraphicsScene):
         delete.triggered.connect(lambda: self._delete_link_item(link))
         menu.addAction(delete)
         menu.exec(event.screenPos())
+
+    def _canvas_context_menu(self, event: QGraphicsSceneContextMenuEvent) -> None:
+        menu = QMenu()
+        add = QAction("Add Backdrop", menu)
+        scene_pos = event.scenePos()
+        add.triggered.connect(lambda: self.add_backdrop(scene_pos))
+        menu.addAction(add)
+        menu.exec(event.screenPos())
+
+    def _backdrop_context_menu(
+        self, backdrop: BackdropItem, event: QGraphicsSceneContextMenuEvent,
+    ) -> None:
+        menu = QMenu()
+
+        rename = QAction("Rename…", menu)
+        rename.triggered.connect(lambda: self._prompt_rename_backdrop(backdrop))
+        menu.addAction(rename)
+
+        colour_menu = menu.addMenu("Colour")
+        for name, colour in BACKDROP_PRESETS.items():
+            act = QAction(name, colour_menu)
+            act.triggered.connect(
+                lambda _checked=False, c=colour: self._recolour_backdrop(backdrop, c)
+            )
+            colour_menu.addAction(act)
+
+        menu.addSeparator()
+        delete = QAction("Delete Backdrop", menu)
+        delete.triggered.connect(lambda: self.remove_backdrop(backdrop))
+        menu.addAction(delete)
+
+        menu.exec(event.screenPos())
+
+    def _prompt_rename_backdrop(self, backdrop: BackdropItem) -> None:
+        """Pop a tiny dialog to rename the backdrop.
+
+        Kept in the scene rather than on the backdrop item itself so
+        the input-dialog-vs-inline-edit decision can change later
+        without touching every BackdropItem.
+        """
+        from PySide6.QtWidgets import QInputDialog
+        views = self.views()
+        parent = views[0] if views else None
+        new_title, ok = QInputDialog.getText(
+            parent, "Rename Backdrop", "Title:", text=backdrop.title,
+        )
+        if ok and new_title != backdrop.title:
+            backdrop.set_title(new_title)
+            self._mark_dirty()
+
+    def _recolour_backdrop(self, backdrop: BackdropItem, colour) -> None:
+        backdrop.set_color(colour)
+        self._mark_dirty()
 
     # ── Mouse: double-click on a link inserts a reroute ────────────────────────
 
@@ -468,6 +586,8 @@ class FlowScene(QGraphicsScene):
                     self.remove_node_item(s)
                 elif isinstance(s, LinkItem):
                     self._delete_link_item(s)
+                elif isinstance(s, BackdropItem):
+                    self.remove_backdrop(s)
             event.accept()
             return
         super().keyPressEvent(event)

--- a/src/ui/flow_scene.py
+++ b/src/ui/flow_scene.py
@@ -16,9 +16,11 @@ from PySide6.QtWidgets import (
 
 from core.flow import Flow
 from core.node_base import NodeBase
+from nodes.util.reroute import Reroute
 from ui.link_item import LinkItem, PendingLinkItem
 from ui.node_item import NodeItem
 from ui.port_item import PortItem
+from ui.reroute_node_item import RerouteNodeItem
 
 if TYPE_CHECKING:
     from core.node_registry import NodeEntry
@@ -103,7 +105,12 @@ class FlowScene(QGraphicsScene):
     # ── Node operations ────────────────────────────────────────────────────────
 
     def add_node(self, node: NodeBase, scene_pos: QPointF | None = None) -> NodeItem:
-        item = NodeItem(node)
+        # Reroute nodes use a minimal "just a dot" item. Everything else
+        # gets the full header / params / buttons treatment.
+        if isinstance(node, Reroute):
+            item: NodeItem = RerouteNodeItem(node)
+        else:
+            item = NodeItem(node)
         item.signals.param_changed.connect(self.param_changed)
         self.addItem(item)
         if scene_pos is not None:
@@ -127,12 +134,39 @@ class FlowScene(QGraphicsScene):
         return self.add_node(node, scene_pos)
 
     def remove_node_item(self, item: NodeItem) -> None:
-        """Remove a node and every link attached to its ports."""
+        """Remove a node and every link attached to its ports.
+
+        Deleting a :class:`Reroute` preserves the data flow: after
+        removal, every downstream that used to consume the reroute's
+        output is re-linked directly to the reroute's upstream. Any
+        reconnection that would fail type-checking is silently dropped
+        (the graph stays strictly-typed; the user just loses that
+        branch rather than crashing).
+        """
+        bridge_src: PortItem | None = None
+        bridge_dsts: list[PortItem] = []
+        if isinstance(item, RerouteNodeItem):
+            in_links = item.input_ports[0].links
+            out_links = item.output_ports[0].links
+            if in_links:
+                bridge_src = in_links[0].src_port
+            bridge_dsts = [link.dst_port for link in out_links]
+
         # Delete attached links first so Flow.disconnect runs cleanly.
         for port in [*item.input_ports, *item.output_ports]:
             for link in list(port.links):
                 self._delete_link_item(link)
         self._delete_node_item(item)
+
+        if bridge_src is not None:
+            for dst in bridge_dsts:
+                try:
+                    self.connect_ports(bridge_src, dst)
+                except TypeError:
+                    logger.debug(
+                        "Skipping reroute-bridge reconnect (type mismatch)",
+                        exc_info=True,
+                    )
 
     # ── Layout helpers ─────────────────────────────────────────────────────────
 
@@ -318,6 +352,53 @@ class FlowScene(QGraphicsScene):
         delete.triggered.connect(lambda: self._delete_link_item(link))
         menu.addAction(delete)
         menu.exec(event.screenPos())
+
+    # ── Mouse: double-click on a link inserts a reroute ────────────────────────
+
+    def mouseDoubleClickEvent(self, event: QGraphicsSceneMouseEvent) -> None:  # type: ignore[override]
+        """Double-click on a link → split it with a reroute at the cursor.
+
+        A reroute is a zero-logic pass-through (see :class:`Reroute`);
+        the existing link is deleted and replaced by two new links,
+        ``src → reroute`` and ``reroute → dst``. All other types of
+        items (nodes, ports, empty canvas) fall through to the default
+        handler.
+        """
+        from PySide6.QtGui import QTransform
+        from PySide6.QtCore import Qt
+        if event.button() != Qt.MouseButton.LeftButton:
+            super().mouseDoubleClickEvent(event)
+            return
+
+        views = self.views()
+        xform = views[0].transform() if views else QTransform()
+        item = self.itemAt(event.scenePos(), xform)
+        while item is not None and not isinstance(item, LinkItem):
+            item = item.parentItem()
+
+        if isinstance(item, LinkItem):
+            self._insert_reroute_on_link(item, event.scenePos())
+            event.accept()
+            return
+        super().mouseDoubleClickEvent(event)
+
+    def _insert_reroute_on_link(self, link: LinkItem, pos: QPointF) -> None:
+        """Replace ``link`` with a reroute positioned at ``pos``.
+
+        Records the old src / dst ports, deletes the link, instantiates
+        a :class:`Reroute` node at the click point, then wires both
+        halves. Dirty bookkeeping and flow-model updates flow through
+        the existing add_node / connect_ports paths, so nothing special
+        needs to happen here beyond ordering.
+        """
+        src = link.src_port
+        dst = link.dst_port
+        self._delete_link_item(link)
+
+        node = Reroute()
+        item = self.add_node(node, pos)
+        self.connect_ports(src, item.input_ports[0])
+        self.connect_ports(item.output_ports[0], dst)
 
     # ── Selection → signal ─────────────────────────────────────────────────────
 

--- a/src/ui/link_item.py
+++ b/src/ui/link_item.py
@@ -47,10 +47,23 @@ class LinkItem(QGraphicsPathItem):
     # ── Path ───────────────────────────────────────────────────────────────────
 
     def update_path(self) -> None:
-        """Recompute the bezier from src_port to dst_port."""
+        """Recompute the bezier from src_port to dst_port.
+
+        Reroute endpoints use a "free" tangent that points towards the
+        other endpoint, so a link passing through a reroute renders as
+        one smooth S-curve instead of two horizontally-tangent arcs
+        that would loop back on themselves whenever the reroute sits
+        above / behind its neighbour.
+        """
         src = self._src_port.scenePos()
         dst = self._dst_port.scenePos()
-        self.setPath(_bezier_path(src, dst))
+        self.setPath(
+            _bezier_path(
+                src, dst,
+                src_tangent=_tangent_for(self._src_port),
+                dst_tangent=_tangent_for(self._dst_port),
+            )
+        )
 
     def paint(self, painter, option, widget=None) -> None:  # type: ignore[override]
         pen = QPen(LINK_SELECTED_COLOR if self.isSelected() else LINK_COLOR, 2)
@@ -67,16 +80,47 @@ class LinkItem(QGraphicsPathItem):
         self._dst_port.remove_link(self)
 
 
-def _bezier_path(src: QPointF, dst: QPointF) -> QPainterPath:
-    """Horizontal-tangent cubic bezier between two points.
+def _tangent_for(port_item) -> QPointF | None:
+    """Return the unit tangent vector the bezier should follow at ``port_item``.
 
-    Good default look for left-to-right node editors: tangents always
-    leave an output port rightward and enter an input port rightward.
+    Ports on a standard node are fixed: outputs point rightward,
+    inputs accept from the right. A port on a reroute has no preferred
+    direction — return ``None`` so the bezier picks a tangent aimed at
+    the other endpoint, which gives smooth S-curves for mäandrierende
+    Flows (Blender / UE style).
+    """
+    if getattr(port_item.node_item, "is_reroute", False):
+        return None
+    return QPointF(1.0, 0.0) if port_item.kind == "output" else QPointF(-1.0, 0.0)
+
+
+def _bezier_path(
+    src: QPointF,
+    dst: QPointF,
+    *,
+    src_tangent: QPointF | None,
+    dst_tangent: QPointF | None,
+) -> QPainterPath:
+    """Cubic bezier between two points with configurable endpoint tangents.
+
+    ``*_tangent`` is a unit vector pointing *out of* the endpoint along
+    the bezier's first derivative. Passing ``None`` means "free" — the
+    tangent is aimed at the other endpoint, so a reroute-anchored link
+    curves naturally towards its neighbour instead of being forced to
+    leave horizontally.
     """
     path = QPainterPath(src)
     dx = max(60.0, abs(dst.x() - src.x()) * 0.5)
-    ctrl1 = QPointF(src.x() + dx, src.y())
-    ctrl2 = QPointF(dst.x() - dx, dst.y())
+
+    def _offset(tangent: QPointF | None, anchor: QPointF, other: QPointF) -> QPointF:
+        if tangent is not None:
+            return QPointF(tangent.x() * dx, tangent.y() * dx)
+        # Free tangent: point from anchor toward the other endpoint,
+        # scaled so the curve has comparable bend to the fixed case.
+        return QPointF((other.x() - anchor.x()) * 0.4, (other.y() - anchor.y()) * 0.4)
+
+    ctrl1 = src + _offset(src_tangent, src, dst)
+    ctrl2 = dst + _offset(dst_tangent, dst, src)
     path.cubicTo(ctrl1, ctrl2, dst)
     return path
 
@@ -99,4 +143,13 @@ class PendingLinkItem(QGraphicsPathItem):
         self._rebuild()
 
     def _rebuild(self) -> None:
-        self.setPath(_bezier_path(self._start, self._end))
+        # The pending (drag-in-progress) link doesn't have a second
+        # endpoint yet, so just use the classic horizontal tangents.
+        # The tangent shape only matters once the drop target is known.
+        self.setPath(
+            _bezier_path(
+                self._start, self._end,
+                src_tangent=QPointF(1.0, 0.0),
+                dst_tangent=QPointF(-1.0, 0.0),
+            )
+        )

--- a/src/ui/node_list.py
+++ b/src/ui/node_list.py
@@ -32,6 +32,12 @@ _SECTION_ORDER: tuple[str, ...] = (
     "Composit",
 )
 
+#: Sections whose nodes are created implicitly by the editor (e.g.
+#: reroutes inserted via double-click on a link) and must not appear
+#: in the drag-and-drop palette. The string must match what a node
+#: declares in its ``super().__init__(section=...)`` call.
+_HIDDEN_SECTIONS: frozenset[str] = frozenset({"__hidden__"})
+
 
 class NodeList(QWidget):
     """Palette listing every registered node grouped by the ``section``
@@ -66,7 +72,11 @@ class NodeList(QWidget):
     # ── Internals ──────────────────────────────────────────────────────────────
 
     def _populate(self, registry: NodeRegistry) -> None:
-        grouped = registry.nodes_by_section()
+        grouped = {
+            section: entries
+            for section, entries in registry.nodes_by_section().items()
+            if section not in _HIDDEN_SECTIONS
+        }
         # Render well-known sections first in canonical order, then any
         # novel sections (e.g. from user plugins) in registry order.
         seen: set[str] = set()

--- a/src/ui/reroute_node_item.py
+++ b/src/ui/reroute_node_item.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from PySide6.QtCore import QRectF, Qt
+from PySide6.QtGui import QBrush, QPainter, QPen
+from PySide6.QtWidgets import QGraphicsItem
+
+from ui.node_item import NodeItem, _NodeSignals
+from ui.port_item import PortItem
+from ui.theme import LINK_COLOR, NODE_BORDER_SELECTED
+
+if TYPE_CHECKING:
+    from core.node_base import NodeBase
+
+
+class RerouteNodeItem(NodeItem):
+    """Tiny pass-through dot used to bend a link around other nodes.
+
+    Inherits from :class:`NodeItem` so that every ``isinstance`` check
+    in the scene, selection handler and serialiser keeps working, but
+    replaces the heavyweight ``__init__`` with a minimal one: no
+    header, no params widget, no close/skip/resize buttons. The item
+    is simply a small draggable circle that carries one input and one
+    output :class:`PortItem`, both centred on the dot so links appear
+    to pass straight through.
+
+    Visual: ~10 px circle in the standard link colour, with a thicker
+    amber outline when selected — same affordance as a selected link.
+    """
+
+    #: Radius of the visible dot.
+    RADIUS: float = 5.0
+    #: Forgiving hit-box radius — slightly larger than the dot so the
+    #: user doesn't need pixel-perfect aim to pick a reroute up.
+    HIT_RADIUS: float = 8.0
+
+    def __init__(self, node: NodeBase) -> None:
+        # Deliberately skip NodeItem.__init__ — its full header / params /
+        # buttons setup is exactly what a reroute is meant to avoid. Go
+        # straight to QGraphicsItem so the base Qt state is initialised
+        # and then hand-set only the attributes the rest of the code
+        # (flow_scene, flow_io, link_item) reads off a node item.
+        QGraphicsItem.__init__(self)
+        self._node = node
+        self._signals = _NodeSignals()
+        self._input_ports: list[PortItem] = []
+        self._output_ports: list[PortItem] = []
+        # NodeItem consumers read these to lay out resize handles and
+        # serialise user-set geometry. A reroute has no resizable body,
+        # so they're fixed at the dot's diameter and never change.
+        self._width: float = 2 * self.RADIUS
+        self._body_height: float = 2 * self.RADIUS
+        self._user_width: float | None = None
+        self._user_height: float | None = None
+
+        self.setZValue(NodeItem.Z_VALUE)
+        self.setFlag(QGraphicsItem.GraphicsItemFlag.ItemIsMovable, True)
+        self.setFlag(QGraphicsItem.GraphicsItemFlag.ItemIsSelectable, True)
+        self.setFlag(
+            QGraphicsItem.GraphicsItemFlag.ItemSendsScenePositionChanges, True,
+        )
+        self.setAcceptHoverEvents(False)
+
+        # Both ports sit at the dot's centre so links appear to pass
+        # through it without a visible kink. The PortItem constructor
+        # already parents to this item, so they'll move with the dot.
+        in_port = PortItem(self, "input", 0, node.inputs[0])
+        out_port = PortItem(self, "output", 0, node.outputs[0])
+        in_port.setPos(0, 0)
+        out_port.setPos(0, 0)
+        self._input_ports.append(in_port)
+        self._output_ports.append(out_port)
+
+    # ── NodeItem API (minimal overrides) ───────────────────────────────────────
+
+    @property
+    def is_reroute(self) -> bool:
+        """True — used by :class:`~ui.link_item.LinkItem` to pick
+        free-tangent bezier routing instead of the default horizontal
+        one."""
+        return True
+
+    @property
+    def body_height(self) -> float:  # type: ignore[override]
+        return self._body_height
+
+    @property
+    def width(self) -> float:  # type: ignore[override]
+        return self._width
+
+    @property
+    def user_size(self) -> tuple[float | None, float | None]:  # type: ignore[override]
+        # Reroutes don't persist a user size — they're always the
+        # built-in dot. Returning (None, None) tells flow_io not to
+        # emit a "size" entry for this node on save.
+        return (None, None)
+
+    def apply_user_size(self, width: float, height: float) -> None:  # type: ignore[override]
+        # Older flows might carry a "size" entry from an accidental
+        # save; ignore it rather than resizing the dot.
+        return
+
+    def refresh_all_links(self) -> None:  # type: ignore[override]
+        for port in (*self._input_ports, *self._output_ports):
+            port.refresh_links()
+
+    def boundingRect(self) -> QRectF:  # type: ignore[override]
+        r = self.HIT_RADIUS
+        return QRectF(-r, -r, 2 * r, 2 * r)
+
+    def paint(self, painter: QPainter, option, widget=None) -> None:  # type: ignore[override]
+        painter.setRenderHint(QPainter.RenderHint.Antialiasing, True)
+        pen_color = NODE_BORDER_SELECTED if self.isSelected() else LINK_COLOR
+        painter.setPen(QPen(pen_color, 1.5))
+        painter.setBrush(QBrush(LINK_COLOR))
+        r = self.RADIUS
+        painter.drawEllipse(QRectF(-r, -r, 2 * r, 2 * r))
+
+    def itemChange(self, change, value):  # type: ignore[override]
+        # Keep the two port items in sync with the dot's position so
+        # the link bezier stays glued to the reroute as it's dragged.
+        if change == QGraphicsItem.GraphicsItemChange.ItemScenePositionHasChanged:
+            self.refresh_all_links()
+        return super().itemChange(change, value)

--- a/tests/test_backdrop.py
+++ b/tests/test_backdrop.py
@@ -1,0 +1,146 @@
+"""Tests for Backdrop scene items and their flow-file round-trip."""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+pytest.importorskip("PySide6")
+
+from PySide6.QtCore import QPointF
+from PySide6.QtGui import QColor
+from PySide6.QtWidgets import QApplication
+
+from core.flow import Flow
+from ui.backdrop_item import (
+    BackdropItem,
+    DEFAULT_BACKDROP_COLOR,
+    MIN_BACKDROP_HEIGHT,
+    MIN_BACKDROP_WIDTH,
+)
+from ui.flow_io import load_flow_into, save_flow_to, serialize_flow
+from ui.flow_scene import FlowScene
+
+
+@pytest.fixture(scope="module")
+def qapp() -> QApplication:
+    return QApplication.instance() or QApplication(sys.argv)
+
+
+def test_backdrop_default_geometry_matches_module_constants(qapp: QApplication) -> None:
+    backdrop = BackdropItem()
+    assert backdrop.title == "Backdrop"
+    assert backdrop.color.red() == DEFAULT_BACKDROP_COLOR.red()
+    assert backdrop.width > 0 and backdrop.height > 0
+
+
+def test_backdrop_set_size_enforces_minimum(qapp: QApplication) -> None:
+    """Dragging the grip past the minimum must clamp, not collapse
+    the frame into an unclickable sliver."""
+    backdrop = BackdropItem()
+    backdrop.set_size(10, 10)
+    assert backdrop.width == MIN_BACKDROP_WIDTH
+    assert backdrop.height == MIN_BACKDROP_HEIGHT
+
+
+def test_add_backdrop_tracks_it_in_the_scene(qapp: QApplication) -> None:
+    scene = FlowScene()
+    scene.set_flow(Flow(name="backdrop"))
+    backdrop = scene.add_backdrop(QPointF(40, 50), title="Group")
+    assert backdrop in scene.iter_backdrops()
+    assert backdrop.pos().x() == 40
+    assert backdrop.title == "Group"
+
+
+def test_add_backdrop_marks_scene_dirty(qapp: QApplication) -> None:
+    scene = FlowScene()
+    scene.set_flow(Flow(name="backdrop"))
+    assert scene.is_dirty is False
+    scene.add_backdrop(QPointF(0, 0))
+    assert scene.is_dirty is True
+
+
+def test_remove_backdrop_drops_it_and_marks_dirty(qapp: QApplication) -> None:
+    scene = FlowScene()
+    scene.set_flow(Flow(name="backdrop"))
+    backdrop = scene.add_backdrop(QPointF(0, 0))
+    scene.mark_saved()
+    assert scene.is_dirty is False
+    scene.remove_backdrop(backdrop)
+    assert backdrop not in scene.iter_backdrops()
+    assert scene.is_dirty is True
+
+
+def test_serialize_backdrops_emits_geometry_and_colour(qapp: QApplication) -> None:
+    scene = FlowScene()
+    flow = Flow(name="backdrop")
+    scene.set_flow(flow)
+    scene.add_backdrop(
+        QPointF(10, 20),
+        title="Chapter",
+        width=240,
+        height=160,
+        color=QColor(30, 40, 50, 180),
+    )
+    data = serialize_flow(scene, flow)
+    assert data["backdrops"] == [{
+        "position": [10.0, 20.0],
+        "size":     [240.0, 160.0],
+        "title":    "Chapter",
+        "color":    [30, 40, 50, 180],
+    }]
+
+
+def test_backdrops_round_trip_through_save_and_load(
+    qapp: QApplication, tmp_path: Path,
+) -> None:
+    """Save a flow with a backdrop, load it back into a fresh scene,
+    and check every persisted property survived intact."""
+    scene = FlowScene()
+    flow = Flow(name="backdrop_roundtrip")
+    scene.set_flow(flow)
+    scene.add_backdrop(
+        QPointF(100, 50),
+        title="Mask prep",
+        width=300,
+        height=180,
+        color=QColor(40, 70, 50, 140),
+    )
+
+    path = tmp_path / "bd.flowjs"
+    save_flow_to(path, scene, flow)
+
+    fresh_scene = FlowScene()
+    load_flow_into(path, fresh_scene)
+    backdrops = fresh_scene.iter_backdrops()
+    assert len(backdrops) == 1
+    b = backdrops[0]
+    assert b.title == "Mask prep"
+    assert b.width == 300
+    assert b.height == 180
+    assert b.pos().x() == 100 and b.pos().y() == 50
+    assert (b.color.red(), b.color.green(), b.color.blue(), b.color.alpha()) == (40, 70, 50, 140)
+
+
+def test_loading_flow_without_backdrops_field_is_fine(
+    qapp: QApplication, tmp_path: Path,
+) -> None:
+    """Older flow files (pre-backdrop) lack the "backdrops" key. The
+    loader must treat the absence as "no backdrops" rather than
+    throwing a KeyError."""
+    path = tmp_path / "old.flowjs"
+    path.write_text(json.dumps({
+        "version":     1,
+        "app_version": "0.1.16",
+        "name":        "old",
+        "nodes":       [],
+        "connections": [],
+    }), encoding="utf-8")
+
+    scene = FlowScene()
+    load_flow_into(path, scene)
+    assert scene.iter_backdrops() == []

--- a/tests/test_reroute.py
+++ b/tests/test_reroute.py
@@ -1,0 +1,161 @@
+"""Tests for the Reroute pass-through node.
+
+Covers the core contract (pass-through semantics, port typing) in
+pure Python, plus the editor-side behaviour (double-click inserts,
+delete-reconnect) under a headless Qt application.
+"""
+from __future__ import annotations
+
+import os
+import sys
+
+import numpy as np
+import pytest
+
+from core.io_data import IMAGE_TYPES, IoData, IoDataType
+from core.port import InputPort
+from nodes.util.reroute import Reroute
+
+
+# ── Core contract ──────────────────────────────────────────────────────────────
+
+
+def test_reroute_has_one_input_and_one_output_both_image_types() -> None:
+    node = Reroute()
+    assert len(node.inputs) == 1
+    assert len(node.outputs) == 1
+    assert node.inputs[0].accepted_types == frozenset(IMAGE_TYPES)
+    assert node.outputs[0].emits == frozenset(IMAGE_TYPES)
+
+
+def test_reroute_forwards_input_payload_verbatim() -> None:
+    """process_impl(inputs[0].data) → outputs[0]; the IoData object
+    is sent through as-is, no copy, no type change."""
+    node = Reroute()
+    capture = InputPort("cap", set(IMAGE_TYPES))
+    node.outputs[0].connect(capture)
+
+    payload = IoData.from_image(np.full((4, 4, 3), 42, dtype=np.uint8))
+    node.inputs[0].receive(payload)  # triggers dispatch
+
+    assert capture.has_data
+    assert capture.data is payload  # identity, not just equality
+
+
+def test_reroute_preserves_greyscale_type() -> None:
+    """A grey frame entering a reroute must emerge as IMAGE_GREY, not
+    silently demoted to IMAGE. The pass-through uses the original
+    IoData object, so the type discriminator is preserved."""
+    node = Reroute()
+    capture = InputPort("cap", set(IMAGE_TYPES))
+    node.outputs[0].connect(capture)
+
+    grey = IoData.from_greyscale(np.full((4, 4), 77, dtype=np.uint8))
+    node.inputs[0].receive(grey)
+
+    assert capture.data.type == IoDataType.IMAGE_GREY
+
+
+def test_reroute_is_marked_hidden_from_palette() -> None:
+    """The Reroute uses the "__hidden__" section sentinel so the
+    palette scanner can filter it out — only the editor's
+    double-click-to-insert flow should ever create one."""
+    assert Reroute().section == "__hidden__"
+
+
+# ── Editor behaviour (needs Qt) ────────────────────────────────────────────────
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+pytest.importorskip("PySide6")
+
+from PySide6.QtCore import QPointF
+from PySide6.QtWidgets import QApplication
+
+from core.flow import Flow
+from nodes.filters.grayscale import Grayscale
+from nodes.sources.image_source import ImageSource
+from ui.flow_scene import FlowScene
+from ui.reroute_node_item import RerouteNodeItem
+
+
+@pytest.fixture(scope="module")
+def qapp() -> QApplication:
+    return QApplication.instance() or QApplication(sys.argv)
+
+
+def _wired_scene() -> tuple[FlowScene, "LinkItem"]:
+    """Return a fresh scene with Source → Grayscale and the joining link."""
+    scene = FlowScene()
+    scene.set_flow(Flow(name="reroute_test"))
+    src = scene.add_node(ImageSource(), QPointF(0, 0))
+    dst = scene.add_node(Grayscale(), QPointF(400, 0))
+    link = scene.connect_ports(src.output_ports[0], dst.input_ports[0])
+    assert link is not None
+    return scene, link
+
+
+def test_insert_reroute_on_link_replaces_it_with_two_links(
+    qapp: QApplication,
+) -> None:
+    scene, link = _wired_scene()
+    scene._insert_reroute_on_link(link, QPointF(200, 0))
+
+    # Original link is gone; two new links plus one reroute node exist.
+    items = scene.iter_node_items()
+    reroutes = [it for it in items if isinstance(it, RerouteNodeItem)]
+    assert len(reroutes) == 1
+    assert len(scene.iter_links()) == 2
+
+
+def test_insert_reroute_preserves_source_to_sink_path(
+    qapp: QApplication,
+) -> None:
+    """After insertion, the source's output still reaches the sink's
+    input via the reroute — the graph semantics haven't changed."""
+    scene, link = _wired_scene()
+    src_port = link.src_port
+    dst_port = link.dst_port
+    scene._insert_reroute_on_link(link, QPointF(200, 0))
+
+    [reroute_item] = [
+        it for it in scene.iter_node_items() if isinstance(it, RerouteNodeItem)
+    ]
+    # src → reroute.in, reroute.out → dst
+    assert reroute_item.input_ports[0].model.upstream is src_port.model
+    assert dst_port.model.upstream is reroute_item.output_ports[0].model
+
+
+def test_deleting_reroute_reconnects_upstream_to_downstream(
+    qapp: QApplication,
+) -> None:
+    """A reroute is a pure visual aid — removing it must re-join its
+    two halves so the pipeline keeps working."""
+    scene, link = _wired_scene()
+    src_port = link.src_port
+    dst_port = link.dst_port
+    scene._insert_reroute_on_link(link, QPointF(200, 0))
+
+    [reroute_item] = [
+        it for it in scene.iter_node_items() if isinstance(it, RerouteNodeItem)
+    ]
+    scene.remove_node_item(reroute_item)
+
+    # No reroutes left; a single direct link reconnects src to dst.
+    assert all(
+        not isinstance(it, RerouteNodeItem) for it in scene.iter_node_items()
+    )
+    assert dst_port.model.upstream is src_port.model
+    assert len(scene.iter_links()) == 1
+
+
+def test_reroute_is_serialisable_as_a_regular_node(qapp: QApplication) -> None:
+    """Reroutes use the normal NodeBase serialisation path, so they
+    round-trip through flow_io without special-case code."""
+    from ui.flow_io import serialize_flow
+
+    scene, link = _wired_scene()
+    scene._insert_reroute_on_link(link, QPointF(200, 0))
+    data = serialize_flow(scene, scene.flow)
+
+    classes = {(n["module"], n["class"]) for n in data["nodes"]}
+    assert ("nodes.util.reroute", "Reroute") in classes


### PR DESCRIPTION
**Closed in favour of a backdrops-only PR.**

The reroute-related work in this branch had two unresolved UX bugs (link-from-reroute-port hijacking the dot's drag, straight lines between back-to-back reroutes) and is being shelved to keep the backdrops feature unblocked. A new branch will land the backdrop changes against current `main` without the reroute code.

https://claude.ai/code/session_01JZ3D7ive83Qrb3NjyZS8dM