### PR TITLE
Fix transparent ComboBox popup on Windows (#136)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,9 +22,7 @@ once a first tagged release is cut.
   scene canvas — the application stylesheet rules never landed on a
   real fill. ``SceneAwareComboBox`` now forces both the container and
   the view opaque on first popup, and pins their palettes to the same
-  dark colours as the rest of the UI. The companion
-  ``QComboBox QAbstractItemView`` rule in ``src/ui/theme.py`` is kept
-  as defence-in-depth for non-proxied use. Fixes #136.
+  dark colours as the rest of the UI. Fixes #136.
 
 ## [0.1.18] — 2026-04-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,14 +13,18 @@ once a first tagged release is cut.
 ## [0.1.19] — 2026-04-25
 
 ### Fixed
-- **Windows: ComboBox popup background.** ``QComboBox`` parameter
-  widgets (the dropdowns used for every enum-typed node parameter)
-  rendered with a transparent / system-default popup on the Windows
-  native style because Qt does not propagate the
-  ``QListWidget``/``QTreeView`` rules in the dark stylesheet to the
-  ``QAbstractItemView`` it creates internally for the popup. An
-  explicit ``QComboBox QAbstractItemView`` rule pins the popup to
-  the same dark palette as the rest of the UI. Fixes #136.
+- **Windows: ComboBox popup background.** Enum-typed node parameters
+  use ``SceneAwareComboBox``, which is hosted inside a
+  ``QGraphicsProxyWidget``. The popup container (a
+  ``QComboBoxPrivateContainer`` QFrame around a ``QListView``) does
+  not inherit ``autoFillBackground=True`` through the proxy on the
+  Windows native style, so the dropdown rendered transparent over the
+  scene canvas — the application stylesheet rules never landed on a
+  real fill. ``SceneAwareComboBox`` now forces both the container and
+  the view opaque on first popup, and pins their palettes to the same
+  dark colours as the rest of the UI. The companion
+  ``QComboBox QAbstractItemView`` rule in ``src/ui/theme.py`` is kept
+  as defence-in-depth for non-proxied use. Fixes #136.
 
 ## [0.1.18] — 2026-04-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ once a first tagged release is cut.
 
 ## [Unreleased]
 
+## [0.1.19] — 2026-04-25
+
+### Fixed
+- **Windows: ComboBox popup background.** ``QComboBox`` parameter
+  widgets (the dropdowns used for every enum-typed node parameter)
+  rendered with a transparent / system-default popup on the Windows
+  native style because Qt does not propagate the
+  ``QListWidget``/``QTreeView`` rules in the dark stylesheet to the
+  ``QAbstractItemView`` it creates internally for the popup. An
+  explicit ``QComboBox QAbstractItemView`` rule pins the popup to
+  the same dark palette as the rest of the UI. Fixes #136.
+
 ## [0.1.18] — 2026-04-25
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,7 @@
 
 ## Implementation
 - Keep performance in mind when writing code, especially on hot paths (per-frame video processing, image ops). Proactively surface non-trivial optimisation opportunities — skippable work, redundant copies, per-frame allocations in streaming paths — but do not spend effort on micro-optimisations (enum lookups, local variable binding, attribute lookup caching) that do not move the needle on real workloads.
+- When fixing a bug tracked by a GitHub issue, reference the issue number in a source-code comment next to the fix (e.g. `Issue: #136`). This overrides any general guidance to keep ticket references out of source — for bug fixes the discoverability via `grep` outweighs the risk of stale references. Applies to bug fixes only; feature work and ordinary code do not need issue references in comments.
 
 ## Communication Style
 - Keine einleitenden Formulierungen (z. B. "Kurze, ehrliche Antwort:", "Gerne,", "Natürlich,"). Direkt zum Punkt, reine Informationsübertragung, so kurz wie möglich.

--- a/doc/welcome.html
+++ b/doc/welcome.html
@@ -164,7 +164,7 @@
   <main class="content-col">
 
     <header class="hero">
-      <h1>Welcome to Stjörnhorn <span class="version">v0.1.18</span></h1>
+      <h1>Welcome to Stjörnhorn <span class="version">v0.1.19</span></h1>
       <div class="tagline">A node-based image- and video-processing playground.</div>
     </header>
 
@@ -197,12 +197,12 @@
     </section>
 
     <section>
-      <h2>What's new in v0.1.18</h2>
+      <h2>What's new in v0.1.19</h2>
       <ul class="tips">
-        <li><strong>Merge node uses the standard optional-port mechanism</strong> — the four quadrant inputs are now declared <code>optional=True</code> and render as hollow dots, matching RGBA Join's alpha input. Behaviour is unchanged: missing quadrants become black.</li>
+        <li><strong>Enum dropdowns have a background again on Windows</strong> — the popup view of <code>QComboBox</code> parameter widgets is now explicitly themed, so it no longer renders transparent / over the canvas on the Windows native style.</li>
+        <li><strong>Merge node uses the standard optional-port mechanism</strong> (v0.1.18) — the four quadrant inputs are now declared <code>optional=True</code> and render as hollow dots, matching RGBA Join's alpha input. Behaviour is unchanged: missing quadrants become black.</li>
         <li><strong>Backdrops</strong> (v0.1.17) — right-click empty canvas to drop a coloured frame behind a group of nodes. Use them as loose chapter headings ("Colour prep", "Alpha mask") so large flows stay readable.</li>
         <li><strong>Video Source paths are now portable</strong> (v0.1.16) — video references under the <code>input/</code> folder save as short relative names and resolve them the same way as image sources, regardless of the working directory.</li>
-        <li><strong>Unsaved-changes indicator</strong> (v0.1.15) — the editor's toolbar shows an amber warning icon with "Unsaved changes" the moment a parameter, node, or connection is edited, and clears it on save, load, or reload.</li>
       </ul>
     </section>
 

--- a/src/constants.py
+++ b/src/constants.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 APP_NAME:         str = "Image-Inquest"
 APP_DISPLAY_NAME: str = "Stjörnhorn"
-APP_VERSION:      str = "0.1.18"
+APP_VERSION:      str = "0.1.19"
 API_URL:    str = "https://beltoforion.de"
 
 # Bundled documentation (offline welcome page, screenshots, …)

--- a/src/ui/controls/scene_aware_combobox.py
+++ b/src/ui/controls/scene_aware_combobox.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing_extensions import override
 
+from PySide6.QtGui import QColor, QPalette
 from PySide6.QtWidgets import QComboBox, QGraphicsItem, QWidget
 
 
@@ -20,9 +21,22 @@ class SceneAwareComboBox(QComboBox):
     While the popup is open we boost the host NodeItem's Z above other
     nodes AND the params proxy's Z above its NodeItem siblings, then
     restore both on close.
+
+    The popup container (a ``QComboBoxPrivateContainer`` QFrame) does not
+    inherit ``autoFillBackground`` through the proxy on Windows, so the
+    application stylesheet's dark colour never lands on a real fill —
+    the dropdown ends up transparent over the scene canvas. We force the
+    container opaque + paint its background ourselves the first time the
+    popup is shown.
     """
 
     _POPUP_Z_BOOST: float = 10_000.0
+
+    # Match QComboBox QAbstractItemView in src/ui/theme.py.
+    _POPUP_BG_COLOR     = QColor(0x1f, 0x1f, 0x22)
+    _POPUP_TEXT_COLOR   = QColor(0xe0, 0xe0, 0xe0)
+    _POPUP_HIGHLIGHT    = QColor(0x3a, 0x5b, 0x8a)
+    _POPUP_HIGHLIGHT_TX = QColor(0xff, 0xff, 0xff)
 
     def __init__(self, parent: QWidget | None = None) -> None:
         super().__init__(parent)
@@ -30,9 +44,37 @@ class SceneAwareComboBox(QComboBox):
         self._raised_node: QGraphicsItem | None = None
         self._saved_proxy_z: float | None = None
         self._saved_node_z: float | None = None
+        self._popup_themed: bool = False
+
+    def _theme_popup_once(self) -> None:
+        """Force the popup container + view to render with a dark background.
+
+        The fix has to be applied to the *container* (the view's parent
+        QFrame), not just the view: when the combo is hosted in a graphics
+        proxy, the container is the widget that ends up painting through to
+        the scene as transparent.
+        """
+        if self._popup_themed:
+            return
+        view = self.view()
+        container = view.parentWidget() if view is not None else None
+        for w in (container, view):
+            if w is None:
+                continue
+            w.setAutoFillBackground(True)
+            pal = w.palette()
+            pal.setColor(QPalette.Window,          self._POPUP_BG_COLOR)
+            pal.setColor(QPalette.Base,            self._POPUP_BG_COLOR)
+            pal.setColor(QPalette.Text,            self._POPUP_TEXT_COLOR)
+            pal.setColor(QPalette.WindowText,      self._POPUP_TEXT_COLOR)
+            pal.setColor(QPalette.Highlight,       self._POPUP_HIGHLIGHT)
+            pal.setColor(QPalette.HighlightedText, self._POPUP_HIGHLIGHT_TX)
+            w.setPalette(pal)
+        self._popup_themed = True
 
     @override
     def showPopup(self) -> None:
+        self._theme_popup_once()
         if self._raised_node is None:
             proxy = self.window().graphicsProxyWidget()
             if proxy is not None:

--- a/src/ui/controls/scene_aware_combobox.py
+++ b/src/ui/controls/scene_aware_combobox.py
@@ -32,7 +32,6 @@ class SceneAwareComboBox(QComboBox):
 
     _POPUP_Z_BOOST: float = 10_000.0
 
-    # Match QComboBox QAbstractItemView in src/ui/theme.py.
     _POPUP_BG_COLOR     = QColor(0x1f, 0x1f, 0x22)
     _POPUP_TEXT_COLOR   = QColor(0xe0, 0xe0, 0xe0)
     _POPUP_HIGHLIGHT    = QColor(0x3a, 0x5b, 0x8a)

--- a/src/ui/controls/scene_aware_combobox.py
+++ b/src/ui/controls/scene_aware_combobox.py
@@ -27,7 +27,7 @@ class SceneAwareComboBox(QComboBox):
     application stylesheet's dark colour never lands on a real fill —
     the dropdown ends up transparent over the scene canvas. We force the
     container opaque + paint its background ourselves the first time the
-    popup is shown.
+    popup is shown. (Issue: #136.)
     """
 
     _POPUP_Z_BOOST: float = 10_000.0

--- a/src/ui/theme.py
+++ b/src/ui/theme.py
@@ -104,18 +104,6 @@ QListWidget, QTreeView {
 QListWidget::item:selected, QTreeView::item:selected {
     background: #3a5b8a;
 }
-/* Windows' native style does not propagate the QListView/QTreeView
-   rules above to the popup view a QComboBox creates internally, so the
-   dropdown ends up with a transparent / system-default background.
-   An explicit selector pins it to the same dark palette. */
-QComboBox QAbstractItemView {
-    background: #1f1f22;
-    border: 1px solid #1a1a1d;
-    color: #e0e0e0;
-    outline: 0;
-    selection-background-color: #3a5b8a;
-    selection-color: #ffffff;
-}
 QStatusBar {
     background: #2a2a2d;
     border-top: 1px solid #1a1a1d;

--- a/src/ui/theme.py
+++ b/src/ui/theme.py
@@ -104,6 +104,18 @@ QListWidget, QTreeView {
 QListWidget::item:selected, QTreeView::item:selected {
     background: #3a5b8a;
 }
+/* Windows' native style does not propagate the QListView/QTreeView
+   rules above to the popup view a QComboBox creates internally, so the
+   dropdown ends up with a transparent / system-default background.
+   An explicit selector pins it to the same dark palette. */
+QComboBox QAbstractItemView {
+    background: #1f1f22;
+    border: 1px solid #1a1a1d;
+    color: #e0e0e0;
+    outline: 0;
+    selection-background-color: #3a5b8a;
+    selection-color: #ffffff;
+}
 QStatusBar {
     background: #2a2a2d;
     border-top: 1px solid #1a1a1d;


### PR DESCRIPTION
## Summary

Enum-typed node parameters (rendered as `SceneAwareComboBox` widgets in the parameter panel) had a transparent popup on Windows — the dropdown list of options drew over the canvas with no background of its own. Linux / macOS were unaffected.

## Root cause

`SceneAwareComboBox` is hosted inside a `QGraphicsProxyWidget` (the params proxy attached to each `NodeItem`). When `QComboBox` shows its popup, Qt creates a `QComboBoxPrivateContainer` (a QFrame around a QListView) and reparents it through the proxy hierarchy. **That container does not pick up `autoFillBackground=True` through the proxy on Windows**, so even with QSS rules in place the painter never lays down a solid fill — the result is a fully transparent dropdown over the scene.

## Fix

`src/ui/controls/scene_aware_combobox.py`: in `SceneAwareComboBox.showPopup()`, on first invocation force the popup *container* (the view's parent QFrame) and the inner `QListView` opaque, and pin their `QPalette::Window` / `Base` / `Text` / `Highlight` / `HighlightedText` to the same dark colours used elsewhere in the theme:

- Window / Base: `#1f1f22`
- Text / WindowText: `#e0e0e0`
- Highlight: `#3a5b8a`, HighlightedText: `#ffffff`

A QSS-only attempt (`QComboBox QAbstractItemView` in `src/ui/theme.py`) was tried first and verified to have no visible effect, so it was removed — every combo box in the app is a `SceneAwareComboBox` and they're all proxied, leaving nothing non-proxied for that rule to defend.

## Other changes

- Bumps `APP_VERSION` `0.1.18` → `0.1.19`.
- Updates the version references in `doc/welcome.html` (hero header span and the "What's new in …" heading).
- CHANGELOG entry under `## [0.1.19]`.

Fixes #136

## Test plan

- [x] Windows: open any node with an enum parameter (e.g. `Debug Params`, or `Dither`'s `method` enum). Click the combo → popup has a solid dark background, white-ish text, blue selection highlight on the hovered row. No transparency, no canvas bleed-through. *(verified by the reporter on the previous push)*
- [ ] Linux / macOS: same nodes, no visual regression.
- [ ] About / Welcome page (offline) shows `v0.1.19` in the hero header and as the "What's new in …" heading.