### PR TITLE
Merge node: use standard optional-port mechanism

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,22 @@ once a first tagged release is cut.
 
 ## [Unreleased]
 
+## [0.1.18] — 2026-04-25
+
+### Changed
+- **Merge node uses the standard optional-port mechanism.** Its four
+  quadrant inputs (``top_left``, ``top_right``, ``bottom_left``,
+  ``bottom_right``) are now declared ``optional=True`` on the
+  ``InputPort`` instead of being handled by a bespoke
+  ``_signal_input_ready`` override. The dispatch logic in
+  ``NodeBase._signal_input_ready`` (``not p.optional or p.upstream is
+  not None``) already filters unconnected optional inputs out of the
+  "wait on" set, so behaviour is unchanged: unconnected quadrants
+  become black and never deadlock the node. The four ports now
+  render as hollow dots in the UI — consistent with RGBA Join's
+  alpha input, which was the first (and until now the only) user of
+  the optional-port flag.
+
 ## [0.1.17] — 2026-04-24
 
 ### Added

--- a/doc/welcome.html
+++ b/doc/welcome.html
@@ -164,7 +164,7 @@
   <main class="content-col">
 
     <header class="hero">
-      <h1>Welcome to Stjörnhorn <span class="version">v0.1.17</span></h1>
+      <h1>Welcome to Stjörnhorn <span class="version">v0.1.18</span></h1>
       <div class="tagline">A node-based image- and video-processing playground.</div>
     </header>
 
@@ -197,12 +197,12 @@
     </section>
 
     <section>
-      <h2>What's new in v0.1.17</h2>
+      <h2>What's new in v0.1.18</h2>
       <ul class="tips">
-        <li><strong>Backdrops</strong> — right-click empty canvas to drop a coloured frame behind a group of nodes. Use them as loose chapter headings ("Colour prep", "Alpha mask") so large flows stay readable.</li>
+        <li><strong>Merge node uses the standard optional-port mechanism</strong> — the four quadrant inputs are now declared <code>optional=True</code> and render as hollow dots, matching RGBA Join's alpha input. Behaviour is unchanged: missing quadrants become black.</li>
+        <li><strong>Backdrops</strong> (v0.1.17) — right-click empty canvas to drop a coloured frame behind a group of nodes. Use them as loose chapter headings ("Colour prep", "Alpha mask") so large flows stay readable.</li>
         <li><strong>Video Source paths are now portable</strong> (v0.1.16) — video references under the <code>input/</code> folder save as short relative names and resolve them the same way as image sources, regardless of the working directory.</li>
         <li><strong>Unsaved-changes indicator</strong> (v0.1.15) — the editor's toolbar shows an amber warning icon with "Unsaved changes" the moment a parameter, node, or connection is edited, and clears it on save, load, or reload.</li>
-        <li><strong>Reload</strong> toolbar action (v0.1.15) re-reads the current flow from disk, discarding unsaved edits after a confirmation.</li>
       </ul>
     </section>
 

--- a/src/constants.py
+++ b/src/constants.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 APP_NAME:         str = "Image-Inquest"
 APP_DISPLAY_NAME: str = "Stjörnhorn"
-APP_VERSION:      str = "0.1.17"
+APP_VERSION:      str = "0.1.18"
 API_URL:    str = "https://beltoforion.de"
 
 # Bundled documentation (offline welcome page, screenshots, …)

--- a/src/nodes/filters/merge.py
+++ b/src/nodes/filters/merge.py
@@ -38,7 +38,7 @@ class Merge(NodeBase):
     def __init__(self) -> None:
         super().__init__("Merge", section="Composit")
         for name in self._QUADRANTS:
-            self._add_input(InputPort(name, set(IMAGE_TYPES)))
+            self._add_input(InputPort(name, set(IMAGE_TYPES), optional=True))
         self._add_output(OutputPort("image", set(IMAGE_TYPES)))
 
     # ── Parameters ─────────────────────────────────────────────────────────────
@@ -49,27 +49,6 @@ class Merge(NodeBase):
         return []
 
     # ── NodeBase interface ─────────────────────────────────────────────────────
-
-    @override
-    def _signal_input_ready(self) -> None:
-        """Fire when every *connected* input has delivered data.
-
-        Overrides the default (all-inputs-ready) because Merge deliberately
-        supports partial connections — unconnected ports never receive
-        anything, so waiting on them would deadlock the node.
-        """
-        connected = [p for p in self._inputs if p.upstream is not None]
-        if not connected:
-            return
-
-        if all(p.has_data for p in connected):
-            self.process()
-            for p in connected:
-                p.clear()
-            return
-
-        if all(p.finished for p in connected):
-            self._on_finish()
 
     @override
     def process_impl(self) -> None:


### PR DESCRIPTION
## Summary
Refactored the Merge node to use the standard optional-port mechanism instead of a custom `_signal_input_ready` override. This simplifies the implementation while maintaining identical behavior.

## Changes
- **Mark quadrant inputs as optional**: All four quadrant input ports (`top_left`, `top_right`, `bottom_left`, `bottom_right`) are now declared with `optional=True` on the `InputPort` constructor
- **Remove custom signal handler**: Deleted the `_signal_input_ready` override that manually filtered connected inputs and checked their readiness state
- **Leverage existing framework logic**: The standard `NodeBase._signal_input_ready` implementation already handles optional ports correctly by filtering unconnected optional inputs out of the "wait on" set

## Implementation Details
The removal of the custom override is safe because `NodeBase._signal_input_ready` contains the logic `not p.optional or p.upstream is not None`, which automatically excludes unconnected optional ports from readiness checks. This prevents deadlocks when quadrants are left unconnected (they become black as before).

As a side effect, the four quadrant ports will now render as hollow dots in the UI, making them visually consistent with RGBA Join's alpha input—the only other node using the optional-port flag until now.

Version bumped to 0.1.18 and documentation updated accordingly.

https://claude.ai/code/session_014g94rK1RACKR3NZf1zJEBH