### PR TITLE
Add backdrops for grouping nodes on the canvas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,9 +23,14 @@ once a first tagged release is cut.
   the moment another node sits on top of it, so backdrops with one
   grip are effectively unusable in a real flow. Each grip pins the
   opposite corner during a drag, so resizing feels predictable from
-  every direction. Persisted alongside nodes and connections in the
-  flow file under a new `backdrops` entry; older flows without the
-  field load unchanged.
+  every direction. Backdrops also carry a **capture toggle** (push-pin
+  glyph in the header): with capture on, dragging the backdrop sweeps
+  every fully enclosed node along by the same delta, so a backdrop
+  doubles as an ad-hoc grouping handle. The captured set is locked in
+  at press-time, so a node that wasn't framed when the drag started
+  doesn't get vacuumed up mid-flight. Persisted alongside nodes and
+  connections in the flow file under a new `backdrops` entry; older
+  flows without the field load unchanged.
 
 ## [0.1.16] — 2026-04-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,11 +17,15 @@ once a first tagged release is cut.
   nodes so dense pipelines can be annotated as loose chapter
   headings (e.g. "Colour prep", "Alpha mask"). Right-click an empty
   canvas to drop one; right-click the backdrop itself for rename /
-  colour preset / delete; resize via the bottom-right grip; Delete
-  key removes a selected backdrop. Persisted alongside nodes and
-  connections in the flow file under a new `backdrops` entry. Older
-  flows without the field load unchanged — the loader treats the
-  absence as "no backdrops".
+  colour preset / delete. Each backdrop carries an `X` close button
+  in its header (matching every regular node) and a resize grip on
+  *all four corners* — a single bottom-right grip is unreachable
+  the moment another node sits on top of it, so backdrops with one
+  grip are effectively unusable in a real flow. Each grip pins the
+  opposite corner during a drag, so resizing feels predictable from
+  every direction. Persisted alongside nodes and connections in the
+  flow file under a new `backdrops` entry; older flows without the
+  field load unchanged.
 
 ## [0.1.16] — 2026-04-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,24 +13,38 @@ once a first tagged release is cut.
 ## [0.1.17] — 2026-04-24
 
 ### Added
-- **Backdrops.** Coloured rectangular frames drawn behind groups of
-  nodes so dense pipelines can be annotated as loose chapter
-  headings (e.g. "Colour prep", "Alpha mask"). Right-click an empty
-  canvas to drop one; right-click the backdrop itself for rename /
-  colour preset / delete. Each backdrop carries an `X` close button
-  in its header (matching every regular node) and a resize grip on
-  *all four corners* — a single bottom-right grip is unreachable
-  the moment another node sits on top of it, so backdrops with one
-  grip are effectively unusable in a real flow. Each grip pins the
-  opposite corner during a drag, so resizing feels predictable from
-  every direction. Backdrops also carry a **capture toggle** (push-pin
-  glyph in the header): with capture on, dragging the backdrop sweeps
-  every fully enclosed node along by the same delta, so a backdrop
-  doubles as an ad-hoc grouping handle. The captured set is locked in
-  at press-time, so a node that wasn't framed when the drag started
-  doesn't get vacuumed up mid-flight. Persisted alongside nodes and
-  connections in the flow file under a new `backdrops` entry; older
-  flows without the field load unchanged.
+- **Backdrops + Create Group.** Coloured rectangular frames drawn
+  behind groups of nodes so dense pipelines can be annotated as
+  loose chapter headings (e.g. "Colour prep", "Alpha mask"). The
+  primary creation path is **Create Group**: select two or more
+  nodes, then either click the new toolbar Group button (in a
+  selection-only section together with V-Stack / H-Stack — the whole
+  section appears when there's a multi-node selection and disappears
+  again when there isn't) or right-click empty canvas → "Create
+  Group". The backdrop is auto-fitted around the selection's
+  bounding box with a generous padding. Each backdrop carries an
+  `X` close button in its header and resize grips on all four
+  corners (one bottom-right grip is unreachable the moment another
+  node sits on top of it; each grip pins the opposite corner during
+  a drag and clamps without letting the anchor drift). Right-click
+  the backdrop for rename / colour preset / delete. **Dragging a
+  backdrop sweeps every fully enclosed node along** — the framed set
+  is snapshot at press-time, so nodes that weren't framed when the
+  drag started don't get vacuumed up mid-flight. Persisted
+  alongside nodes and connections in the flow file under a new
+  `backdrops` entry; older flows without the field load unchanged.
+
+### Changed
+- ``PageBase`` gains a ``toolbar_layout_changed`` signal so a page
+  can ask MainWindow to rebuild the toolbar when its
+  ``page_toolbar_sections`` answer would change at runtime — used
+  by the editor to add / remove the "Selection" section as the
+  multi-node selection comes and goes.
+- The empty-canvas right-click no longer clears the scene's
+  selection — Qt's default mousePress handler used to deselect
+  everything an instant before the context menu opened, which
+  killed any multi-node selection right before "Create Group" could
+  read it.
 
 ## [0.1.16] — 2026-04-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,19 @@ once a first tagged release is cut.
 
 ## [Unreleased]
 
+## [0.1.17] — 2026-04-24
+
+### Added
+- **Backdrops.** Coloured rectangular frames drawn behind groups of
+  nodes so dense pipelines can be annotated as loose chapter
+  headings (e.g. "Colour prep", "Alpha mask"). Right-click an empty
+  canvas to drop one; right-click the backdrop itself for rename /
+  colour preset / delete; resize via the bottom-right grip; Delete
+  key removes a selected backdrop. Persisted alongside nodes and
+  connections in the flow file under a new `backdrops` entry. Older
+  flows without the field load unchanged — the loader treats the
+  absence as "no backdrops".
+
 ## [0.1.16] — 2026-04-24
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,17 +22,18 @@ once a first tagged release is cut.
   section appears when there's a multi-node selection and disappears
   again when there isn't) or right-click empty canvas → "Create
   Group". The backdrop is auto-fitted around the selection's
-  bounding box with a generous padding. Each backdrop carries an
-  `X` close button in its header and resize grips on all four
-  corners (one bottom-right grip is unreachable the moment another
-  node sits on top of it; each grip pins the opposite corner during
-  a drag and clamps without letting the anchor drift). Right-click
-  the backdrop for rename / colour preset / delete. **Dragging a
-  backdrop sweeps every fully enclosed node along** — the framed set
-  is snapshot at press-time, so nodes that weren't framed when the
-  drag started don't get vacuumed up mid-flight. Persisted
-  alongside nodes and connections in the flow file under a new
-  `backdrops` entry; older flows without the field load unchanged.
+  bounding box with a generous padding, so frame size is correct
+  the moment it's created and never has to be adjusted. Each
+  backdrop carries an `X` close button in its header and a
+  right-click menu for rename / colour preset / delete; the frame
+  is intentionally not interactively resizable — the framed group's
+  contents are expected to evolve, not the frame itself.
+  **Dragging a backdrop sweeps every fully enclosed node along** —
+  the framed set is snapshot at press-time, so nodes that weren't
+  framed when the drag started don't get vacuumed up mid-flight.
+  Persisted alongside nodes and connections in the flow file under
+  a new `backdrops` entry; older flows without the field load
+  unchanged.
 
 ### Changed
 - ``PageBase`` gains a ``toolbar_layout_changed`` signal so a page

--- a/doc/welcome.html
+++ b/doc/welcome.html
@@ -164,7 +164,7 @@
   <main class="content-col">
 
     <header class="hero">
-      <h1>Welcome to Stjörnhorn <span class="version">v0.1.16</span></h1>
+      <h1>Welcome to Stjörnhorn <span class="version">v0.1.17</span></h1>
       <div class="tagline">A node-based image- and video-processing playground.</div>
     </header>
 
@@ -197,13 +197,12 @@
     </section>
 
     <section>
-      <h2>What's new in v0.1.16</h2>
+      <h2>What's new in v0.1.17</h2>
       <ul class="tips">
-        <li><strong>Video Source paths are now portable</strong> — flows that reference a video under the <code>input/</code> folder save as short relative names and resolve them the same way as image sources, regardless of the working directory.</li>
+        <li><strong>Backdrops</strong> — right-click empty canvas to drop a coloured frame behind a group of nodes. Use them as loose chapter headings ("Colour prep", "Alpha mask") so large flows stay readable.</li>
+        <li><strong>Video Source paths are now portable</strong> (v0.1.16) — video references under the <code>input/</code> folder save as short relative names and resolve them the same way as image sources, regardless of the working directory.</li>
         <li><strong>Unsaved-changes indicator</strong> (v0.1.15) — the editor's toolbar shows an amber warning icon with "Unsaved changes" the moment a parameter, node, or connection is edited, and clears it on save, load, or reload.</li>
         <li><strong>Reload</strong> toolbar action (v0.1.15) re-reads the current flow from disk, discarding unsaved edits after a confirmation.</li>
-        <li><strong>Python runtime</strong> (v0.1.15) appears in the toolbar and is written to the log at startup, so bug reports always include which interpreter the app was bound to.</li>
-        <li><strong>RGBA-aware split/join + per-pixel Overlay alpha</strong> (v0.1.14) — the Overlay node now honours the overlay image's alpha channel as a per-pixel blend mask; <code>RgbaSplit</code> / <code>RgbaJoin</code> supersede the RGB-only nodes, with the alpha port marked optional so old 3-channel flows keep working.</li>
       </ul>
     </section>
 

--- a/flow/rgb_dither.flowjs
+++ b/flow/rgb_dither.flowjs
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "app_version": "0.1.16",
+  "app_version": "0.1.17",
   "name": "rgb_dither",
   "nodes": [
     {
@@ -28,8 +28,8 @@
       "module": "nodes.sinks.file_sink",
       "class": "FileSink",
       "position": [
-        -613.0,
-        -600.0
+        -799.3448237173192,
+        -615.3036811748523
       ],
       "params": {
         "output_path": "out.png"
@@ -40,8 +40,8 @@
       "module": "nodes.sources.image_source",
       "class": "ImageSource",
       "position": [
-        -1788.9559912621874,
-        -669.0594064681123
+        -1520.6914624324236,
+        -1003.9399592354686
       ],
       "params": {
         "file_path": "ship.jpg"
@@ -88,13 +88,13 @@
       "module": "nodes.filters.display",
       "class": "Display",
       "position": [
-        -946.0822962547235,
-        -1065.9314930931341
+        -922.6766662225965,
+        -1101.940154681022
       ],
       "params": {},
       "size": [
-        317.8491968384102,
-        284.40150607302803
+        488.8903393808771,
+        430.2365855039735
       ]
     }
   ],
@@ -152,6 +152,25 @@
       "src_output": 0,
       "dst_node": 2,
       "dst_input": 0
+    }
+  ],
+  "backdrops": [
+    {
+      "position": [
+        -1535.4279939393775,
+        -835.9546588863568
+      ],
+      "size": [
+        594.1347552286093,
+        450.0
+      ],
+      "title": "Processing",
+      "color": [
+        70,
+        60,
+        40,
+        140
+      ]
     }
   ]
 }

--- a/src/constants.py
+++ b/src/constants.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 APP_NAME:         str = "Image-Inquest"
 APP_DISPLAY_NAME: str = "Stjörnhorn"
-APP_VERSION:      str = "0.1.16"
+APP_VERSION:      str = "0.1.17"
 API_URL:    str = "https://beltoforion.de"
 
 # Bundled documentation (offline welcome page, screenshots, …)

--- a/src/ui/backdrop_item.py
+++ b/src/ui/backdrop_item.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from enum import Enum
 from typing import TYPE_CHECKING
 
-from PySide6.QtCore import QPointF, QRectF, Qt, QTimer
+from PySide6.QtCore import QPointF, QRectF, QSize, Qt, QTimer
 from PySide6.QtGui import (
     QBrush,
     QColor,
@@ -14,6 +14,7 @@ from PySide6.QtGui import (
 )
 from PySide6.QtWidgets import QGraphicsItem
 
+from ui.icons import material_icon
 from ui.theme import NODE_BORDER_SELECTED, NODE_TITLE_TEXT_COLOR
 
 if TYPE_CHECKING:
@@ -86,7 +87,9 @@ class BackdropItem(QGraphicsItem):
     CORNER_RADIUS: float = 6.0
     GRIP_SIZE: float = 12.0
     CLOSE_BUTTON_SIZE: float = 14.0
-    CLOSE_BUTTON_MARGIN: float = 4.0
+    CAPTURE_BUTTON_SIZE: float = 14.0
+    HEADER_BUTTON_GAP: float = 4.0
+    HEADER_BUTTON_MARGIN: float = 4.0
     TITLE_PADDING: float = 8.0
 
     def __init__(
@@ -95,12 +98,22 @@ class BackdropItem(QGraphicsItem):
         width: float = DEFAULT_BACKDROP_WIDTH,
         height: float = DEFAULT_BACKDROP_HEIGHT,
         color: QColor | None = None,
+        capture_active: bool = False,
     ) -> None:
         super().__init__()
         self._title: str = title
         self._width: float = float(width)
         self._height: float = float(height)
         self._color: QColor = QColor(color if color is not None else DEFAULT_BACKDROP_COLOR)
+        self._capture_active: bool = bool(capture_active)
+        # Drag bookkeeping: when capture is on and the user starts
+        # dragging the backdrop, we snapshot every node fully inside
+        # the frame at press-time and shift them by the same delta on
+        # every position change. The snapshot is *not* re-evaluated
+        # mid-drag, so a node that wasn't framed at press-time won't
+        # be swept along just because the moving backdrop crossed it.
+        self._captured_snapshot: list = []
+        self._drag_anchor_pos: QPointF | None = None
 
         self.setZValue(self.Z_VALUE)
         self.setFlag(QGraphicsItem.GraphicsItemFlag.ItemIsMovable, True)
@@ -115,6 +128,7 @@ class BackdropItem(QGraphicsItem):
             corner: _BackdropResizeGrip(self, corner) for corner in _Corner
         }
         self._close_button = _BackdropCloseButton(self)
+        self._capture_button = _BackdropCaptureButton(self)
         self._reposition_children()
 
     # ── Public API ─────────────────────────────────────────────────────────────
@@ -143,6 +157,22 @@ class BackdropItem(QGraphicsItem):
     def height(self) -> float:
         return self._height
 
+    @property
+    def capture_active(self) -> bool:
+        """True if dragging the backdrop should sweep enclosed nodes along.
+
+        See :meth:`set_capture_active`. Reflects the toggle button in
+        the header.
+        """
+        return self._capture_active
+
+    def set_capture_active(self, active: bool) -> None:
+        flag = bool(active)
+        if flag == self._capture_active:
+            return
+        self._capture_active = flag
+        self._capture_button.update()
+
     def set_size(self, width: float, height: float) -> None:
         """Update the backdrop rectangle. Enforces the minimum so the
         resize grips can't collapse the frame out of existence."""
@@ -155,6 +185,62 @@ class BackdropItem(QGraphicsItem):
         self._height = new_h
         self._reposition_children()
         self.update()
+
+    # ── Capture / drag-with-contents ───────────────────────────────────────────
+
+    def captured_node_items(self) -> list:
+        """Return every node-item *fully* enclosed by this backdrop.
+
+        "Fully enclosed" means the node's scene-bounding rect is
+        completely inside the backdrop's scene-bounding rect — partial
+        overlap doesn't count, so a node only "joins" the backdrop's
+        group once the user has clearly placed it inside.
+
+        Imported lazily to avoid pulling :mod:`ui.node_item` (which
+        wires up Qt widgets and the param-widget infrastructure) into
+        backdrop tests that only care about geometry.
+        """
+        if self.scene() is None:
+            return []
+        from ui.node_item import NodeItem
+
+        backdrop_rect = self.sceneBoundingRect()
+        captured = []
+        for item in self.scene().items():
+            if isinstance(item, NodeItem) and backdrop_rect.contains(
+                item.sceneBoundingRect()
+            ):
+                captured.append(item)
+        return captured
+
+    def mousePressEvent(self, event) -> None:  # type: ignore[override]
+        # When capture is on, snapshot the framed nodes + their
+        # current positions so the move handler can shift them by the
+        # same delta the backdrop travels. The snapshot is taken
+        # *before* super() starts the drag so press-time geometry is
+        # what we lock in.
+        if self._capture_active and event.button() == Qt.MouseButton.LeftButton:
+            self._drag_anchor_pos = self.scenePos()
+            self._captured_snapshot = [
+                (item, item.pos()) for item in self.captured_node_items()
+            ]
+        super().mousePressEvent(event)
+
+    def mouseReleaseEvent(self, event) -> None:  # type: ignore[override]
+        self._drag_anchor_pos = None
+        self._captured_snapshot = []
+        super().mouseReleaseEvent(event)
+
+    def itemChange(self, change, value):  # type: ignore[override]
+        if (
+            change == QGraphicsItem.GraphicsItemChange.ItemScenePositionHasChanged
+            and self._drag_anchor_pos is not None
+            and self._captured_snapshot
+        ):
+            delta = self.scenePos() - self._drag_anchor_pos
+            for node_item, start_pos in self._captured_snapshot:
+                node_item.setPos(start_pos + delta)
+        return super().itemChange(change, value)
 
     # ── Qt overrides ───────────────────────────────────────────────────────────
 
@@ -185,8 +271,9 @@ class BackdropItem(QGraphicsItem):
         painter.drawPath(body_path)
 
         # Title bar text — rendered directly onto the header strip.
-        # The close button paints itself separately so the text doesn't
-        # need to know about it; we just leave room on the right.
+        # Each header button paints itself separately so the text doesn't
+        # need to know about them; we just leave room on the right for
+        # both (capture toggle + close).
         if self._title:
             title_rect = QRectF(
                 self.TITLE_PADDING,
@@ -194,7 +281,9 @@ class BackdropItem(QGraphicsItem):
                 self._width
                 - 2 * self.TITLE_PADDING
                 - self.CLOSE_BUTTON_SIZE
-                - self.CLOSE_BUTTON_MARGIN,
+                - self.HEADER_BUTTON_GAP
+                - self.CAPTURE_BUTTON_SIZE
+                - self.HEADER_BUTTON_MARGIN,
                 self.HEADER_HEIGHT,
             )
             font = QFont(painter.font())
@@ -210,7 +299,7 @@ class BackdropItem(QGraphicsItem):
     # ── Internals ──────────────────────────────────────────────────────────────
 
     def _reposition_children(self) -> None:
-        """Place every grip + close button at its corner / header slot.
+        """Place every grip + header button at its corner / header slot.
 
         Called from :meth:`set_size` and from ``__init__``. Each grip
         sits exactly on its corner (top-left coordinate of the
@@ -226,11 +315,14 @@ class BackdropItem(QGraphicsItem):
         self._grips[_Corner.SE].setPos(w - gs, h - gs)
 
         cb_size = self.CLOSE_BUTTON_SIZE
-        cb_margin = self.CLOSE_BUTTON_MARGIN
-        self._close_button.setPos(
-            w - cb_size - cb_margin,
-            (self.HEADER_HEIGHT - cb_size) / 2.0,
-        )
+        cap_size = self.CAPTURE_BUTTON_SIZE
+        margin = self.HEADER_BUTTON_MARGIN
+        gap = self.HEADER_BUTTON_GAP
+        # Right-aligned button row: [Capture] [gap] [Close] [margin] | edge
+        close_x = w - cb_size - margin
+        capture_x = close_x - gap - cap_size
+        self._close_button.setPos(close_x, (self.HEADER_HEIGHT - cb_size) / 2.0)
+        self._capture_button.setPos(capture_x, (self.HEADER_HEIGHT - cap_size) / 2.0)
 
 
 class _BackdropResizeGrip(QGraphicsItem):
@@ -343,6 +435,85 @@ class _BackdropResizeGrip(QGraphicsItem):
         self._drag_start_scene = None
         self._drag_start_pos = None
         self._drag_start_size = None
+        super().mouseReleaseEvent(event)
+
+
+class _BackdropCaptureButton(QGraphicsItem):
+    """Toggle button that switches the backdrop's "capture" mode on/off.
+
+    While capture is active, dragging the backdrop sweeps every fully-
+    enclosed node along by the same delta. The button paints a small
+    push-pin glyph (Material Icons) and shows a faint white wash when
+    hovered, plus a stronger wash when the toggle is on — same visual
+    grammar as :class:`~ui.node_item._SkipButtonItem`.
+    """
+
+    SIZE: float = 14.0
+    Z_VALUE: int = 2
+
+    def __init__(self, backdrop: BackdropItem) -> None:
+        super().__init__(parent=backdrop)
+        self._backdrop = backdrop
+        self._hovered = False
+        self._pressed = False
+        self.setZValue(self.Z_VALUE)
+        self.setAcceptHoverEvents(True)
+        self.setAcceptedMouseButtons(Qt.MouseButton.LeftButton)
+        self.setCursor(Qt.CursorShape.ArrowCursor)
+        self.setToolTip(
+            "Capture nodes — drag the backdrop and any fully enclosed "
+            "node moves with it."
+        )
+        # Cache the icon — the same QIcon paints at every state, so
+        # re-creating it on each frame would waste font-rendering work.
+        self._icon = material_icon("push_pin", color=NODE_TITLE_TEXT_COLOR)
+
+    def boundingRect(self) -> QRectF:  # type: ignore[override]
+        return QRectF(0, 0, self.SIZE, self.SIZE)
+
+    def paint(self, painter: QPainter, option, widget=None) -> None:  # type: ignore[override]
+        painter.setRenderHint(QPainter.RenderHint.Antialiasing, True)
+        active = self._backdrop.capture_active
+        if self._hovered or self._pressed or active:
+            painter.setPen(Qt.NoPen)
+            alpha = 120 if active else 70
+            painter.setBrush(QBrush(QColor(255, 255, 255, alpha)))
+            painter.drawRoundedRect(self.boundingRect(), 2, 2)
+
+        # Push-pin glyph rendered through the Material Icons font so
+        # it scales crisply alongside the close X.
+        size = int(self.SIZE)
+        pixmap = self._icon.pixmap(QSize(size, size))
+        painter.drawPixmap(0, 0, pixmap)
+
+    def hoverEnterEvent(self, event) -> None:  # type: ignore[override]
+        self._hovered = True
+        self.update()
+        super().hoverEnterEvent(event)
+
+    def hoverLeaveEvent(self, event) -> None:  # type: ignore[override]
+        self._hovered = False
+        self.update()
+        super().hoverLeaveEvent(event)
+
+    def mousePressEvent(self, event) -> None:  # type: ignore[override]
+        if event.button() == Qt.MouseButton.LeftButton:
+            self._pressed = True
+            self.update()
+            event.accept()
+            return
+        super().mousePressEvent(event)
+
+    def mouseReleaseEvent(self, event) -> None:  # type: ignore[override]
+        if event.button() == Qt.MouseButton.LeftButton and self._pressed:
+            self._pressed = False
+            if self.boundingRect().contains(event.pos()):
+                self._backdrop.set_capture_active(
+                    not self._backdrop.capture_active
+                )
+            self.update()
+            event.accept()
+            return
         super().mouseReleaseEvent(event)
 
 

--- a/src/ui/backdrop_item.py
+++ b/src/ui/backdrop_item.py
@@ -1,0 +1,236 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from PySide6.QtCore import QPointF, QRectF, Qt
+from PySide6.QtGui import (
+    QBrush,
+    QColor,
+    QFont,
+    QPainter,
+    QPainterPath,
+    QPen,
+)
+from PySide6.QtWidgets import QGraphicsItem
+
+from ui.theme import NODE_BORDER_SELECTED
+
+if TYPE_CHECKING:
+    pass
+
+
+#: Default fill when a backdrop is first dropped — a subtle, muted
+#: amber so the frame reads as a loose grouping affordance without
+#: fighting the nodes inside for attention.
+DEFAULT_BACKDROP_COLOR: QColor = QColor(70, 60, 40, 140)
+
+#: Default dimensions used when the user drops a fresh backdrop.
+DEFAULT_BACKDROP_WIDTH: float = 320.0
+DEFAULT_BACKDROP_HEIGHT: float = 220.0
+
+#: Minimum size when the user drags the resize grip. Small enough that
+#: a backdrop can frame a single node, but not so small it collapses
+#: into an invisible square.
+MIN_BACKDROP_WIDTH: float = 80.0
+MIN_BACKDROP_HEIGHT: float = 60.0
+
+#: Built-in palette offered through the context menu. Kept deliberately
+#: small — this is a "hint at intent" affordance, not a full colour
+#: picker. Values mirror the muted dark-theme palette so backdrops
+#: read as loose grouping rather than as primary UI.
+BACKDROP_PRESETS: dict[str, QColor] = {
+    "Amber":   QColor( 70,  60,  40, 140),
+    "Azure":   QColor( 40,  60,  80, 140),
+    "Forest":  QColor( 40,  70,  50, 140),
+    "Plum":    QColor( 70,  45,  70, 140),
+    "Slate":   QColor( 55,  55,  60, 140),
+}
+
+
+class BackdropItem(QGraphicsItem):
+    """Rectangular frame drawn behind a group of nodes.
+
+    A backdrop is a pure visual affordance: it has no connection to
+    the flow model, no execution semantics, and does not appear in the
+    node palette. Use it as a "chapter heading" on the canvas —
+    e.g. "Colour prep", "Alpha mask" — so dense pipelines stay
+    readable.
+
+    Sits on a lower Z than nodes (:attr:`Z_VALUE`) so mouse events on
+    the interior of a framed group still reach the node on top. Drag
+    the title to move the backdrop; drag the bottom-right grip to
+    resize.
+    """
+
+    Z_VALUE: int = -10
+    HEADER_HEIGHT: float = 22.0
+    CORNER_RADIUS: float = 6.0
+    RESIZE_GRIP_SIZE: float = 12.0
+    TITLE_PADDING: float = 8.0
+
+    def __init__(
+        self,
+        title: str = "Backdrop",
+        width: float = DEFAULT_BACKDROP_WIDTH,
+        height: float = DEFAULT_BACKDROP_HEIGHT,
+        color: QColor | None = None,
+    ) -> None:
+        super().__init__()
+        self._title: str = title
+        self._width: float = float(width)
+        self._height: float = float(height)
+        self._color: QColor = QColor(color if color is not None else DEFAULT_BACKDROP_COLOR)
+
+        self.setZValue(self.Z_VALUE)
+        self.setFlag(QGraphicsItem.GraphicsItemFlag.ItemIsMovable, True)
+        self.setFlag(QGraphicsItem.GraphicsItemFlag.ItemIsSelectable, True)
+        self.setFlag(
+            QGraphicsItem.GraphicsItemFlag.ItemSendsScenePositionChanges, True,
+        )
+
+        self._resize_grip = _BackdropResizeGrip(self)
+        self._position_resize_grip()
+
+    # ── Public API ─────────────────────────────────────────────────────────────
+
+    @property
+    def title(self) -> str:
+        return self._title
+
+    def set_title(self, title: str) -> None:
+        self._title = str(title)
+        self.update()
+
+    @property
+    def color(self) -> QColor:
+        return QColor(self._color)
+
+    def set_color(self, color: QColor) -> None:
+        self._color = QColor(color)
+        self.update()
+
+    @property
+    def width(self) -> float:
+        return self._width
+
+    @property
+    def height(self) -> float:
+        return self._height
+
+    def set_size(self, width: float, height: float) -> None:
+        """Update the backdrop rectangle. Enforces the minimum so the
+        resize grip can't collapse the frame out of existence."""
+        new_w = max(MIN_BACKDROP_WIDTH, float(width))
+        new_h = max(MIN_BACKDROP_HEIGHT, float(height))
+        if (new_w, new_h) == (self._width, self._height):
+            return
+        self.prepareGeometryChange()
+        self._width = new_w
+        self._height = new_h
+        self._position_resize_grip()
+        self.update()
+
+    # ── Qt overrides ───────────────────────────────────────────────────────────
+
+    def boundingRect(self) -> QRectF:  # type: ignore[override]
+        return QRectF(0, 0, self._width, self._height)
+
+    def paint(self, painter: QPainter, option, widget=None) -> None:  # type: ignore[override]
+        painter.setRenderHint(QPainter.RenderHint.Antialiasing, True)
+
+        # Body
+        body_path = QPainterPath()
+        body_path.addRoundedRect(
+            self.boundingRect(), self.CORNER_RADIUS, self.CORNER_RADIUS,
+        )
+        painter.fillPath(body_path, QBrush(self._color))
+
+        # Border: amber when selected, subtle darker tint otherwise.
+        if self.isSelected():
+            painter.setPen(QPen(NODE_BORDER_SELECTED, 1.5))
+        else:
+            border = QColor(self._color)
+            border.setAlpha(230)
+            border.setRed(max(0, border.red() - 25))
+            border.setGreen(max(0, border.green() - 25))
+            border.setBlue(max(0, border.blue() - 25))
+            painter.setPen(QPen(border, 1.0))
+        painter.setBrush(Qt.BrushStyle.NoBrush)
+        painter.drawPath(body_path)
+
+        # Title bar text — rendered directly onto the header strip.
+        if self._title:
+            title_rect = QRectF(
+                self.TITLE_PADDING,
+                0.0,
+                self._width - 2 * self.TITLE_PADDING,
+                self.HEADER_HEIGHT,
+            )
+            font = QFont(painter.font())
+            font.setBold(True)
+            painter.setFont(font)
+            painter.setPen(QColor(230, 230, 230))
+            painter.drawText(
+                title_rect,
+                Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignVCenter,
+                self._title,
+            )
+
+    # ── Internals ──────────────────────────────────────────────────────────────
+
+    def _position_resize_grip(self) -> None:
+        self._resize_grip.setPos(
+            self._width - self.RESIZE_GRIP_SIZE,
+            self._height - self.RESIZE_GRIP_SIZE,
+        )
+
+
+class _BackdropResizeGrip(QGraphicsItem):
+    """Bottom-right drag handle that resizes its owning backdrop."""
+
+    SIZE: float = 12.0
+
+    def __init__(self, backdrop: BackdropItem) -> None:
+        super().__init__(parent=backdrop)
+        self._backdrop = backdrop
+        self.setFlag(QGraphicsItem.GraphicsItemFlag.ItemStacksBehindParent, False)
+        self.setCursor(Qt.CursorShape.SizeFDiagCursor)
+        self.setZValue(1)
+        self._drag_start_scene: QPointF | None = None
+        self._drag_start_size: tuple[float, float] | None = None
+
+    def boundingRect(self) -> QRectF:  # type: ignore[override]
+        return QRectF(0, 0, self.SIZE, self.SIZE)
+
+    def paint(self, painter: QPainter, option, widget=None) -> None:  # type: ignore[override]
+        painter.setRenderHint(QPainter.RenderHint.Antialiasing, True)
+        painter.setPen(QPen(QColor(200, 200, 200, 180), 1))
+        # Three short diagonal tick marks — enough to telegraph
+        # "resize handle" without looking like a button.
+        for i in (2, 5, 8):
+            painter.drawLine(
+                QPointF(self.SIZE - i, self.SIZE - 1),
+                QPointF(self.SIZE - 1, self.SIZE - i),
+            )
+
+    def mousePressEvent(self, event) -> None:  # type: ignore[override]
+        if event.button() == Qt.MouseButton.LeftButton:
+            self._drag_start_scene = event.scenePos()
+            self._drag_start_size = (self._backdrop.width, self._backdrop.height)
+            event.accept()
+            return
+        super().mousePressEvent(event)
+
+    def mouseMoveEvent(self, event) -> None:  # type: ignore[override]
+        if self._drag_start_scene is not None and self._drag_start_size is not None:
+            delta = event.scenePos() - self._drag_start_scene
+            w0, h0 = self._drag_start_size
+            self._backdrop.set_size(w0 + delta.x(), h0 + delta.y())
+            event.accept()
+            return
+        super().mouseMoveEvent(event)
+
+    def mouseReleaseEvent(self, event) -> None:  # type: ignore[override]
+        self._drag_start_scene = None
+        self._drag_start_size = None
+        super().mouseReleaseEvent(event)

--- a/src/ui/backdrop_item.py
+++ b/src/ui/backdrop_item.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
+from enum import Enum
 from typing import TYPE_CHECKING
 
-from PySide6.QtCore import QPointF, QRectF, Qt
+from PySide6.QtCore import QPointF, QRectF, Qt, QTimer
 from PySide6.QtGui import (
     QBrush,
     QColor,
@@ -13,7 +14,7 @@ from PySide6.QtGui import (
 )
 from PySide6.QtWidgets import QGraphicsItem
 
-from ui.theme import NODE_BORDER_SELECTED
+from ui.theme import NODE_BORDER_SELECTED, NODE_TITLE_TEXT_COLOR
 
 if TYPE_CHECKING:
     pass
@@ -28,9 +29,9 @@ DEFAULT_BACKDROP_COLOR: QColor = QColor(70, 60, 40, 140)
 DEFAULT_BACKDROP_WIDTH: float = 320.0
 DEFAULT_BACKDROP_HEIGHT: float = 220.0
 
-#: Minimum size when the user drags the resize grip. Small enough that
-#: a backdrop can frame a single node, but not so small it collapses
-#: into an invisible square.
+#: Minimum size when the user drags any of the resize grips. Small
+#: enough that a backdrop can frame a single node, but not so small
+#: it collapses into an invisible square.
 MIN_BACKDROP_WIDTH: float = 80.0
 MIN_BACKDROP_HEIGHT: float = 60.0
 
@@ -47,6 +48,19 @@ BACKDROP_PRESETS: dict[str, QColor] = {
 }
 
 
+class _Corner(Enum):
+    """Identifier for which corner of a backdrop a resize grip is attached to.
+
+    The mapping is consistent with screen coordinates used by Qt:
+    Y grows downward, so "north" is the top edge and "south" the
+    bottom.
+    """
+    NW = "NW"
+    NE = "NE"
+    SW = "SW"
+    SE = "SE"
+
+
 class BackdropItem(QGraphicsItem):
     """Rectangular frame drawn behind a group of nodes.
 
@@ -58,14 +72,21 @@ class BackdropItem(QGraphicsItem):
 
     Sits on a lower Z than nodes (:attr:`Z_VALUE`) so mouse events on
     the interior of a framed group still reach the node on top. Drag
-    the title to move the backdrop; drag the bottom-right grip to
-    resize.
+    the title bar to move; drag *any* of the four corner grips to
+    resize — both axes scale at once and the opposite corner stays
+    pinned. All four are needed because the bottom-right grip alone
+    is unreachable as soon as another node sits on top of it.
+
+    The header carries an X close button on the right edge, mirroring
+    the affordance every regular node has.
     """
 
     Z_VALUE: int = -10
     HEADER_HEIGHT: float = 22.0
     CORNER_RADIUS: float = 6.0
-    RESIZE_GRIP_SIZE: float = 12.0
+    GRIP_SIZE: float = 12.0
+    CLOSE_BUTTON_SIZE: float = 14.0
+    CLOSE_BUTTON_MARGIN: float = 4.0
     TITLE_PADDING: float = 8.0
 
     def __init__(
@@ -88,8 +109,13 @@ class BackdropItem(QGraphicsItem):
             QGraphicsItem.GraphicsItemFlag.ItemSendsScenePositionChanges, True,
         )
 
-        self._resize_grip = _BackdropResizeGrip(self)
-        self._position_resize_grip()
+        # One grip per corner — bottom-right alone gets buried under
+        # nodes too easily to be a reliable handle.
+        self._grips: dict[_Corner, _BackdropResizeGrip] = {
+            corner: _BackdropResizeGrip(self, corner) for corner in _Corner
+        }
+        self._close_button = _BackdropCloseButton(self)
+        self._reposition_children()
 
     # ── Public API ─────────────────────────────────────────────────────────────
 
@@ -119,7 +145,7 @@ class BackdropItem(QGraphicsItem):
 
     def set_size(self, width: float, height: float) -> None:
         """Update the backdrop rectangle. Enforces the minimum so the
-        resize grip can't collapse the frame out of existence."""
+        resize grips can't collapse the frame out of existence."""
         new_w = max(MIN_BACKDROP_WIDTH, float(width))
         new_h = max(MIN_BACKDROP_HEIGHT, float(height))
         if (new_w, new_h) == (self._width, self._height):
@@ -127,7 +153,7 @@ class BackdropItem(QGraphicsItem):
         self.prepareGeometryChange()
         self._width = new_w
         self._height = new_h
-        self._position_resize_grip()
+        self._reposition_children()
         self.update()
 
     # ── Qt overrides ───────────────────────────────────────────────────────────
@@ -159,11 +185,16 @@ class BackdropItem(QGraphicsItem):
         painter.drawPath(body_path)
 
         # Title bar text — rendered directly onto the header strip.
+        # The close button paints itself separately so the text doesn't
+        # need to know about it; we just leave room on the right.
         if self._title:
             title_rect = QRectF(
                 self.TITLE_PADDING,
                 0.0,
-                self._width - 2 * self.TITLE_PADDING,
+                self._width
+                - 2 * self.TITLE_PADDING
+                - self.CLOSE_BUTTON_SIZE
+                - self.CLOSE_BUTTON_MARGIN,
                 self.HEADER_HEIGHT,
             )
             font = QFont(painter.font())
@@ -178,25 +209,58 @@ class BackdropItem(QGraphicsItem):
 
     # ── Internals ──────────────────────────────────────────────────────────────
 
-    def _position_resize_grip(self) -> None:
-        self._resize_grip.setPos(
-            self._width - self.RESIZE_GRIP_SIZE,
-            self._height - self.RESIZE_GRIP_SIZE,
+    def _reposition_children(self) -> None:
+        """Place every grip + close button at its corner / header slot.
+
+        Called from :meth:`set_size` and from ``__init__``. Each grip
+        sits exactly on its corner (top-left coordinate of the
+        ``GRIP_SIZE`` square aligns with the corner so the grip extends
+        into the frame and not outside it).
+        """
+        gs = self.GRIP_SIZE
+        w = self._width
+        h = self._height
+        self._grips[_Corner.NW].setPos(0, 0)
+        self._grips[_Corner.NE].setPos(w - gs, 0)
+        self._grips[_Corner.SW].setPos(0, h - gs)
+        self._grips[_Corner.SE].setPos(w - gs, h - gs)
+
+        cb_size = self.CLOSE_BUTTON_SIZE
+        cb_margin = self.CLOSE_BUTTON_MARGIN
+        self._close_button.setPos(
+            w - cb_size - cb_margin,
+            (self.HEADER_HEIGHT - cb_size) / 2.0,
         )
 
 
 class _BackdropResizeGrip(QGraphicsItem):
-    """Bottom-right drag handle that resizes its owning backdrop."""
+    """Drag handle attached to one corner of a backdrop.
+
+    Each corner pins the *opposite* corner during a drag, so the
+    handle the user grabs is the one that follows the cursor and the
+    frame grows / shrinks symmetrically about that anchor. Below the
+    minimum size, the frame clamps and the dragged corner stops where
+    it would have shrunk past the anchor.
+    """
 
     SIZE: float = 12.0
 
-    def __init__(self, backdrop: BackdropItem) -> None:
+    _CURSORS: dict[_Corner, Qt.CursorShape] = {
+        _Corner.NW: Qt.CursorShape.SizeFDiagCursor,  # top-left  ↘ shape
+        _Corner.SE: Qt.CursorShape.SizeFDiagCursor,  # bot-right ↘
+        _Corner.NE: Qt.CursorShape.SizeBDiagCursor,  # top-right ↙
+        _Corner.SW: Qt.CursorShape.SizeBDiagCursor,  # bot-left  ↙
+    }
+
+    def __init__(self, backdrop: BackdropItem, corner: _Corner) -> None:
         super().__init__(parent=backdrop)
         self._backdrop = backdrop
+        self._corner = corner
         self.setFlag(QGraphicsItem.GraphicsItemFlag.ItemStacksBehindParent, False)
-        self.setCursor(Qt.CursorShape.SizeFDiagCursor)
+        self.setCursor(self._CURSORS[corner])
         self.setZValue(1)
         self._drag_start_scene: QPointF | None = None
+        self._drag_start_pos: QPointF | None = None
         self._drag_start_size: tuple[float, float] | None = None
 
     def boundingRect(self) -> QRectF:  # type: ignore[override]
@@ -205,32 +269,149 @@ class _BackdropResizeGrip(QGraphicsItem):
     def paint(self, painter: QPainter, option, widget=None) -> None:  # type: ignore[override]
         painter.setRenderHint(QPainter.RenderHint.Antialiasing, True)
         painter.setPen(QPen(QColor(200, 200, 200, 180), 1))
-        # Three short diagonal tick marks — enough to telegraph
-        # "resize handle" without looking like a button.
-        for i in (2, 5, 8):
-            painter.drawLine(
-                QPointF(self.SIZE - i, self.SIZE - 1),
-                QPointF(self.SIZE - 1, self.SIZE - i),
-            )
+        # Three short diagonal tick marks oriented for the corner the
+        # grip sits on, so the affordance points "outward" the way an
+        # actual resize handle should.
+        s = self.SIZE
+        if self._corner == _Corner.SE:
+            for i in (2, 5, 8):
+                painter.drawLine(QPointF(s - i, s - 1), QPointF(s - 1, s - i))
+        elif self._corner == _Corner.NW:
+            for i in (2, 5, 8):
+                painter.drawLine(QPointF(0, i), QPointF(i, 0))
+        elif self._corner == _Corner.NE:
+            for i in (2, 5, 8):
+                painter.drawLine(QPointF(s - i, 0), QPointF(s, i))
+        else:  # SW
+            for i in (2, 5, 8):
+                painter.drawLine(QPointF(0, s - i), QPointF(i, s))
 
     def mousePressEvent(self, event) -> None:  # type: ignore[override]
         if event.button() == Qt.MouseButton.LeftButton:
             self._drag_start_scene = event.scenePos()
+            self._drag_start_pos = self._backdrop.pos()
             self._drag_start_size = (self._backdrop.width, self._backdrop.height)
             event.accept()
             return
         super().mousePressEvent(event)
 
     def mouseMoveEvent(self, event) -> None:  # type: ignore[override]
-        if self._drag_start_scene is not None and self._drag_start_size is not None:
-            delta = event.scenePos() - self._drag_start_scene
-            w0, h0 = self._drag_start_size
-            self._backdrop.set_size(w0 + delta.x(), h0 + delta.y())
-            event.accept()
+        if (
+            self._drag_start_scene is None
+            or self._drag_start_pos is None
+            or self._drag_start_size is None
+        ):
+            super().mouseMoveEvent(event)
             return
-        super().mouseMoveEvent(event)
+        delta = event.scenePos() - self._drag_start_scene
+        sp = self._drag_start_pos
+        sw, sh = self._drag_start_size
+
+        new_x = sp.x()
+        new_y = sp.y()
+        new_w = sw
+        new_h = sh
+
+        if self._corner in (_Corner.SE, _Corner.NE):
+            new_w = sw + delta.x()
+        else:  # NW, SW — pull the left edge with the cursor
+            new_w = sw - delta.x()
+            new_x = sp.x() + delta.x()
+
+        if self._corner in (_Corner.SE, _Corner.SW):
+            new_h = sh + delta.y()
+        else:  # NW, NE — pull the top edge with the cursor
+            new_h = sh - delta.y()
+            new_y = sp.y() + delta.y()
+
+        # Clamp to minimum, and when clamped, re-pin the moved edge so
+        # the opposite corner doesn't drift.
+        if new_w < MIN_BACKDROP_WIDTH:
+            if self._corner in (_Corner.NW, _Corner.SW):
+                new_x = sp.x() + (sw - MIN_BACKDROP_WIDTH)
+            new_w = MIN_BACKDROP_WIDTH
+        if new_h < MIN_BACKDROP_HEIGHT:
+            if self._corner in (_Corner.NW, _Corner.NE):
+                new_y = sp.y() + (sh - MIN_BACKDROP_HEIGHT)
+            new_h = MIN_BACKDROP_HEIGHT
+
+        self._backdrop.setPos(new_x, new_y)
+        self._backdrop.set_size(new_w, new_h)
+        event.accept()
 
     def mouseReleaseEvent(self, event) -> None:  # type: ignore[override]
         self._drag_start_scene = None
+        self._drag_start_pos = None
         self._drag_start_size = None
+        super().mouseReleaseEvent(event)
+
+
+class _BackdropCloseButton(QGraphicsItem):
+    """``X`` button at the top-right of a backdrop's header.
+
+    Clicking it asks the owning scene to remove the backdrop, mirroring
+    the close affordance every regular node header carries.
+    """
+
+    SIZE: float = 14.0
+    Z_VALUE: int = 2
+
+    def __init__(self, backdrop: BackdropItem) -> None:
+        super().__init__(parent=backdrop)
+        self._backdrop = backdrop
+        self._hovered = False
+        self._pressed = False
+        self.setZValue(self.Z_VALUE)
+        self.setAcceptHoverEvents(True)
+        self.setAcceptedMouseButtons(Qt.MouseButton.LeftButton)
+        self.setCursor(Qt.CursorShape.ArrowCursor)
+
+    def boundingRect(self) -> QRectF:  # type: ignore[override]
+        return QRectF(0, 0, self.SIZE, self.SIZE)
+
+    def paint(self, painter: QPainter, option, widget=None) -> None:  # type: ignore[override]
+        painter.setRenderHint(QPainter.RenderHint.Antialiasing, True)
+        if self._hovered or self._pressed:
+            painter.setPen(Qt.NoPen)
+            painter.setBrush(QBrush(QColor(255, 255, 255, 70)))
+            painter.drawRoundedRect(self.boundingRect(), 2, 2)
+        pen = QPen(NODE_TITLE_TEXT_COLOR, 1.6)
+        pen.setCapStyle(Qt.PenCapStyle.RoundCap)
+        painter.setPen(pen)
+        m = 4.0
+        s = self.SIZE
+        painter.drawLine(QPointF(m, m), QPointF(s - m, s - m))
+        painter.drawLine(QPointF(s - m, m), QPointF(m, s - m))
+
+    def hoverEnterEvent(self, event) -> None:  # type: ignore[override]
+        self._hovered = True
+        self.update()
+        super().hoverEnterEvent(event)
+
+    def hoverLeaveEvent(self, event) -> None:  # type: ignore[override]
+        self._hovered = False
+        self.update()
+        super().hoverLeaveEvent(event)
+
+    def mousePressEvent(self, event) -> None:  # type: ignore[override]
+        if event.button() == Qt.MouseButton.LeftButton:
+            self._pressed = True
+            self.update()
+            event.accept()
+            return
+        super().mousePressEvent(event)
+
+    def mouseReleaseEvent(self, event) -> None:  # type: ignore[override]
+        if event.button() == Qt.MouseButton.LeftButton and self._pressed:
+            self._pressed = False
+            self.update()
+            if self.boundingRect().contains(event.pos()):
+                scene = self.scene()
+                backdrop = self._backdrop
+                if scene is not None and hasattr(scene, "remove_backdrop"):
+                    # Defer so we don't delete ourselves from inside
+                    # our own event handler.
+                    QTimer.singleShot(0, lambda: scene.remove_backdrop(backdrop))
+            event.accept()
+            return
         super().mouseReleaseEvent(event)

--- a/src/ui/backdrop_item.py
+++ b/src/ui/backdrop_item.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from enum import Enum
 from typing import TYPE_CHECKING
 
 from PySide6.QtCore import QPointF, QRectF, Qt, QTimer
@@ -48,34 +47,21 @@ BACKDROP_PRESETS: dict[str, QColor] = {
 }
 
 
-class _Corner(Enum):
-    """Identifier for which corner of a backdrop a resize grip is attached to.
-
-    The mapping is consistent with screen coordinates used by Qt:
-    Y grows downward, so "north" is the top edge and "south" the
-    bottom.
-    """
-    NW = "NW"
-    NE = "NE"
-    SW = "SW"
-    SE = "SE"
-
-
 class BackdropItem(QGraphicsItem):
     """Rectangular frame drawn behind a group of nodes.
 
     A backdrop is a pure visual affordance: it has no connection to
-    the flow model, no execution semantics, and does not appear in the
-    node palette. Use it as a "chapter heading" on the canvas —
+    the flow model, no execution semantics, and does not appear in
+    the node palette. Use it as a "chapter heading" on the canvas —
     e.g. "Colour prep", "Alpha mask" — so dense pipelines stay
     readable.
 
-    Sits on a lower Z than nodes (:attr:`Z_VALUE`) so mouse events on
-    the interior of a framed group still reach the node on top. Drag
-    the title bar to move; drag *any* of the four corner grips to
-    resize — both axes scale at once and the opposite corner stays
-    pinned. All four are needed because the bottom-right grip alone
-    is unreachable as soon as another node sits on top of it.
+    Sits on a lower Z than nodes (:attr:`Z_VALUE`) so mouse events
+    on the interior of a framed group still reach the node on top.
+    Drag the title bar to move; the geometry is fixed at creation
+    time (see :meth:`FlowScene.create_group_around_selection`) and
+    is not interactively resizable — the framed group's contents are
+    expected to evolve, not the frame itself.
 
     The header carries an X close button on the right edge, mirroring
     the affordance every regular node has.
@@ -84,7 +70,6 @@ class BackdropItem(QGraphicsItem):
     Z_VALUE: int = -10
     HEADER_HEIGHT: float = 22.0
     CORNER_RADIUS: float = 6.0
-    GRIP_SIZE: float = 12.0
     CLOSE_BUTTON_SIZE: float = 14.0
     HEADER_BUTTON_MARGIN: float = 4.0
     TITLE_PADDING: float = 8.0
@@ -121,11 +106,6 @@ class BackdropItem(QGraphicsItem):
             QGraphicsItem.GraphicsItemFlag.ItemSendsScenePositionChanges, True,
         )
 
-        # One grip per corner — bottom-right alone gets buried under
-        # nodes too easily to be a reliable handle.
-        self._grips: dict[_Corner, _BackdropResizeGrip] = {
-            corner: _BackdropResizeGrip(self, corner) for corner in _Corner
-        }
         self._close_button = _BackdropCloseButton(self)
         self._reposition_children()
 
@@ -156,8 +136,12 @@ class BackdropItem(QGraphicsItem):
         return self._height
 
     def set_size(self, width: float, height: float) -> None:
-        """Update the backdrop rectangle. Enforces the minimum so the
-        resize grips can't collapse the frame out of existence."""
+        """Update the backdrop rectangle. Used by the loader and
+        :meth:`FlowScene.create_group_around_selection` — the user
+        can't drive this at runtime since the frame has no resize
+        handles. The minimum clamp is kept as defensive sanity for
+        legacy flow files.
+        """
         new_w = max(MIN_BACKDROP_WIDTH, float(width))
         new_h = max(MIN_BACKDROP_HEIGHT, float(height))
         if (new_w, new_h) == (self._width, self._height):
@@ -277,140 +261,16 @@ class BackdropItem(QGraphicsItem):
     # ── Internals ──────────────────────────────────────────────────────────────
 
     def _reposition_children(self) -> None:
-        """Place every grip + the close button at its corner / header slot.
+        """Place the close button in its header slot.
 
-        Called from :meth:`set_size` and from ``__init__``. Each grip
-        sits exactly on its corner (top-left coordinate of the
-        ``GRIP_SIZE`` square aligns with the corner so the grip extends
-        into the frame and not outside it).
+        Called from :meth:`set_size` and from ``__init__``.
         """
-        gs = self.GRIP_SIZE
-        w = self._width
-        h = self._height
-        self._grips[_Corner.NW].setPos(0, 0)
-        self._grips[_Corner.NE].setPos(w - gs, 0)
-        self._grips[_Corner.SW].setPos(0, h - gs)
-        self._grips[_Corner.SE].setPos(w - gs, h - gs)
-
         cb_size = self.CLOSE_BUTTON_SIZE
         margin = self.HEADER_BUTTON_MARGIN
         self._close_button.setPos(
-            w - cb_size - margin,
+            self._width - cb_size - margin,
             (self.HEADER_HEIGHT - cb_size) / 2.0,
         )
-
-
-class _BackdropResizeGrip(QGraphicsItem):
-    """Drag handle attached to one corner of a backdrop.
-
-    Each corner pins the *opposite* corner during a drag, so the
-    handle the user grabs is the one that follows the cursor and the
-    frame grows / shrinks symmetrically about that anchor. Below the
-    minimum size, the frame clamps and the dragged corner stops where
-    it would have shrunk past the anchor.
-    """
-
-    SIZE: float = 12.0
-
-    _CURSORS: dict[_Corner, Qt.CursorShape] = {
-        _Corner.NW: Qt.CursorShape.SizeFDiagCursor,  # top-left  ↘ shape
-        _Corner.SE: Qt.CursorShape.SizeFDiagCursor,  # bot-right ↘
-        _Corner.NE: Qt.CursorShape.SizeBDiagCursor,  # top-right ↙
-        _Corner.SW: Qt.CursorShape.SizeBDiagCursor,  # bot-left  ↙
-    }
-
-    def __init__(self, backdrop: BackdropItem, corner: _Corner) -> None:
-        super().__init__(parent=backdrop)
-        self._backdrop = backdrop
-        self._corner = corner
-        self.setFlag(QGraphicsItem.GraphicsItemFlag.ItemStacksBehindParent, False)
-        self.setCursor(self._CURSORS[corner])
-        self.setZValue(1)
-        self._drag_start_scene: QPointF | None = None
-        self._drag_start_pos: QPointF | None = None
-        self._drag_start_size: tuple[float, float] | None = None
-
-    def boundingRect(self) -> QRectF:  # type: ignore[override]
-        return QRectF(0, 0, self.SIZE, self.SIZE)
-
-    def paint(self, painter: QPainter, option, widget=None) -> None:  # type: ignore[override]
-        painter.setRenderHint(QPainter.RenderHint.Antialiasing, True)
-        painter.setPen(QPen(QColor(200, 200, 200, 180), 1))
-        # Three short diagonal tick marks oriented for the corner the
-        # grip sits on, so the affordance points "outward" the way an
-        # actual resize handle should.
-        s = self.SIZE
-        if self._corner == _Corner.SE:
-            for i in (2, 5, 8):
-                painter.drawLine(QPointF(s - i, s - 1), QPointF(s - 1, s - i))
-        elif self._corner == _Corner.NW:
-            for i in (2, 5, 8):
-                painter.drawLine(QPointF(0, i), QPointF(i, 0))
-        elif self._corner == _Corner.NE:
-            for i in (2, 5, 8):
-                painter.drawLine(QPointF(s - i, 0), QPointF(s, i))
-        else:  # SW
-            for i in (2, 5, 8):
-                painter.drawLine(QPointF(0, s - i), QPointF(i, s))
-
-    def mousePressEvent(self, event) -> None:  # type: ignore[override]
-        if event.button() == Qt.MouseButton.LeftButton:
-            self._drag_start_scene = event.scenePos()
-            self._drag_start_pos = self._backdrop.pos()
-            self._drag_start_size = (self._backdrop.width, self._backdrop.height)
-            event.accept()
-            return
-        super().mousePressEvent(event)
-
-    def mouseMoveEvent(self, event) -> None:  # type: ignore[override]
-        if (
-            self._drag_start_scene is None
-            or self._drag_start_pos is None
-            or self._drag_start_size is None
-        ):
-            super().mouseMoveEvent(event)
-            return
-        delta = event.scenePos() - self._drag_start_scene
-        sp = self._drag_start_pos
-        sw, sh = self._drag_start_size
-
-        new_x = sp.x()
-        new_y = sp.y()
-        new_w = sw
-        new_h = sh
-
-        if self._corner in (_Corner.SE, _Corner.NE):
-            new_w = sw + delta.x()
-        else:  # NW, SW — pull the left edge with the cursor
-            new_w = sw - delta.x()
-            new_x = sp.x() + delta.x()
-
-        if self._corner in (_Corner.SE, _Corner.SW):
-            new_h = sh + delta.y()
-        else:  # NW, NE — pull the top edge with the cursor
-            new_h = sh - delta.y()
-            new_y = sp.y() + delta.y()
-
-        # Clamp to minimum, and when clamped, re-pin the moved edge so
-        # the opposite corner doesn't drift.
-        if new_w < MIN_BACKDROP_WIDTH:
-            if self._corner in (_Corner.NW, _Corner.SW):
-                new_x = sp.x() + (sw - MIN_BACKDROP_WIDTH)
-            new_w = MIN_BACKDROP_WIDTH
-        if new_h < MIN_BACKDROP_HEIGHT:
-            if self._corner in (_Corner.NW, _Corner.NE):
-                new_y = sp.y() + (sh - MIN_BACKDROP_HEIGHT)
-            new_h = MIN_BACKDROP_HEIGHT
-
-        self._backdrop.setPos(new_x, new_y)
-        self._backdrop.set_size(new_w, new_h)
-        event.accept()
-
-    def mouseReleaseEvent(self, event) -> None:  # type: ignore[override]
-        self._drag_start_scene = None
-        self._drag_start_pos = None
-        self._drag_start_size = None
-        super().mouseReleaseEvent(event)
 
 
 class _BackdropCloseButton(QGraphicsItem):

--- a/src/ui/backdrop_item.py
+++ b/src/ui/backdrop_item.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from enum import Enum
 from typing import TYPE_CHECKING
 
-from PySide6.QtCore import QPointF, QRectF, QSize, Qt, QTimer
+from PySide6.QtCore import QPointF, QRectF, Qt, QTimer
 from PySide6.QtGui import (
     QBrush,
     QColor,
@@ -14,7 +14,6 @@ from PySide6.QtGui import (
 )
 from PySide6.QtWidgets import QGraphicsItem
 
-from ui.icons import material_icon
 from ui.theme import NODE_BORDER_SELECTED, NODE_TITLE_TEXT_COLOR
 
 if TYPE_CHECKING:
@@ -87,8 +86,6 @@ class BackdropItem(QGraphicsItem):
     CORNER_RADIUS: float = 6.0
     GRIP_SIZE: float = 12.0
     CLOSE_BUTTON_SIZE: float = 14.0
-    CAPTURE_BUTTON_SIZE: float = 14.0
-    HEADER_BUTTON_GAP: float = 4.0
     HEADER_BUTTON_MARGIN: float = 4.0
     TITLE_PADDING: float = 8.0
 
@@ -98,20 +95,22 @@ class BackdropItem(QGraphicsItem):
         width: float = DEFAULT_BACKDROP_WIDTH,
         height: float = DEFAULT_BACKDROP_HEIGHT,
         color: QColor | None = None,
-        capture_active: bool = False,
     ) -> None:
         super().__init__()
         self._title: str = title
         self._width: float = float(width)
         self._height: float = float(height)
         self._color: QColor = QColor(color if color is not None else DEFAULT_BACKDROP_COLOR)
-        self._capture_active: bool = bool(capture_active)
-        # Drag bookkeeping: when capture is on and the user starts
-        # dragging the backdrop, we snapshot every node fully inside
-        # the frame at press-time and shift them by the same delta on
-        # every position change. The snapshot is *not* re-evaluated
+        # Drag bookkeeping: when the user starts dragging the
+        # backdrop, we snapshot every node fully inside the frame at
+        # press-time and shift them by the same delta on every
+        # position change. The snapshot is *not* re-evaluated
         # mid-drag, so a node that wasn't framed at press-time won't
         # be swept along just because the moving backdrop crossed it.
+        # Capture-the-enclosed is always on — the typical creation
+        # path is "Create Group" around an existing selection, so by
+        # the time the user moves the backdrop, it already frames
+        # exactly what they want to drag together.
         self._captured_snapshot: list = []
         self._drag_anchor_pos: QPointF | None = None
 
@@ -128,7 +127,6 @@ class BackdropItem(QGraphicsItem):
             corner: _BackdropResizeGrip(self, corner) for corner in _Corner
         }
         self._close_button = _BackdropCloseButton(self)
-        self._capture_button = _BackdropCaptureButton(self)
         self._reposition_children()
 
     # ── Public API ─────────────────────────────────────────────────────────────
@@ -156,22 +154,6 @@ class BackdropItem(QGraphicsItem):
     @property
     def height(self) -> float:
         return self._height
-
-    @property
-    def capture_active(self) -> bool:
-        """True if dragging the backdrop should sweep enclosed nodes along.
-
-        See :meth:`set_capture_active`. Reflects the toggle button in
-        the header.
-        """
-        return self._capture_active
-
-    def set_capture_active(self, active: bool) -> None:
-        flag = bool(active)
-        if flag == self._capture_active:
-            return
-        self._capture_active = flag
-        self._capture_button.update()
 
     def set_size(self, width: float, height: float) -> None:
         """Update the backdrop rectangle. Enforces the minimum so the
@@ -214,12 +196,11 @@ class BackdropItem(QGraphicsItem):
         return captured
 
     def mousePressEvent(self, event) -> None:  # type: ignore[override]
-        # When capture is on, snapshot the framed nodes + their
-        # current positions so the move handler can shift them by the
-        # same delta the backdrop travels. The snapshot is taken
-        # *before* super() starts the drag so press-time geometry is
-        # what we lock in.
-        if self._capture_active and event.button() == Qt.MouseButton.LeftButton:
+        # Snapshot the framed nodes + their current positions so the
+        # move handler can shift them by the same delta the backdrop
+        # travels. Taken *before* super() starts the drag so
+        # press-time geometry is what we lock in.
+        if event.button() == Qt.MouseButton.LeftButton:
             self._drag_anchor_pos = self.scenePos()
             self._captured_snapshot = [
                 (item, item.pos()) for item in self.captured_node_items()
@@ -271,9 +252,8 @@ class BackdropItem(QGraphicsItem):
         painter.drawPath(body_path)
 
         # Title bar text — rendered directly onto the header strip.
-        # Each header button paints itself separately so the text doesn't
-        # need to know about them; we just leave room on the right for
-        # both (capture toggle + close).
+        # The close button paints itself separately, so we just leave
+        # room on the right for it.
         if self._title:
             title_rect = QRectF(
                 self.TITLE_PADDING,
@@ -281,8 +261,6 @@ class BackdropItem(QGraphicsItem):
                 self._width
                 - 2 * self.TITLE_PADDING
                 - self.CLOSE_BUTTON_SIZE
-                - self.HEADER_BUTTON_GAP
-                - self.CAPTURE_BUTTON_SIZE
                 - self.HEADER_BUTTON_MARGIN,
                 self.HEADER_HEIGHT,
             )
@@ -299,7 +277,7 @@ class BackdropItem(QGraphicsItem):
     # ── Internals ──────────────────────────────────────────────────────────────
 
     def _reposition_children(self) -> None:
-        """Place every grip + header button at its corner / header slot.
+        """Place every grip + the close button at its corner / header slot.
 
         Called from :meth:`set_size` and from ``__init__``. Each grip
         sits exactly on its corner (top-left coordinate of the
@@ -315,14 +293,11 @@ class BackdropItem(QGraphicsItem):
         self._grips[_Corner.SE].setPos(w - gs, h - gs)
 
         cb_size = self.CLOSE_BUTTON_SIZE
-        cap_size = self.CAPTURE_BUTTON_SIZE
         margin = self.HEADER_BUTTON_MARGIN
-        gap = self.HEADER_BUTTON_GAP
-        # Right-aligned button row: [Capture] [gap] [Close] [margin] | edge
-        close_x = w - cb_size - margin
-        capture_x = close_x - gap - cap_size
-        self._close_button.setPos(close_x, (self.HEADER_HEIGHT - cb_size) / 2.0)
-        self._capture_button.setPos(capture_x, (self.HEADER_HEIGHT - cap_size) / 2.0)
+        self._close_button.setPos(
+            w - cb_size - margin,
+            (self.HEADER_HEIGHT - cb_size) / 2.0,
+        )
 
 
 class _BackdropResizeGrip(QGraphicsItem):
@@ -435,85 +410,6 @@ class _BackdropResizeGrip(QGraphicsItem):
         self._drag_start_scene = None
         self._drag_start_pos = None
         self._drag_start_size = None
-        super().mouseReleaseEvent(event)
-
-
-class _BackdropCaptureButton(QGraphicsItem):
-    """Toggle button that switches the backdrop's "capture" mode on/off.
-
-    While capture is active, dragging the backdrop sweeps every fully-
-    enclosed node along by the same delta. The button paints a small
-    push-pin glyph (Material Icons) and shows a faint white wash when
-    hovered, plus a stronger wash when the toggle is on — same visual
-    grammar as :class:`~ui.node_item._SkipButtonItem`.
-    """
-
-    SIZE: float = 14.0
-    Z_VALUE: int = 2
-
-    def __init__(self, backdrop: BackdropItem) -> None:
-        super().__init__(parent=backdrop)
-        self._backdrop = backdrop
-        self._hovered = False
-        self._pressed = False
-        self.setZValue(self.Z_VALUE)
-        self.setAcceptHoverEvents(True)
-        self.setAcceptedMouseButtons(Qt.MouseButton.LeftButton)
-        self.setCursor(Qt.CursorShape.ArrowCursor)
-        self.setToolTip(
-            "Capture nodes — drag the backdrop and any fully enclosed "
-            "node moves with it."
-        )
-        # Cache the icon — the same QIcon paints at every state, so
-        # re-creating it on each frame would waste font-rendering work.
-        self._icon = material_icon("push_pin", color=NODE_TITLE_TEXT_COLOR)
-
-    def boundingRect(self) -> QRectF:  # type: ignore[override]
-        return QRectF(0, 0, self.SIZE, self.SIZE)
-
-    def paint(self, painter: QPainter, option, widget=None) -> None:  # type: ignore[override]
-        painter.setRenderHint(QPainter.RenderHint.Antialiasing, True)
-        active = self._backdrop.capture_active
-        if self._hovered or self._pressed or active:
-            painter.setPen(Qt.NoPen)
-            alpha = 120 if active else 70
-            painter.setBrush(QBrush(QColor(255, 255, 255, alpha)))
-            painter.drawRoundedRect(self.boundingRect(), 2, 2)
-
-        # Push-pin glyph rendered through the Material Icons font so
-        # it scales crisply alongside the close X.
-        size = int(self.SIZE)
-        pixmap = self._icon.pixmap(QSize(size, size))
-        painter.drawPixmap(0, 0, pixmap)
-
-    def hoverEnterEvent(self, event) -> None:  # type: ignore[override]
-        self._hovered = True
-        self.update()
-        super().hoverEnterEvent(event)
-
-    def hoverLeaveEvent(self, event) -> None:  # type: ignore[override]
-        self._hovered = False
-        self.update()
-        super().hoverLeaveEvent(event)
-
-    def mousePressEvent(self, event) -> None:  # type: ignore[override]
-        if event.button() == Qt.MouseButton.LeftButton:
-            self._pressed = True
-            self.update()
-            event.accept()
-            return
-        super().mousePressEvent(event)
-
-    def mouseReleaseEvent(self, event) -> None:  # type: ignore[override]
-        if event.button() == Qt.MouseButton.LeftButton and self._pressed:
-            self._pressed = False
-            if self.boundingRect().contains(event.pos()):
-                self._backdrop.set_capture_active(
-                    not self._backdrop.capture_active
-                )
-            self.update()
-            event.accept()
-            return
         super().mouseReleaseEvent(event)
 
 

--- a/src/ui/flow_io.py
+++ b/src/ui/flow_io.py
@@ -78,12 +78,17 @@ def serialize_flow(scene: FlowScene, flow: Flow) -> dict:
     for backdrop in scene.iter_backdrops():
         pos = backdrop.pos()
         colour = backdrop.color
-        backdrops_out.append({
+        entry: dict = {
             "position": [float(pos.x()), float(pos.y())],
             "size":     [float(backdrop.width), float(backdrop.height)],
             "title":    backdrop.title,
             "color":    [colour.red(), colour.green(), colour.blue(), colour.alpha()],
-        })
+        }
+        # Only emit the capture flag when it's on — keeps the file
+        # tidy for the common case (no capture).
+        if backdrop.capture_active:
+            entry["capture"] = True
+        backdrops_out.append(entry)
 
     return {
         "version":     FLOW_FORMAT_VERSION,
@@ -188,6 +193,7 @@ def load_flow_into(path: Path, scene: FlowScene) -> Flow:
             width=float(size[0]) if size[0] is not None else None,
             height=float(size[1]) if size[1] is not None else None,
             color=colour,
+            capture_active=bool(entry.get("capture", False)),
         )
 
     return flow

--- a/src/ui/flow_io.py
+++ b/src/ui/flow_io.py
@@ -74,12 +74,24 @@ def serialize_flow(scene: FlowScene, flow: Flow) -> dict:
             "dst_input":  link.dst_port.index,
         })
 
+    backdrops_out: list[dict] = []
+    for backdrop in scene.iter_backdrops():
+        pos = backdrop.pos()
+        colour = backdrop.color
+        backdrops_out.append({
+            "position": [float(pos.x()), float(pos.y())],
+            "size":     [float(backdrop.width), float(backdrop.height)],
+            "title":    backdrop.title,
+            "color":    [colour.red(), colour.green(), colour.blue(), colour.alpha()],
+        })
+
     return {
         "version":     FLOW_FORMAT_VERSION,
         "app_version": APP_VERSION,
         "name":        flow.name,
         "nodes":       nodes_out,
         "connections": connections_out,
+        "backdrops":   backdrops_out,
     }
 
 
@@ -158,6 +170,25 @@ def load_flow_into(path: Path, scene: FlowScene) -> Flow:
             # into an IMAGE-only port). Log and continue so the rest of the
             # flow still loads rather than aborting the whole file.
             logger.warning(f"Skipping incompatible connection {conn}: {err}")
+
+    for entry in data.get("backdrops", []):
+        pos = entry.get("position") or [0.0, 0.0]
+        size = entry.get("size") or [None, None]
+        col_rgba = entry.get("color")
+        colour = None
+        if col_rgba and len(col_rgba) >= 3:
+            from PySide6.QtGui import QColor
+            alpha = col_rgba[3] if len(col_rgba) >= 4 else 255
+            colour = QColor(
+                int(col_rgba[0]), int(col_rgba[1]), int(col_rgba[2]), int(alpha),
+            )
+        scene.add_backdrop(
+            QPointF(float(pos[0]), float(pos[1])),
+            title=str(entry.get("title", "Backdrop")),
+            width=float(size[0]) if size[0] is not None else None,
+            height=float(size[1]) if size[1] is not None else None,
+            color=colour,
+        )
 
     return flow
 

--- a/src/ui/flow_io.py
+++ b/src/ui/flow_io.py
@@ -78,17 +78,12 @@ def serialize_flow(scene: FlowScene, flow: Flow) -> dict:
     for backdrop in scene.iter_backdrops():
         pos = backdrop.pos()
         colour = backdrop.color
-        entry: dict = {
+        backdrops_out.append({
             "position": [float(pos.x()), float(pos.y())],
             "size":     [float(backdrop.width), float(backdrop.height)],
             "title":    backdrop.title,
             "color":    [colour.red(), colour.green(), colour.blue(), colour.alpha()],
-        }
-        # Only emit the capture flag when it's on — keeps the file
-        # tidy for the common case (no capture).
-        if backdrop.capture_active:
-            entry["capture"] = True
-        backdrops_out.append(entry)
+        })
 
     return {
         "version":     FLOW_FORMAT_VERSION,
@@ -193,7 +188,6 @@ def load_flow_into(path: Path, scene: FlowScene) -> Flow:
             width=float(size[0]) if size[0] is not None else None,
             height=float(size[1]) if size[1] is not None else None,
             color=colour,
-            capture_active=bool(entry.get("capture", False)),
         )
 
     return flow

--- a/src/ui/flow_scene.py
+++ b/src/ui/flow_scene.py
@@ -256,6 +256,7 @@ class FlowScene(QGraphicsScene):
         width: float | None = None,
         height: float | None = None,
         color=None,
+        capture_active: bool = False,
     ) -> BackdropItem:
         """Add a :class:`BackdropItem` to the scene and mark dirty.
 
@@ -263,7 +264,7 @@ class FlowScene(QGraphicsScene):
         explicit geometry (e.g. from a deserialised flow) without
         forcing every call site to re-import the defaults module.
         """
-        kwargs: dict = {"title": title}
+        kwargs: dict = {"title": title, "capture_active": capture_active}
         if width is not None:
             kwargs["width"] = width
         if height is not None:

--- a/src/ui/flow_scene.py
+++ b/src/ui/flow_scene.py
@@ -16,6 +16,7 @@ from PySide6.QtWidgets import (
 
 from core.flow import Flow
 from core.node_base import NodeBase
+from ui.backdrop_item import BACKDROP_PRESETS, BackdropItem
 from ui.link_item import LinkItem, PendingLinkItem
 from ui.node_item import NodeItem
 from ui.port_item import PortItem
@@ -59,6 +60,7 @@ class FlowScene(QGraphicsScene):
         self._flow: Flow | None = None
         self._node_items: dict[int, NodeItem] = {}          # id(node_base) → NodeItem
         self._links: list[LinkItem] = []
+        self._backdrops: list[BackdropItem] = []
         self._pending_link: PendingLinkItem | None = None
         self._pending_src_port: PortItem | None = None
         self._last_emitted_selected: NodeBase | None = None
@@ -94,8 +96,11 @@ class FlowScene(QGraphicsScene):
             self._delete_link_item(link)
         for item in list(self._node_items.values()):
             self._delete_node_item(item)
+        for backdrop in list(self._backdrops):
+            self.removeItem(backdrop)
         self._node_items.clear()
         self._links.clear()
+        self._backdrops.clear()
         self._pending_link = None
         self._pending_src_port = None
         self._last_emitted_selected = None
@@ -241,6 +246,48 @@ class FlowScene(QGraphicsScene):
         self.removeItem(link)
         self._mark_dirty()
 
+    # ── Backdrops ──────────────────────────────────────────────────────────────
+
+    def add_backdrop(
+        self,
+        scene_pos: QPointF | None = None,
+        *,
+        title: str = "Backdrop",
+        width: float | None = None,
+        height: float | None = None,
+        color=None,
+    ) -> BackdropItem:
+        """Add a :class:`BackdropItem` to the scene and mark dirty.
+
+        Keyword arguments with ``None`` defaults let the caller pass
+        explicit geometry (e.g. from a deserialised flow) without
+        forcing every call site to re-import the defaults module.
+        """
+        kwargs: dict = {"title": title}
+        if width is not None:
+            kwargs["width"] = width
+        if height is not None:
+            kwargs["height"] = height
+        if color is not None:
+            kwargs["color"] = color
+        backdrop = BackdropItem(**kwargs)
+        self.addItem(backdrop)
+        if scene_pos is not None:
+            backdrop.setPos(scene_pos)
+        self._backdrops.append(backdrop)
+        self._mark_dirty()
+        return backdrop
+
+    def remove_backdrop(self, backdrop: BackdropItem) -> None:
+        if backdrop in self._backdrops:
+            self._backdrops.remove(backdrop)
+        self.removeItem(backdrop)
+        self._mark_dirty()
+
+    def iter_backdrops(self) -> list[BackdropItem]:
+        """Return a snapshot of every backdrop currently in the scene."""
+        return list(self._backdrops)
+
     # ── Pending-link drag ──────────────────────────────────────────────────────
 
     def mousePressEvent(self, event: QGraphicsSceneMouseEvent) -> None:  # type: ignore[override]
@@ -302,13 +349,25 @@ class FlowScene(QGraphicsScene):
         from PySide6.QtGui import QTransform
         views = self.views()
         xform = views[0].transform() if views else QTransform()
-        item = self.itemAt(event.scenePos(), xform)
-        # Walk up to a LinkItem if a label was clicked.
-        while item is not None and not isinstance(item, LinkItem):
+        raw_item = self.itemAt(event.scenePos(), xform)
+        # Walk up the parent chain so right-clicking a title / grip on
+        # a backdrop hits the BackdropItem, and right-clicking a link
+        # label hits the LinkItem.
+        item = raw_item
+        while item is not None:
+            if isinstance(item, (LinkItem, BackdropItem)):
+                break
             item = item.parentItem()
 
         if isinstance(item, LinkItem):
             self._link_context_menu(item, event)
+            return
+        if isinstance(item, BackdropItem):
+            self._backdrop_context_menu(item, event)
+            return
+        # Empty canvas → offer Add Backdrop.
+        if raw_item is None:
+            self._canvas_context_menu(event)
             return
         super().contextMenuEvent(event)
 
@@ -318,6 +377,59 @@ class FlowScene(QGraphicsScene):
         delete.triggered.connect(lambda: self._delete_link_item(link))
         menu.addAction(delete)
         menu.exec(event.screenPos())
+
+    def _canvas_context_menu(self, event: QGraphicsSceneContextMenuEvent) -> None:
+        menu = QMenu()
+        add = QAction("Add Backdrop", menu)
+        scene_pos = event.scenePos()
+        add.triggered.connect(lambda: self.add_backdrop(scene_pos))
+        menu.addAction(add)
+        menu.exec(event.screenPos())
+
+    def _backdrop_context_menu(
+        self, backdrop: BackdropItem, event: QGraphicsSceneContextMenuEvent,
+    ) -> None:
+        menu = QMenu()
+
+        rename = QAction("Rename…", menu)
+        rename.triggered.connect(lambda: self._prompt_rename_backdrop(backdrop))
+        menu.addAction(rename)
+
+        colour_menu = menu.addMenu("Colour")
+        for name, colour in BACKDROP_PRESETS.items():
+            act = QAction(name, colour_menu)
+            act.triggered.connect(
+                lambda _checked=False, c=colour: self._recolour_backdrop(backdrop, c)
+            )
+            colour_menu.addAction(act)
+
+        menu.addSeparator()
+        delete = QAction("Delete Backdrop", menu)
+        delete.triggered.connect(lambda: self.remove_backdrop(backdrop))
+        menu.addAction(delete)
+
+        menu.exec(event.screenPos())
+
+    def _prompt_rename_backdrop(self, backdrop: BackdropItem) -> None:
+        """Pop a tiny dialog to rename the backdrop.
+
+        Kept in the scene rather than on the backdrop item itself so
+        the input-dialog-vs-inline-edit decision can change later
+        without touching every BackdropItem.
+        """
+        from PySide6.QtWidgets import QInputDialog
+        views = self.views()
+        parent = views[0] if views else None
+        new_title, ok = QInputDialog.getText(
+            parent, "Rename Backdrop", "Title:", text=backdrop.title,
+        )
+        if ok and new_title != backdrop.title:
+            backdrop.set_title(new_title)
+            self._mark_dirty()
+
+    def _recolour_backdrop(self, backdrop: BackdropItem, colour) -> None:
+        backdrop.set_color(colour)
+        self._mark_dirty()
 
     # ── Selection → signal ─────────────────────────────────────────────────────
 
@@ -387,6 +499,8 @@ class FlowScene(QGraphicsScene):
                     self.remove_node_item(s)
                 elif isinstance(s, LinkItem):
                     self._delete_link_item(s)
+                elif isinstance(s, BackdropItem):
+                    self.remove_backdrop(s)
             event.accept()
             return
         super().keyPressEvent(event)

--- a/src/ui/flow_scene.py
+++ b/src/ui/flow_scene.py
@@ -256,7 +256,6 @@ class FlowScene(QGraphicsScene):
         width: float | None = None,
         height: float | None = None,
         color=None,
-        capture_active: bool = False,
     ) -> BackdropItem:
         """Add a :class:`BackdropItem` to the scene and mark dirty.
 
@@ -264,7 +263,7 @@ class FlowScene(QGraphicsScene):
         explicit geometry (e.g. from a deserialised flow) without
         forcing every call site to re-import the defaults module.
         """
-        kwargs: dict = {"title": title, "capture_active": capture_active}
+        kwargs: dict = {"title": title}
         if width is not None:
             kwargs["width"] = width
         if height is not None:
@@ -289,10 +288,66 @@ class FlowScene(QGraphicsScene):
         """Return a snapshot of every backdrop currently in the scene."""
         return list(self._backdrops)
 
+    #: Padding around the bounding rect of selected nodes when a group
+    #: backdrop is auto-fitted around them. The top axis gets the
+    #: header height added on top of this so the title bar sits above
+    #: the framed nodes rather than overlapping their own headers.
+    GROUP_PADDING: float = 24.0
+
+    def create_group_around_selection(
+        self, *, title: str = "Group",
+    ) -> BackdropItem | None:
+        """Drop a backdrop framing every currently-selected node.
+
+        Returns ``None`` if fewer than two nodes are selected — the
+        caller (Toolbar / Context Menu) is responsible for gating the
+        action so this never gets a no-op invocation in normal use.
+        Geometry is the union of every selected node's scene
+        bounding rect, padded by :attr:`GROUP_PADDING` on every side
+        and an extra header-height on top so the title sits clear of
+        the nodes inside.
+        """
+        node_items = [
+            item for item in self.selectedItems() if isinstance(item, NodeItem)
+        ]
+        if len(node_items) < 2:
+            return None
+
+        # Union of every selected node's scene bounding rect.
+        rect = node_items[0].sceneBoundingRect()
+        for item in node_items[1:]:
+            rect = rect.united(item.sceneBoundingRect())
+
+        pad = self.GROUP_PADDING
+        header = BackdropItem.HEADER_HEIGHT
+        x = rect.x() - pad
+        y = rect.y() - pad - header
+        w = rect.width() + 2 * pad
+        h = rect.height() + 2 * pad + header
+
+        return self.add_backdrop(
+            QPointF(x, y), title=title, width=w, height=h,
+        )
+
     # ── Pending-link drag ──────────────────────────────────────────────────────
 
     def mousePressEvent(self, event: QGraphicsSceneMouseEvent) -> None:  # type: ignore[override]
         from PySide6.QtCore import Qt
+        from PySide6.QtGui import QTransform
+        if event.button() == Qt.MouseButton.RightButton:
+            # Qt's default mousePress handler clears the scene
+            # selection on a right-click that lands on empty canvas,
+            # which kills any multi-node selection right before our
+            # context menu reads it for "Create Group". Swallow the
+            # press in that one case so the selection survives long
+            # enough for contextMenuEvent to use it. Right-clicks on
+            # actual items still flow to super() so single-item
+            # selection updates keep working.
+            views = self.views()
+            xform = views[0].transform() if views else QTransform()
+            if self.itemAt(event.scenePos(), xform) is None:
+                event.accept()
+                return
         if event.button() == Qt.MouseButton.LeftButton:
             port = self._port_at(event.scenePos())
             if port is not None:
@@ -380,11 +435,19 @@ class FlowScene(QGraphicsScene):
         menu.exec(event.screenPos())
 
     def _canvas_context_menu(self, event: QGraphicsSceneContextMenuEvent) -> None:
+        # The empty-canvas context menu is currently single-purpose:
+        # "Create Group" around the selection. Hide the menu entirely
+        # if nothing meaningful can be done — a menu with one disabled
+        # entry reads as broken UI.
+        node_count = sum(
+            1 for item in self.selectedItems() if isinstance(item, NodeItem)
+        )
+        if node_count < 2:
+            return
         menu = QMenu()
-        add = QAction("Add Backdrop", menu)
-        scene_pos = event.scenePos()
-        add.triggered.connect(lambda: self.add_backdrop(scene_pos))
-        menu.addAction(add)
+        group = QAction("Create Group", menu)
+        group.triggered.connect(self.create_group_around_selection)
+        menu.addAction(group)
         menu.exec(event.screenPos())
 
     def _backdrop_context_menu(

--- a/src/ui/icons.py
+++ b/src/ui/icons.py
@@ -48,6 +48,7 @@ _CODEPOINTS: Final[dict[str, str]] = {
     "visibility":   "e8f4",
     "warning":      "e002",
     "refresh":      "e5d5",
+    "push_pin":     "f10d",
 }
 
 

--- a/src/ui/icons.py
+++ b/src/ui/icons.py
@@ -49,6 +49,7 @@ _CODEPOINTS: Final[dict[str, str]] = {
     "warning":      "e002",
     "refresh":      "e5d5",
     "push_pin":     "f10d",
+    "select_all":   "e162",
 }
 
 

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -99,6 +99,13 @@ class MainWindow(QMainWindow):
             page.status_widget_changed.connect(
                 lambda p=page: self._on_page_status_widget_changed(p)
             )
+            # Pages that grow / shrink their toolbar section list at
+            # runtime (e.g. a "Selection" section that only exists
+            # when something is selected) emit toolbar_layout_changed
+            # to ask MainWindow to re-read page_toolbar_sections.
+            page.toolbar_layout_changed.connect(
+                lambda p=page: self._on_page_toolbar_layout_changed(p)
+            )
 
         # Per-page signals that only make sense on one page live outside
         # the iteration above.
@@ -301,6 +308,19 @@ class MainWindow(QMainWindow):
         self._detach_page_status_action()
         self._install_page_status_widget(page)
         self._apply_consistent_button_sizes()
+
+    def _on_page_toolbar_layout_changed(self, page: PageBase) -> None:
+        """Re-install the active page's toolbar sections.
+
+        Pages emit ``toolbar_layout_changed`` when their
+        :meth:`page_toolbar_sections` answer would change — typically
+        a section appearing or disappearing as selection state
+        changes. Inactive pages are ignored; their layout is rebuilt
+        from scratch the next time they activate.
+        """
+        if self._pages.currentWidget() is not page:
+            return
+        self._install_page_toolbar_actions(page)
 
     def _apply_consistent_button_sizes(self) -> None:
         """Apply a uniform fixed size to every QToolButton in the main toolbar."""

--- a/src/ui/node_editor_page.py
+++ b/src/ui/node_editor_page.py
@@ -137,10 +137,17 @@ class NodeEditorPage(PageBase):
 
         # Actions: reused by both the page menu and the main toolbar.
         self._actions = self._build_actions()
-        # Stack actions need at least two selected nodes; keep them disabled
-        # until that is true and toggle them on selection changes.
+        # The "Selection" section (stack-V, stack-H, group) is hidden
+        # while there's no multi-node selection; flag tracks whether
+        # it's currently in the toolbar so threshold crossings can
+        # trigger a single rebuild instead of one per selection event.
+        self._selection_actions_visible: bool = False
+        # Stack / group actions need at least two selected nodes; keep
+        # them disabled until that is true and toggle them on selection
+        # changes.
         self._actions["stack_vertical"].setEnabled(False)
         self._actions["stack_horizontal"].setEnabled(False)
+        self._actions["group"].setEnabled(False)
         self._scene.selectionChanged.connect(self._update_selection_actions)
 
         # Status bar at the bottom of the inner window. The running-flow
@@ -196,7 +203,7 @@ class NodeEditorPage(PageBase):
         return material_icon("account_tree")
 
     def page_toolbar_sections(self) -> list[ToolbarSection]:
-        return [
+        sections = [
             ToolbarSection("Flow", [
                 self._actions["run"],
                 self._actions["save"],
@@ -208,10 +215,19 @@ class NodeEditorPage(PageBase):
             ToolbarSection("View", [
                 self._actions["fit"],
                 self._actions["reset_zoom"],
-                self._actions["stack_vertical"],
-                self._actions["stack_horizontal"],
             ]),
         ]
+        # The "Selection" section only makes sense with at least two
+        # nodes selected; suppressing it (rather than just disabling
+        # its actions) avoids flashing greyed-out buttons in the
+        # toolbar most of the time.
+        if self._selection_actions_visible:
+            sections.append(ToolbarSection("Selection", [
+                self._actions["stack_vertical"],
+                self._actions["stack_horizontal"],
+                self._actions["group"],
+            ]))
+        return sections
 
     @override
     def page_status_widget(self) -> QWidget | None:
@@ -231,6 +247,10 @@ class NodeEditorPage(PageBase):
         menu.addAction(self._actions["save_as"])
         menu.addAction(self._actions["open"])
         menu.addAction(self._actions["reload"])
+        menu.addSeparator()
+        menu.addAction(self._actions["stack_vertical"])
+        menu.addAction(self._actions["stack_horizontal"])
+        menu.addAction(self._actions["group"])
         menu.addSeparator()
         menu.addAction(self._actions["clear"])
         menu.addSeparator()
@@ -342,18 +362,36 @@ class NodeEditorPage(PageBase):
             "stack_horizontal": mk(
                 "H-Stack", "view_column", self._on_stack_horizontal_clicked,
             ),
+            "group": mk("Group", "select_all", self._on_group_clicked),
         }
 
     # ── Action handlers ────────────────────────────────────────────────────────
 
     def _update_selection_actions(self) -> None:
-        """Enable/disable selection-dependent actions based on node count."""
+        """Sync selection-dependent toolbar / menu state with the scene.
+
+        Two things move together:
+          - Each selection-gated action's ``enabled`` flag (so menu
+            entries grey out cleanly).
+          - The "Selection" toolbar section as a whole, which only
+            appears at all when there's something to operate on.
+            Toggling its visibility goes through
+            :attr:`toolbar_layout_changed` so MainWindow rebuilds the
+            toolbar instead of leaving an orphan separator.
+        """
         from ui.node_item import NodeItem
         selected_nodes = sum(
             1 for s in self._scene.selectedItems() if isinstance(s, NodeItem)
         )
-        self._actions["stack_vertical"].setEnabled(selected_nodes >= 2)
-        self._actions["stack_horizontal"].setEnabled(selected_nodes >= 2)
+        active = selected_nodes >= 2
+        for name in ("stack_vertical", "stack_horizontal", "group"):
+            self._actions[name].setEnabled(active)
+        if active != self._selection_actions_visible:
+            self._selection_actions_visible = active
+            self.toolbar_layout_changed.emit()
+
+    def _on_group_clicked(self) -> None:
+        self._scene.create_group_around_selection()
 
     def _on_stack_vertical_clicked(self) -> None:
         """Align selected nodes on a shared X axis and stack them vertically."""

--- a/src/ui/page.py
+++ b/src/ui/page.py
@@ -56,6 +56,11 @@ class PageBase(QWidget):
 
     title_changed = Signal(str)
     status_widget_changed = Signal()
+    #: Asks MainWindow to re-read :meth:`page_toolbar_sections` and
+    #: reinstall the toolbar. Emit when a section appears or
+    #: disappears at runtime — e.g. an "operate on selection"
+    #: section that's only present when the selection is non-empty.
+    toolbar_layout_changed = Signal()
 
     def __init__(self, parent: QWidget | None = None) -> None:
         if type(self) is PageBase:

--- a/tests/test_backdrop.py
+++ b/tests/test_backdrop.py
@@ -11,7 +11,7 @@ import pytest
 os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
 pytest.importorskip("PySide6")
 
-from PySide6.QtCore import QPointF
+from PySide6.QtCore import QPointF, Qt
 from PySide6.QtGui import QColor
 from PySide6.QtWidgets import QApplication
 
@@ -245,3 +245,136 @@ def test_close_button_routes_to_scene_remove_backdrop(qapp: QApplication) -> Non
     # needing the Qt event loop.
     scene.remove_backdrop(backdrop)
     assert backdrop not in scene.iter_backdrops()
+
+
+# ── Capture mode ──────────────────────────────────────────────────────────────
+
+
+def test_capture_active_defaults_to_off(qapp: QApplication) -> None:
+    backdrop = BackdropItem()
+    assert backdrop.capture_active is False
+
+
+def test_set_capture_active_toggles_the_flag(qapp: QApplication) -> None:
+    backdrop = BackdropItem()
+    backdrop.set_capture_active(True)
+    assert backdrop.capture_active is True
+    backdrop.set_capture_active(False)
+    assert backdrop.capture_active is False
+
+
+def _drag_backdrop(backdrop: BackdropItem, dx: float, dy: float) -> None:
+    """Simulate the press → move → release sequence the capture-aware
+    drag relies on, without spinning a Qt event loop.
+
+    Forging real ``QGraphicsSceneMouseEvent`` instances offscreen is
+    brittle, so we poke the same drag-bookkeeping fields the press
+    handler would set and rely on ``setPos`` to fire ``itemChange``
+    exactly the way Qt's drag would. The test then verifies the
+    handler's effect on captured node positions.
+    """
+    if backdrop.capture_active:
+        backdrop._drag_anchor_pos = backdrop.scenePos()  # noqa: SLF001 — internal contract under test
+        backdrop._captured_snapshot = [
+            (item, item.pos()) for item in backdrop.captured_node_items()
+        ]
+    backdrop.setPos(backdrop.pos().x() + dx, backdrop.pos().y() + dy)
+    backdrop._drag_anchor_pos = None
+    backdrop._captured_snapshot = []
+
+
+def test_dragging_with_capture_off_does_not_move_enclosed_nodes(
+    qapp: QApplication,
+) -> None:
+    """A node fully framed by the backdrop must stay put when the
+    backdrop is dragged with capture toggle off."""
+    from nodes.sources.image_source import ImageSource
+    scene = FlowScene()
+    scene.set_flow(Flow(name="cap_off"))
+    backdrop = scene.add_backdrop(QPointF(0, 0), width=400, height=300)
+    node = scene.add_node(ImageSource(), QPointF(50, 50))
+    start_pos = node.pos()
+    _drag_backdrop(backdrop, 100, 80)
+    assert node.pos() == start_pos
+
+
+def test_dragging_with_capture_on_sweeps_fully_enclosed_nodes(
+    qapp: QApplication,
+) -> None:
+    """The headline behaviour: with capture on, a node fully inside
+    the backdrop moves by the same delta the backdrop did."""
+    from nodes.sources.image_source import ImageSource
+    scene = FlowScene()
+    scene.set_flow(Flow(name="cap_on"))
+    backdrop = scene.add_backdrop(QPointF(0, 0), width=400, height=300)
+    backdrop.set_capture_active(True)
+    node = scene.add_node(ImageSource(), QPointF(50, 50))
+    start_pos = node.pos()
+    _drag_backdrop(backdrop, 100, 80)
+    assert node.pos().x() == start_pos.x() + 100
+    assert node.pos().y() == start_pos.y() + 80
+
+
+def test_capture_does_not_pull_nodes_outside_the_backdrop(
+    qapp: QApplication,
+) -> None:
+    """Only nodes whose bounding box lies fully inside the backdrop
+    at press-time count. A node clearly outside must stay put."""
+    from nodes.sources.image_source import ImageSource
+    scene = FlowScene()
+    scene.set_flow(Flow(name="cap_outside"))
+    backdrop = scene.add_backdrop(QPointF(0, 0), width=200, height=150)
+    backdrop.set_capture_active(True)
+    outside = scene.add_node(ImageSource(), QPointF(2000, 2000))
+    start_pos = outside.pos()
+    _drag_backdrop(backdrop, 50, 50)
+    assert outside.pos() == start_pos
+
+
+def test_capture_snapshot_is_taken_at_press_time(qapp: QApplication) -> None:
+    """A node that wasn't framed at press-time mustn't get swept along
+    just because the moving backdrop ran into it mid-drag — we'd
+    otherwise vacuum up every node the backdrop crosses."""
+    from nodes.sources.image_source import ImageSource
+    scene = FlowScene()
+    scene.set_flow(Flow(name="cap_snap"))
+    backdrop = scene.add_backdrop(QPointF(0, 0), width=200, height=150)
+    backdrop.set_capture_active(True)
+    # Node sitting outside the backdrop at press-time. Even though
+    # dragging the backdrop +250px right would have it overlap the
+    # node mid-flight, the snapshot was empty at press, so no shift.
+    far = scene.add_node(ImageSource(), QPointF(500, 50))
+    start_pos = far.pos()
+    _drag_backdrop(backdrop, 250, 0)
+    assert far.pos() == start_pos
+
+
+def test_capture_flag_round_trips_through_save_and_load(
+    qapp: QApplication, tmp_path: Path,
+) -> None:
+    scene = FlowScene()
+    flow = Flow(name="cap_persist")
+    scene.set_flow(flow)
+    backdrop = scene.add_backdrop(QPointF(0, 0))
+    backdrop.set_capture_active(True)
+
+    path = tmp_path / "cap.flowjs"
+    save_flow_to(path, scene, flow)
+
+    fresh = FlowScene()
+    load_flow_into(path, fresh)
+    [restored] = fresh.iter_backdrops()
+    assert restored.capture_active is True
+
+
+def test_capture_flag_omitted_when_off_in_serialised_form(
+    qapp: QApplication,
+) -> None:
+    """Default-off capture state stays out of the JSON to keep flows
+    tidy for the common case."""
+    scene = FlowScene()
+    flow = Flow(name="cap_default")
+    scene.set_flow(flow)
+    scene.add_backdrop(QPointF(0, 0))
+    data = serialize_flow(scene, flow)
+    assert "capture" not in data["backdrops"][0]

--- a/tests/test_backdrop.py
+++ b/tests/test_backdrop.py
@@ -1,0 +1,146 @@
+"""Tests for Backdrop scene items and their flow-file round-trip."""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+pytest.importorskip("PySide6")
+
+from PySide6.QtCore import QPointF
+from PySide6.QtGui import QColor
+from PySide6.QtWidgets import QApplication
+
+from core.flow import Flow
+from ui.backdrop_item import (
+    BackdropItem,
+    DEFAULT_BACKDROP_COLOR,
+    MIN_BACKDROP_HEIGHT,
+    MIN_BACKDROP_WIDTH,
+)
+from ui.flow_io import load_flow_into, save_flow_to, serialize_flow
+from ui.flow_scene import FlowScene
+
+
+@pytest.fixture(scope="module")
+def qapp() -> QApplication:
+    return QApplication.instance() or QApplication(sys.argv)
+
+
+def test_backdrop_default_geometry_matches_module_constants(qapp: QApplication) -> None:
+    backdrop = BackdropItem()
+    assert backdrop.title == "Backdrop"
+    assert backdrop.color.red() == DEFAULT_BACKDROP_COLOR.red()
+    assert backdrop.width > 0 and backdrop.height > 0
+
+
+def test_backdrop_set_size_enforces_minimum(qapp: QApplication) -> None:
+    """Dragging the grip past the minimum must clamp, not collapse
+    the frame into an unclickable sliver."""
+    backdrop = BackdropItem()
+    backdrop.set_size(10, 10)
+    assert backdrop.width == MIN_BACKDROP_WIDTH
+    assert backdrop.height == MIN_BACKDROP_HEIGHT
+
+
+def test_add_backdrop_tracks_it_in_the_scene(qapp: QApplication) -> None:
+    scene = FlowScene()
+    scene.set_flow(Flow(name="backdrop"))
+    backdrop = scene.add_backdrop(QPointF(40, 50), title="Group")
+    assert backdrop in scene.iter_backdrops()
+    assert backdrop.pos().x() == 40
+    assert backdrop.title == "Group"
+
+
+def test_add_backdrop_marks_scene_dirty(qapp: QApplication) -> None:
+    scene = FlowScene()
+    scene.set_flow(Flow(name="backdrop"))
+    assert scene.is_dirty is False
+    scene.add_backdrop(QPointF(0, 0))
+    assert scene.is_dirty is True
+
+
+def test_remove_backdrop_drops_it_and_marks_dirty(qapp: QApplication) -> None:
+    scene = FlowScene()
+    scene.set_flow(Flow(name="backdrop"))
+    backdrop = scene.add_backdrop(QPointF(0, 0))
+    scene.mark_saved()
+    assert scene.is_dirty is False
+    scene.remove_backdrop(backdrop)
+    assert backdrop not in scene.iter_backdrops()
+    assert scene.is_dirty is True
+
+
+def test_serialize_backdrops_emits_geometry_and_colour(qapp: QApplication) -> None:
+    scene = FlowScene()
+    flow = Flow(name="backdrop")
+    scene.set_flow(flow)
+    scene.add_backdrop(
+        QPointF(10, 20),
+        title="Chapter",
+        width=240,
+        height=160,
+        color=QColor(30, 40, 50, 180),
+    )
+    data = serialize_flow(scene, flow)
+    assert data["backdrops"] == [{
+        "position": [10.0, 20.0],
+        "size":     [240.0, 160.0],
+        "title":    "Chapter",
+        "color":    [30, 40, 50, 180],
+    }]
+
+
+def test_backdrops_round_trip_through_save_and_load(
+    qapp: QApplication, tmp_path: Path,
+) -> None:
+    """Save a flow with a backdrop, load it back into a fresh scene,
+    and check every persisted property survived intact."""
+    scene = FlowScene()
+    flow = Flow(name="backdrop_roundtrip")
+    scene.set_flow(flow)
+    scene.add_backdrop(
+        QPointF(100, 50),
+        title="Mask prep",
+        width=300,
+        height=180,
+        color=QColor(40, 70, 50, 140),
+    )
+
+    path = tmp_path / "bd.flowjs"
+    save_flow_to(path, scene, flow)
+
+    fresh_scene = FlowScene()
+    load_flow_into(path, fresh_scene)
+    backdrops = fresh_scene.iter_backdrops()
+    assert len(backdrops) == 1
+    b = backdrops[0]
+    assert b.title == "Mask prep"
+    assert b.width == 300
+    assert b.height == 180
+    assert b.pos().x() == 100 and b.pos().y() == 50
+    assert (b.color.red(), b.color.green(), b.color.blue(), b.color.alpha()) == (40, 70, 50, 140)
+
+
+def test_loading_flow_without_backdrops_field_is_fine(
+    qapp: QApplication, tmp_path: Path,
+) -> None:
+    """Older flow files (pre-backdrop) lack the "backdrops" key. The
+    loader must treat the absence as "no backdrops" rather than
+    throwing a KeyError."""
+    path = tmp_path / "old.flowjs"
+    path.write_text(json.dumps({
+        "version":     1,
+        "app_version": "0.1.16",
+        "name":        "old",
+        "nodes":       [],
+        "connections": [],
+    }), encoding="utf-8")
+
+    scene = FlowScene()
+    load_flow_into(path, scene)
+    assert scene.iter_backdrops() == []

--- a/tests/test_backdrop.py
+++ b/tests/test_backdrop.py
@@ -247,20 +247,7 @@ def test_close_button_routes_to_scene_remove_backdrop(qapp: QApplication) -> Non
     assert backdrop not in scene.iter_backdrops()
 
 
-# ── Capture mode ──────────────────────────────────────────────────────────────
-
-
-def test_capture_active_defaults_to_off(qapp: QApplication) -> None:
-    backdrop = BackdropItem()
-    assert backdrop.capture_active is False
-
-
-def test_set_capture_active_toggles_the_flag(qapp: QApplication) -> None:
-    backdrop = BackdropItem()
-    backdrop.set_capture_active(True)
-    assert backdrop.capture_active is True
-    backdrop.set_capture_active(False)
-    assert backdrop.capture_active is False
+# ── Capture-on-drag (always on) ───────────────────────────────────────────────
 
 
 def _drag_backdrop(backdrop: BackdropItem, dx: float, dy: float) -> None:
@@ -270,44 +257,24 @@ def _drag_backdrop(backdrop: BackdropItem, dx: float, dy: float) -> None:
     Forging real ``QGraphicsSceneMouseEvent`` instances offscreen is
     brittle, so we poke the same drag-bookkeeping fields the press
     handler would set and rely on ``setPos`` to fire ``itemChange``
-    exactly the way Qt's drag would. The test then verifies the
-    handler's effect on captured node positions.
+    exactly the way Qt's drag would.
     """
-    if backdrop.capture_active:
-        backdrop._drag_anchor_pos = backdrop.scenePos()  # noqa: SLF001 — internal contract under test
-        backdrop._captured_snapshot = [
-            (item, item.pos()) for item in backdrop.captured_node_items()
-        ]
+    backdrop._drag_anchor_pos = backdrop.scenePos()  # noqa: SLF001 — internal contract under test
+    backdrop._captured_snapshot = [
+        (item, item.pos()) for item in backdrop.captured_node_items()
+    ]
     backdrop.setPos(backdrop.pos().x() + dx, backdrop.pos().y() + dy)
     backdrop._drag_anchor_pos = None
     backdrop._captured_snapshot = []
 
 
-def test_dragging_with_capture_off_does_not_move_enclosed_nodes(
-    qapp: QApplication,
-) -> None:
-    """A node fully framed by the backdrop must stay put when the
-    backdrop is dragged with capture toggle off."""
-    from nodes.sources.image_source import ImageSource
-    scene = FlowScene()
-    scene.set_flow(Flow(name="cap_off"))
-    backdrop = scene.add_backdrop(QPointF(0, 0), width=400, height=300)
-    node = scene.add_node(ImageSource(), QPointF(50, 50))
-    start_pos = node.pos()
-    _drag_backdrop(backdrop, 100, 80)
-    assert node.pos() == start_pos
-
-
-def test_dragging_with_capture_on_sweeps_fully_enclosed_nodes(
-    qapp: QApplication,
-) -> None:
-    """The headline behaviour: with capture on, a node fully inside
-    the backdrop moves by the same delta the backdrop did."""
+def test_dragging_sweeps_fully_enclosed_nodes(qapp: QApplication) -> None:
+    """The headline behaviour: a node fully inside the backdrop moves
+    by the same delta the backdrop did."""
     from nodes.sources.image_source import ImageSource
     scene = FlowScene()
     scene.set_flow(Flow(name="cap_on"))
     backdrop = scene.add_backdrop(QPointF(0, 0), width=400, height=300)
-    backdrop.set_capture_active(True)
     node = scene.add_node(ImageSource(), QPointF(50, 50))
     start_pos = node.pos()
     _drag_backdrop(backdrop, 100, 80)
@@ -315,7 +282,7 @@ def test_dragging_with_capture_on_sweeps_fully_enclosed_nodes(
     assert node.pos().y() == start_pos.y() + 80
 
 
-def test_capture_does_not_pull_nodes_outside_the_backdrop(
+def test_dragging_does_not_pull_nodes_outside_the_backdrop(
     qapp: QApplication,
 ) -> None:
     """Only nodes whose bounding box lies fully inside the backdrop
@@ -324,7 +291,6 @@ def test_capture_does_not_pull_nodes_outside_the_backdrop(
     scene = FlowScene()
     scene.set_flow(Flow(name="cap_outside"))
     backdrop = scene.add_backdrop(QPointF(0, 0), width=200, height=150)
-    backdrop.set_capture_active(True)
     outside = scene.add_node(ImageSource(), QPointF(2000, 2000))
     start_pos = outside.pos()
     _drag_backdrop(backdrop, 50, 50)
@@ -339,9 +305,8 @@ def test_capture_snapshot_is_taken_at_press_time(qapp: QApplication) -> None:
     scene = FlowScene()
     scene.set_flow(Flow(name="cap_snap"))
     backdrop = scene.add_backdrop(QPointF(0, 0), width=200, height=150)
-    backdrop.set_capture_active(True)
     # Node sitting outside the backdrop at press-time. Even though
-    # dragging the backdrop +250px right would have it overlap the
+    # dragging the backdrop +250 px right would have it overlap the
     # node mid-flight, the snapshot was empty at press, so no shift.
     far = scene.add_node(ImageSource(), QPointF(500, 50))
     start_pos = far.pos()
@@ -349,32 +314,49 @@ def test_capture_snapshot_is_taken_at_press_time(qapp: QApplication) -> None:
     assert far.pos() == start_pos
 
 
-def test_capture_flag_round_trips_through_save_and_load(
-    qapp: QApplication, tmp_path: Path,
-) -> None:
-    scene = FlowScene()
-    flow = Flow(name="cap_persist")
-    scene.set_flow(flow)
-    backdrop = scene.add_backdrop(QPointF(0, 0))
-    backdrop.set_capture_active(True)
-
-    path = tmp_path / "cap.flowjs"
-    save_flow_to(path, scene, flow)
-
-    fresh = FlowScene()
-    load_flow_into(path, fresh)
-    [restored] = fresh.iter_backdrops()
-    assert restored.capture_active is True
+# ── Create Group around selection ─────────────────────────────────────────────
 
 
-def test_capture_flag_omitted_when_off_in_serialised_form(
+def test_create_group_returns_none_when_fewer_than_two_nodes_selected(
     qapp: QApplication,
 ) -> None:
-    """Default-off capture state stays out of the JSON to keep flows
-    tidy for the common case."""
+    from nodes.sources.image_source import ImageSource
     scene = FlowScene()
-    flow = Flow(name="cap_default")
-    scene.set_flow(flow)
-    scene.add_backdrop(QPointF(0, 0))
-    data = serialize_flow(scene, flow)
-    assert "capture" not in data["backdrops"][0]
+    scene.set_flow(Flow(name="group_empty"))
+    item = scene.add_node(ImageSource(), QPointF(0, 0))
+    item.setSelected(True)
+    assert scene.create_group_around_selection() is None
+
+
+def test_create_group_frames_every_selected_node(qapp: QApplication) -> None:
+    """The auto-fitted backdrop's scene rect must contain every
+    selected node's scene rect (with padding) — i.e. the framed
+    group is "captured" for the very next drag."""
+    from nodes.filters.grayscale import Grayscale
+    from nodes.sources.image_source import ImageSource
+    scene = FlowScene()
+    scene.set_flow(Flow(name="group_two"))
+    a = scene.add_node(ImageSource(), QPointF(0, 0))
+    b = scene.add_node(Grayscale(), QPointF(400, 100))
+    a.setSelected(True)
+    b.setSelected(True)
+    backdrop = scene.create_group_around_selection()
+    assert backdrop is not None
+    rect = backdrop.sceneBoundingRect()
+    assert rect.contains(a.sceneBoundingRect())
+    assert rect.contains(b.sceneBoundingRect())
+
+
+def test_create_group_marks_scene_dirty(qapp: QApplication) -> None:
+    from nodes.filters.grayscale import Grayscale
+    from nodes.sources.image_source import ImageSource
+    scene = FlowScene()
+    scene.set_flow(Flow(name="group_dirty"))
+    a = scene.add_node(ImageSource(), QPointF(0, 0))
+    b = scene.add_node(Grayscale(), QPointF(400, 0))
+    a.setSelected(True)
+    b.setSelected(True)
+    scene.mark_saved()
+    assert scene.is_dirty is False
+    scene.create_group_around_selection()
+    assert scene.is_dirty is True

--- a/tests/test_backdrop.py
+++ b/tests/test_backdrop.py
@@ -21,6 +21,7 @@ from ui.backdrop_item import (
     DEFAULT_BACKDROP_COLOR,
     MIN_BACKDROP_HEIGHT,
     MIN_BACKDROP_WIDTH,
+    _Corner,
 )
 from ui.flow_io import load_flow_into, save_flow_to, serialize_flow
 from ui.flow_scene import FlowScene
@@ -144,3 +145,103 @@ def test_loading_flow_without_backdrops_field_is_fine(
     scene = FlowScene()
     load_flow_into(path, scene)
     assert scene.iter_backdrops() == []
+
+
+# ── Resize from each corner / close button ────────────────────────────────────
+
+
+def _simulate_grip_drag(backdrop: BackdropItem, corner: _Corner, dx: float, dy: float) -> None:
+    """Drive a grip drag programmatically by feeding the same start /
+    end scene positions a real Qt mouse press + move would emit.
+
+    We poke the grip's internal drag-state directly because building
+    real ``QGraphicsSceneMouseEvent`` instances offscreen is brittle —
+    the only behaviour under test is "drag-from-corner produces the
+    right pos / size", which mouseMoveEvent computes from those
+    fields.
+    """
+    grip = backdrop._grips[corner]  # noqa: SLF001 — test of internals
+    grip._drag_start_scene = QPointF(0, 0)
+    grip._drag_start_pos = backdrop.pos()
+    grip._drag_start_size = (backdrop.width, backdrop.height)
+
+    class _FakeEvent:
+        def __init__(self, p: QPointF) -> None:
+            self._p = p
+
+        def scenePos(self) -> QPointF:
+            return self._p
+
+        def accept(self) -> None:
+            pass
+
+    grip.mouseMoveEvent(_FakeEvent(QPointF(dx, dy)))
+
+
+def test_resize_from_se_grows_to_the_right_and_down(qapp: QApplication) -> None:
+    backdrop = BackdropItem(width=200, height=150)
+    backdrop.setPos(50, 60)
+    _simulate_grip_drag(backdrop, _Corner.SE, dx=40, dy=30)
+    # SE drag pins the top-left, so position is unchanged.
+    assert (backdrop.pos().x(), backdrop.pos().y()) == (50, 60)
+    assert (backdrop.width, backdrop.height) == (240, 180)
+
+
+def test_resize_from_nw_pins_the_bottom_right(qapp: QApplication) -> None:
+    backdrop = BackdropItem(width=200, height=150)
+    backdrop.setPos(50, 60)
+    _simulate_grip_drag(backdrop, _Corner.NW, dx=20, dy=10)
+    # The bottom-right corner must stay where it was: x=50+200=250,
+    # y=60+150=210. Pulling NW by (20, 10) shrinks both axes by that
+    # amount and shifts the position accordingly.
+    assert (backdrop.pos().x(), backdrop.pos().y()) == (70, 70)
+    assert (backdrop.width, backdrop.height) == (180, 140)
+    assert backdrop.pos().x() + backdrop.width == 250
+    assert backdrop.pos().y() + backdrop.height == 210
+
+
+def test_resize_from_ne_pins_the_bottom_left(qapp: QApplication) -> None:
+    backdrop = BackdropItem(width=200, height=150)
+    backdrop.setPos(50, 60)
+    _simulate_grip_drag(backdrop, _Corner.NE, dx=30, dy=20)
+    assert backdrop.pos().x() == 50
+    assert backdrop.pos().y() == 80
+    assert (backdrop.width, backdrop.height) == (230, 130)
+    assert backdrop.pos().y() + backdrop.height == 210
+
+
+def test_resize_from_sw_pins_the_top_right(qapp: QApplication) -> None:
+    backdrop = BackdropItem(width=200, height=150)
+    backdrop.setPos(50, 60)
+    _simulate_grip_drag(backdrop, _Corner.SW, dx=15, dy=25)
+    assert backdrop.pos().x() == 65
+    assert backdrop.pos().y() == 60
+    assert (backdrop.width, backdrop.height) == (185, 175)
+    assert backdrop.pos().x() + backdrop.width == 250
+
+
+def test_resize_clamp_keeps_anchor_pinned(qapp: QApplication) -> None:
+    """Clamping at the minimum must not let the anchor corner drift —
+    a giant inward drag with NW must still leave the bottom-right
+    where the user originally placed it."""
+    backdrop = BackdropItem(width=200, height=150)
+    backdrop.setPos(50, 60)
+    _simulate_grip_drag(backdrop, _Corner.NW, dx=999, dy=999)
+    assert backdrop.width == MIN_BACKDROP_WIDTH
+    assert backdrop.height == MIN_BACKDROP_HEIGHT
+    assert backdrop.pos().x() + backdrop.width == 250
+    assert backdrop.pos().y() + backdrop.height == 210
+
+
+def test_close_button_routes_to_scene_remove_backdrop(qapp: QApplication) -> None:
+    """The X close button on a backdrop must remove it through the
+    same path the context menu uses (``scene.remove_backdrop``).
+    """
+    scene = FlowScene()
+    scene.set_flow(Flow(name="bd_close"))
+    backdrop = scene.add_backdrop(QPointF(0, 0))
+    # The close button defers via QTimer.singleShot(0); call the
+    # scene method directly here to exercise the same end state without
+    # needing the Qt event loop.
+    scene.remove_backdrop(backdrop)
+    assert backdrop not in scene.iter_backdrops()

--- a/tests/test_backdrop.py
+++ b/tests/test_backdrop.py
@@ -21,7 +21,6 @@ from ui.backdrop_item import (
     DEFAULT_BACKDROP_COLOR,
     MIN_BACKDROP_HEIGHT,
     MIN_BACKDROP_WIDTH,
-    _Corner,
 )
 from ui.flow_io import load_flow_into, save_flow_to, serialize_flow
 from ui.flow_scene import FlowScene
@@ -145,92 +144,6 @@ def test_loading_flow_without_backdrops_field_is_fine(
     scene = FlowScene()
     load_flow_into(path, scene)
     assert scene.iter_backdrops() == []
-
-
-# ── Resize from each corner / close button ────────────────────────────────────
-
-
-def _simulate_grip_drag(backdrop: BackdropItem, corner: _Corner, dx: float, dy: float) -> None:
-    """Drive a grip drag programmatically by feeding the same start /
-    end scene positions a real Qt mouse press + move would emit.
-
-    We poke the grip's internal drag-state directly because building
-    real ``QGraphicsSceneMouseEvent`` instances offscreen is brittle —
-    the only behaviour under test is "drag-from-corner produces the
-    right pos / size", which mouseMoveEvent computes from those
-    fields.
-    """
-    grip = backdrop._grips[corner]  # noqa: SLF001 — test of internals
-    grip._drag_start_scene = QPointF(0, 0)
-    grip._drag_start_pos = backdrop.pos()
-    grip._drag_start_size = (backdrop.width, backdrop.height)
-
-    class _FakeEvent:
-        def __init__(self, p: QPointF) -> None:
-            self._p = p
-
-        def scenePos(self) -> QPointF:
-            return self._p
-
-        def accept(self) -> None:
-            pass
-
-    grip.mouseMoveEvent(_FakeEvent(QPointF(dx, dy)))
-
-
-def test_resize_from_se_grows_to_the_right_and_down(qapp: QApplication) -> None:
-    backdrop = BackdropItem(width=200, height=150)
-    backdrop.setPos(50, 60)
-    _simulate_grip_drag(backdrop, _Corner.SE, dx=40, dy=30)
-    # SE drag pins the top-left, so position is unchanged.
-    assert (backdrop.pos().x(), backdrop.pos().y()) == (50, 60)
-    assert (backdrop.width, backdrop.height) == (240, 180)
-
-
-def test_resize_from_nw_pins_the_bottom_right(qapp: QApplication) -> None:
-    backdrop = BackdropItem(width=200, height=150)
-    backdrop.setPos(50, 60)
-    _simulate_grip_drag(backdrop, _Corner.NW, dx=20, dy=10)
-    # The bottom-right corner must stay where it was: x=50+200=250,
-    # y=60+150=210. Pulling NW by (20, 10) shrinks both axes by that
-    # amount and shifts the position accordingly.
-    assert (backdrop.pos().x(), backdrop.pos().y()) == (70, 70)
-    assert (backdrop.width, backdrop.height) == (180, 140)
-    assert backdrop.pos().x() + backdrop.width == 250
-    assert backdrop.pos().y() + backdrop.height == 210
-
-
-def test_resize_from_ne_pins_the_bottom_left(qapp: QApplication) -> None:
-    backdrop = BackdropItem(width=200, height=150)
-    backdrop.setPos(50, 60)
-    _simulate_grip_drag(backdrop, _Corner.NE, dx=30, dy=20)
-    assert backdrop.pos().x() == 50
-    assert backdrop.pos().y() == 80
-    assert (backdrop.width, backdrop.height) == (230, 130)
-    assert backdrop.pos().y() + backdrop.height == 210
-
-
-def test_resize_from_sw_pins_the_top_right(qapp: QApplication) -> None:
-    backdrop = BackdropItem(width=200, height=150)
-    backdrop.setPos(50, 60)
-    _simulate_grip_drag(backdrop, _Corner.SW, dx=15, dy=25)
-    assert backdrop.pos().x() == 65
-    assert backdrop.pos().y() == 60
-    assert (backdrop.width, backdrop.height) == (185, 175)
-    assert backdrop.pos().x() + backdrop.width == 250
-
-
-def test_resize_clamp_keeps_anchor_pinned(qapp: QApplication) -> None:
-    """Clamping at the minimum must not let the anchor corner drift —
-    a giant inward drag with NW must still leave the bottom-right
-    where the user originally placed it."""
-    backdrop = BackdropItem(width=200, height=150)
-    backdrop.setPos(50, 60)
-    _simulate_grip_drag(backdrop, _Corner.NW, dx=999, dy=999)
-    assert backdrop.width == MIN_BACKDROP_WIDTH
-    assert backdrop.height == MIN_BACKDROP_HEIGHT
-    assert backdrop.pos().x() + backdrop.width == 250
-    assert backdrop.pos().y() + backdrop.height == 210
 
 
 def test_close_button_routes_to_scene_remove_backdrop(qapp: QApplication) -> None:


### PR DESCRIPTION
## Summary

Adds **backdrops** — coloured rectangular frames drawn behind groups of nodes — as a visual grouping affordance for dense pipelines. Pure visual; no execution semantics, no flow-model impact.

This is the backdrops half of the work that was originally on PR #147; the reroute half was shelved (open UX issues) so the closed PR isn't blocking this.

## Interactions

- **Right-click empty canvas** → "Add Backdrop" drops one at the cursor.
- **Right-click a backdrop** → rename, colour preset (Amber / Azure / Forest / Plum / Slate), delete.
- **Bottom-right grip** resizes (min 80×60 to stay clickable).
- **Delete key** removes a selected backdrop.

## Persistence

New `backdrops` entry alongside `nodes` / `connections` in the flow JSON. Each entry: `position`, `size`, `title`, `color (RGBA)`. Older flows lacking the field load unchanged — the loader treats absence as "no backdrops".

## Tests

- 8 new tests in `tests/test_backdrop.py`: defaults, min-size clamp, dirty tracking on add/remove, scene tracking, serialisation shape, full save→load round-trip, and the legacy "no backdrops field" fallback.
- Full suite: **141 passed**.

## Test plan

- [x] `pytest tests/` — green.
- [ ] Manual: right-click empty canvas → Add Backdrop drops a frame.
- [ ] Manual: drag the title bar to move; bottom-right grip to resize.
- [ ] Manual: rename via context menu; pick a colour preset.
- [ ] Manual: select + Delete to remove.
- [ ] Manual: save a flow with backdrops, reopen → frames are exactly where they were, with title and colour intact.
- [ ] Manual: open a pre-0.1.17 flow without `backdrops` field → no regressions.

https://claude.ai/code/session_01JZ3D7ive83Qrb3NjyZS8dM

---
_Generated by [Claude Code](https://claude.ai/code/session_01JZ3D7ive83Qrb3NjyZS8dM)_