### PR TITLE
Add 8 new processing nodes + FPS overlay on Display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,15 +32,16 @@ once a first tagged release is cut.
     where mean would smear them across the window). All three reset
     their state on a new flow run, and the rolling reductions also
     flush their buffer if the input shape changes mid-stream.
-- **FPS read-out on the Display node.** New ``show_fps`` BOOL
-  parameter (default off, preserving existing behaviour). When
-  enabled, the preview gets a small FPS counter rendered into a
+- **FPS read-out on the Display node.** From the second tick of a
+  run onwards, the preview gets a small FPS counter rendered into a
   black rectangle in the top-left corner; the value is an
   exponential moving average (α = 0.2) over per-frame ``dt`` so it
-  stays readable even with jittery sources. The overlay only
-  affects what the preview widget sees — the output port still
-  forwards the original ``IoData`` so a downstream VideoSink isn't
-  recording debug overlays into the file.
+  stays readable even with jittery sources. Always on — no toggle —
+  since live timing information is the kind of thing you only ever
+  notice when it's missing. The overlay only affects what the
+  preview widget sees: the output port still forwards the original
+  ``IoData`` so a downstream VideoSink isn't recording debug
+  overlays into the file.
 
 ## [0.1.19] — 2026-04-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,38 @@ once a first tagged release is cut.
 
 ## [Unreleased]
 
+## [0.1.20] — 2026-04-25
+
+### Added
+- **Eight new image-processing nodes.**
+  - *Transform:* **Flip** (horizontal / vertical / both, mirroring
+    OpenCV's ``flipCode`` convention), **Crop** (ROI by ``x, y,
+    width, height``; out-of-bounds rectangles are clamped to the
+    input), **Rotate** (free angle around the centre, with an
+    ``expand`` toggle that grows the canvas to fit the rotated image
+    so corners are never clipped).
+  - *Processing:* **Gaussian Blur** (wraps ``cv2.GaussianBlur``;
+    even ``ksize`` values are bumped up to the next odd integer like
+    Median already does), **Invert** (per-channel ``255 - pixel``
+    via ``cv2.bitwise_not``).
+  - *Temporal:* a brand-new palette section. **Frame Difference**
+    emits ``|current - previous|`` for change/motion detection;
+    **Temporal Mean** and **Temporal Median** maintain a rolling
+    buffer of the last *N* frames and emit the per-pixel mean /
+    median each tick (median is robust against single-frame outliers
+    where mean would smear them across the window). All three reset
+    their state on a new flow run, and the rolling reductions also
+    flush their buffer if the input shape changes mid-stream.
+- **FPS read-out on the Display node.** New ``show_fps`` BOOL
+  parameter (default off, preserving existing behaviour). When
+  enabled, the preview gets a small FPS counter rendered into a
+  black rectangle in the top-left corner; the value is an
+  exponential moving average (α = 0.2) over per-frame ``dt`` so it
+  stays readable even with jittery sources. The overlay only
+  affects what the preview widget sees — the output port still
+  forwards the original ``IoData`` so a downstream VideoSink isn't
+  recording debug overlays into the file.
+
 ## [0.1.19] — 2026-04-25
 
 ### Fixed

--- a/doc/welcome.html
+++ b/doc/welcome.html
@@ -200,7 +200,7 @@
       <h2>What's new in v0.1.20</h2>
       <ul class="tips">
         <li><strong>Eight new processing nodes.</strong> <em>Transform:</em> Flip (horizontal / vertical / both), Crop, Rotate (with optional canvas expansion). <em>Processing:</em> Gaussian Blur, Invert. <em>Temporal:</em> Frame Difference, Temporal Mean, Temporal Median — rolling per-pixel reductions over the last <em>N</em> frames.</li>
-        <li><strong>FPS read-out on Display.</strong> Toggle <code>show_fps</code> on the Display node to overlay an exponentially-smoothed FPS counter in the preview. The overlay is preview-only — anything written downstream by a sink stays clean.</li>
+        <li><strong>FPS read-out on Display.</strong> The Display preview now shows an exponentially-smoothed FPS counter in the top-left corner. The overlay is preview-only — anything written downstream by a sink stays clean.</li>
         <li><strong>Enum dropdowns have a background again on Windows</strong> (v0.1.19) — the popup view of <code>QComboBox</code> parameter widgets is now explicitly themed, so it no longer renders transparent / over the canvas on the Windows native style.</li>
         <li><strong>Merge node uses the standard optional-port mechanism</strong> (v0.1.18) — the four quadrant inputs are now declared <code>optional=True</code> and render as hollow dots, matching RGBA Join's alpha input. Behaviour is unchanged: missing quadrants become black.</li>
       </ul>

--- a/doc/welcome.html
+++ b/doc/welcome.html
@@ -164,7 +164,7 @@
   <main class="content-col">
 
     <header class="hero">
-      <h1>Welcome to Stjörnhorn <span class="version">v0.1.19</span></h1>
+      <h1>Welcome to Stjörnhorn <span class="version">v0.1.20</span></h1>
       <div class="tagline">A node-based image- and video-processing playground.</div>
     </header>
 
@@ -197,12 +197,12 @@
     </section>
 
     <section>
-      <h2>What's new in v0.1.19</h2>
+      <h2>What's new in v0.1.20</h2>
       <ul class="tips">
-        <li><strong>Enum dropdowns have a background again on Windows</strong> — the popup view of <code>QComboBox</code> parameter widgets is now explicitly themed, so it no longer renders transparent / over the canvas on the Windows native style.</li>
+        <li><strong>Eight new processing nodes.</strong> <em>Transform:</em> Flip (horizontal / vertical / both), Crop, Rotate (with optional canvas expansion). <em>Processing:</em> Gaussian Blur, Invert. <em>Temporal:</em> Frame Difference, Temporal Mean, Temporal Median — rolling per-pixel reductions over the last <em>N</em> frames.</li>
+        <li><strong>FPS read-out on Display.</strong> Toggle <code>show_fps</code> on the Display node to overlay an exponentially-smoothed FPS counter in the preview. The overlay is preview-only — anything written downstream by a sink stays clean.</li>
+        <li><strong>Enum dropdowns have a background again on Windows</strong> (v0.1.19) — the popup view of <code>QComboBox</code> parameter widgets is now explicitly themed, so it no longer renders transparent / over the canvas on the Windows native style.</li>
         <li><strong>Merge node uses the standard optional-port mechanism</strong> (v0.1.18) — the four quadrant inputs are now declared <code>optional=True</code> and render as hollow dots, matching RGBA Join's alpha input. Behaviour is unchanged: missing quadrants become black.</li>
-        <li><strong>Backdrops</strong> (v0.1.17) — right-click empty canvas to drop a coloured frame behind a group of nodes. Use them as loose chapter headings ("Colour prep", "Alpha mask") so large flows stay readable.</li>
-        <li><strong>Video Source paths are now portable</strong> (v0.1.16) — video references under the <code>input/</code> folder save as short relative names and resolve them the same way as image sources, regardless of the working directory.</li>
       </ul>
     </section>
 

--- a/flow/sample_video_proc.flowjs
+++ b/flow/sample_video_proc.flowjs
@@ -1,0 +1,105 @@
+{
+  "version": 1,
+  "app_version": "0.1.20",
+  "name": "sample_video_proc",
+  "nodes": [
+    {
+      "id": 0,
+      "module": "nodes.sources.video_source",
+      "class": "VideoSource",
+      "position": [
+        -1476.0,
+        -766.0
+      ],
+      "params": {
+        "file_path": "video.mp4",
+        "max_num_frames": -1
+      }
+    },
+    {
+      "id": 1,
+      "module": "nodes.sinks.video_sink",
+      "class": "VideoSink",
+      "position": [
+        -624.0,
+        -265.0
+      ],
+      "params": {
+        "output_path": "out.mp4",
+        "fps": 30.0,
+        "codec": 0
+      }
+    },
+    {
+      "id": 2,
+      "module": "nodes.filters.flip",
+      "class": "Flip",
+      "position": [
+        -1436.0,
+        -580.0
+      ],
+      "params": {
+        "mode": 1
+      }
+    },
+    {
+      "id": 3,
+      "module": "nodes.filters.display",
+      "class": "Display",
+      "position": [
+        -1210.0,
+        -940.0
+      ],
+      "params": {
+        "show_fps": true
+      },
+      "size": [
+        800.0,
+        629.0
+      ]
+    },
+    {
+      "id": 4,
+      "module": "nodes.filters.temporal_mean",
+      "class": "TemporalMean",
+      "position": [
+        -1453.0,
+        -422.0
+      ],
+      "params": {
+        "window": 5
+      },
+      "size": [
+        169.0,
+        118.0
+      ]
+    }
+  ],
+  "connections": [
+    {
+      "src_node": 0,
+      "src_output": 0,
+      "dst_node": 2,
+      "dst_input": 0
+    },
+    {
+      "src_node": 3,
+      "src_output": 0,
+      "dst_node": 1,
+      "dst_input": 0
+    },
+    {
+      "src_node": 2,
+      "src_output": 0,
+      "dst_node": 4,
+      "dst_input": 0
+    },
+    {
+      "src_node": 4,
+      "src_output": 0,
+      "dst_node": 3,
+      "dst_input": 0
+    }
+  ],
+  "backdrops": []
+}

--- a/flow/sample_video_proc.flowjs
+++ b/flow/sample_video_proc.flowjs
@@ -8,8 +8,8 @@
       "module": "nodes.sources.video_source",
       "class": "VideoSource",
       "position": [
-        -1476.0,
-        -766.0
+        -1660.4444444444443,
+        -1304.4444444444448
       ],
       "params": {
         "file_path": "video.mp4",
@@ -21,8 +21,8 @@
       "module": "nodes.sinks.video_sink",
       "class": "VideoSink",
       "position": [
-        -624.0,
-        -265.0
+        -875.4444444444443,
+        -666.4444444444446
       ],
       "params": {
         "output_path": "out.mp4",
@@ -35,8 +35,8 @@
       "module": "nodes.filters.flip",
       "class": "Flip",
       "position": [
-        -1436.0,
-        -580.0
+        -1612.4444444444443,
+        -1063.4444444444448
       ],
       "params": {
         "mode": 1
@@ -47,8 +47,8 @@
       "module": "nodes.filters.display",
       "class": "Display",
       "position": [
-        -1210.0,
-        -940.0
+        -1394.4444444444443,
+        -1322.4444444444448
       ],
       "params": {
         "show_fps": true
@@ -63,8 +63,8 @@
       "module": "nodes.filters.temporal_mean",
       "class": "TemporalMean",
       "position": [
-        -1453.0,
-        -422.0
+        -1629.4444444444443,
+        -905.4444444444448
       ],
       "params": {
         "window": 5
@@ -72,7 +72,18 @@
       "size": [
         169.0,
         118.0
-      ]
+      ],
+      "skipped": true
+    },
+    {
+      "id": 5,
+      "module": "nodes.filters.frame_difference",
+      "class": "FrameDifference",
+      "position": [
+        -1620.4444444444443,
+        -738.4444444444448
+      ],
+      "params": {}
     }
   ],
   "connections": [
@@ -97,9 +108,33 @@
     {
       "src_node": 4,
       "src_output": 0,
+      "dst_node": 5,
+      "dst_input": 0
+    },
+    {
+      "src_node": 5,
+      "src_output": 0,
       "dst_node": 3,
       "dst_input": 0
     }
   ],
-  "backdrops": []
+  "backdrops": [
+    {
+      "position": [
+        -1655.4444444444443,
+        -1111.4444444444448
+      ],
+      "size": [
+        221.0,
+        457.0
+      ],
+      "title": "Processing",
+      "color": [
+        70,
+        60,
+        40,
+        140
+      ]
+    }
+  ]
 }

--- a/src/constants.py
+++ b/src/constants.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 APP_NAME:         str = "Image-Inquest"
 APP_DISPLAY_NAME: str = "Stjörnhorn"
-APP_VERSION:      str = "0.1.19"
+APP_VERSION:      str = "0.1.20"
 API_URL:    str = "https://beltoforion.de"
 
 # Bundled documentation (offline welcome page, screenshots, …)

--- a/src/nodes/filters/crop.py
+++ b/src/nodes/filters/crop.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import numpy as np
+from typing_extensions import override
+
+from core.io_data import IMAGE_TYPES
+from core.node_base import NodeBase, NodeParam, NodeParamType
+from core.port import InputPort, OutputPort
+
+
+class Crop(NodeBase):
+    """Crop an image to a rectangular ROI.
+
+    Parameters express the ROI in input-pixel coordinates: top-left
+    ``(x, y)`` plus ``width`` and ``height``. The ROI is clamped to
+    the input bounds, so the node always emits a positive-area image
+    even if the user-specified rectangle reaches outside the input.
+    """
+
+    def __init__(self) -> None:
+        super().__init__("Crop", section="Transform")
+        self._x:      int = 0
+        self._y:      int = 0
+        self._width:  int = 100
+        self._height: int = 100
+
+        self._add_input(InputPort("image", set(IMAGE_TYPES)))
+        self._add_output(OutputPort("image", set(IMAGE_TYPES)))
+
+        self._apply_default_params()
+
+    @property
+    @override
+    def params(self) -> list[NodeParam]:
+        return [
+            NodeParam("x",      NodeParamType.INT, {"default": 0}),
+            NodeParam("y",      NodeParamType.INT, {"default": 0}),
+            NodeParam("width",  NodeParamType.INT, {"default": 100}),
+            NodeParam("height", NodeParamType.INT, {"default": 100}),
+        ]
+
+    @property
+    def x(self) -> int:
+        return self._x
+
+    @x.setter
+    def x(self, value: int) -> None:
+        self._x = int(value)
+
+    @property
+    def y(self) -> int:
+        return self._y
+
+    @y.setter
+    def y(self, value: int) -> None:
+        self._y = int(value)
+
+    @property
+    def width(self) -> int:
+        return self._width
+
+    @width.setter
+    def width(self, value: int) -> None:
+        v = int(value)
+        if v < 1:
+            raise ValueError(f"width must be >= 1 (got {v})")
+        self._width = v
+
+    @property
+    def height(self) -> int:
+        return self._height
+
+    @height.setter
+    def height(self, value: int) -> None:
+        v = int(value)
+        if v < 1:
+            raise ValueError(f"height must be >= 1 (got {v})")
+        self._height = v
+
+    @override
+    def process_impl(self) -> None:
+        in_data = self.inputs[0].data
+        image: np.ndarray = in_data.image
+        h, w = image.shape[:2]
+
+        x0 = max(0, min(self._x, w - 1))
+        y0 = max(0, min(self._y, h - 1))
+        x1 = max(x0 + 1, min(self._x + self._width,  w))
+        y1 = max(y0 + 1, min(self._y + self._height, h))
+
+        cropped = image[y0:y1, x0:x1]
+        # cv2 ops downstream want a contiguous array; numpy slicing yields
+        # a view, which is fine for read-only consumers but bites in-place
+        # writers. Cheap insurance for ~100kB-100MB frames.
+        cropped = np.ascontiguousarray(cropped)
+        self.outputs[0].send(in_data.with_image(cropped))

--- a/src/nodes/filters/display.py
+++ b/src/nodes/filters/display.py
@@ -8,7 +8,7 @@ import numpy as np
 from typing_extensions import override
 
 from core.io_data import IMAGE_TYPES
-from core.node_base import NodeBase, NodeParam, NodeParamType
+from core.node_base import NodeBase, NodeParam
 from core.port import InputPort, OutputPort
 
 
@@ -21,11 +21,12 @@ class Display(NodeBase):
     output unchanged so the node can sit inline between any two others
     (e.g. upstream of a VideoSink to watch encoding as it happens).
 
-    The optional ``show_fps`` parameter draws a small FPS read-out in
-    the top-left of the *displayed* frame. The overlay only affects
-    what the preview widget sees — the output port still forwards the
-    original :class:`IoData` so a downstream VideoSink isn't recording
-    debug overlays into the file.
+    A small FPS read-out is always rendered into the top-left of the
+    *displayed* frame from the second tick onwards (the first tick has
+    no measurable ``dt`` to derive a rate from). The overlay is
+    preview-only — the output port still forwards the original
+    :class:`IoData` so a downstream VideoSink isn't recording debug
+    overlays into the file.
 
     The node itself is Qt-free — the preview widget lives on the UI
     side in :mod:`ui.preview_widgets`; the worker-thread → main-thread
@@ -41,31 +42,18 @@ class Display(NodeBase):
         super().__init__("Display", section="Output")
         self._latest_frame:    np.ndarray | None = None
         self._frame_callback:  Callable[[np.ndarray], None] | None = None
-        self._show_fps:        bool = False
         self._last_frame_ts:   float | None = None
         self._fps_ema:         float | None = None
 
         self._add_input(InputPort("image", set(IMAGE_TYPES)))
         self._add_output(OutputPort("image", set(IMAGE_TYPES)))
 
-        self._apply_default_params()
-
     # ── Parameters ─────────────────────────────────────────────────────────────
 
     @property
     @override
     def params(self) -> list[NodeParam]:
-        return [
-            NodeParam("show_fps", NodeParamType.BOOL, {"default": False}),
-        ]
-
-    @property
-    def show_fps(self) -> bool:
-        return self._show_fps
-
-    @show_fps.setter
-    def show_fps(self, value: bool) -> None:
-        self._show_fps = bool(value)
+        return []
 
     # ── Properties ─────────────────────────────────────────────────────────────
 
@@ -73,9 +61,9 @@ class Display(NodeBase):
     def latest_frame(self) -> np.ndarray | None:
         """Most recent frame seen, or ``None`` before any run.
 
-        With ``show_fps=True`` this is the *annotated* frame (so the
-        preview widget renders the overlay too); the output port
-        always forwards the original payload.
+        From the second tick of a run onwards this is the FPS-annotated
+        frame (so the preview widget renders the overlay); the output
+        port always forwards the original payload.
         """
         return self._latest_frame
 
@@ -121,7 +109,7 @@ class Display(NodeBase):
         self._last_frame_ts = now
 
         displayed = image
-        if self._show_fps and self._fps_ema is not None:
+        if self._fps_ema is not None:
             displayed = self._draw_fps_overlay(image, self._fps_ema)
 
         self._latest_frame = displayed

--- a/src/nodes/filters/display.py
+++ b/src/nodes/filters/display.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
+import time
 from typing import Callable
 
+import cv2
 import numpy as np
 from typing_extensions import override
 
 from core.io_data import IMAGE_TYPES
-from core.node_base import NodeBase, NodeParam
+from core.node_base import NodeBase, NodeParam, NodeParamType
 from core.port import InputPort, OutputPort
 
 
@@ -19,31 +21,62 @@ class Display(NodeBase):
     output unchanged so the node can sit inline between any two others
     (e.g. upstream of a VideoSink to watch encoding as it happens).
 
+    The optional ``show_fps`` parameter draws a small FPS read-out in
+    the top-left of the *displayed* frame. The overlay only affects
+    what the preview widget sees — the output port still forwards the
+    original :class:`IoData` so a downstream VideoSink isn't recording
+    debug overlays into the file.
+
     The node itself is Qt-free — the preview widget lives on the UI
     side in :mod:`ui.preview_widgets`; the worker-thread → main-thread
     hand-off is the UI widget's responsibility (queued signal).
     """
 
+    # Exponential-moving-average smoothing factor for the FPS readout.
+    # 0.2 gives a half-life of ~3 frames — fast enough to track a real
+    # speed-up, slow enough to absorb single-frame jitter from cv2 ops.
+    _FPS_EMA_ALPHA: float = 0.2
+
     def __init__(self) -> None:
         super().__init__("Display", section="Output")
-        self._latest_frame: np.ndarray | None = None
-        self._frame_callback: Callable[[np.ndarray], None] | None = None
+        self._latest_frame:    np.ndarray | None = None
+        self._frame_callback:  Callable[[np.ndarray], None] | None = None
+        self._show_fps:        bool = False
+        self._last_frame_ts:   float | None = None
+        self._fps_ema:         float | None = None
 
         self._add_input(InputPort("image", set(IMAGE_TYPES)))
         self._add_output(OutputPort("image", set(IMAGE_TYPES)))
+
+        self._apply_default_params()
 
     # ── Parameters ─────────────────────────────────────────────────────────────
 
     @property
     @override
     def params(self) -> list[NodeParam]:
-        return []
+        return [
+            NodeParam("show_fps", NodeParamType.BOOL, {"default": False}),
+        ]
+
+    @property
+    def show_fps(self) -> bool:
+        return self._show_fps
+
+    @show_fps.setter
+    def show_fps(self, value: bool) -> None:
+        self._show_fps = bool(value)
 
     # ── Properties ─────────────────────────────────────────────────────────────
 
     @property
     def latest_frame(self) -> np.ndarray | None:
-        """Most recent frame seen, or ``None`` before any run."""
+        """Most recent frame seen, or ``None`` before any run.
+
+        With ``show_fps=True`` this is the *annotated* frame (so the
+        preview widget renders the overlay too); the output port
+        always forwards the original payload.
+        """
         return self._latest_frame
 
     # ── UI integration ─────────────────────────────────────────────────────────
@@ -64,13 +97,74 @@ class Display(NodeBase):
     @override
     def _before_run_impl(self) -> None:
         super()._before_run_impl()
-        self._latest_frame = None
+        self._latest_frame  = None
+        self._last_frame_ts = None
+        self._fps_ema       = None
 
     @override
     def process_impl(self) -> None:
         in_data = self.inputs[0].data
         image: np.ndarray = in_data.image
-        self._latest_frame = image
+
+        now = time.monotonic()
+        if self._last_frame_ts is not None:
+            dt = now - self._last_frame_ts
+            if dt > 0.0:
+                inst_fps = 1.0 / dt
+                if self._fps_ema is None:
+                    self._fps_ema = inst_fps
+                else:
+                    self._fps_ema = (
+                        self._FPS_EMA_ALPHA * inst_fps
+                        + (1.0 - self._FPS_EMA_ALPHA) * self._fps_ema
+                    )
+        self._last_frame_ts = now
+
+        displayed = image
+        if self._show_fps and self._fps_ema is not None:
+            displayed = self._draw_fps_overlay(image, self._fps_ema)
+
+        self._latest_frame = displayed
         if self._frame_callback is not None:
-            self._frame_callback(image)
+            self._frame_callback(displayed)
+
+        # Forward the original payload — overlays are display-only so a
+        # downstream sink (e.g. VideoSink) doesn't record them to disk.
         self.outputs[0].send(in_data)
+
+    # ── Overlay ────────────────────────────────────────────────────────────────
+
+    @staticmethod
+    def _draw_fps_overlay(image: np.ndarray, fps: float) -> np.ndarray:
+        """Return a copy of *image* with a small FPS read-out in the top-left."""
+        annotated = image.copy()
+        text   = f"FPS {fps:5.1f}"
+        font   = cv2.FONT_HERSHEY_SIMPLEX
+        scale  = 0.6
+        thick  = 1
+        (tw, th), baseline = cv2.getTextSize(text, font, scale, thick)
+        x, y = 8, 8 + th
+        pad  = 4
+
+        # Greyscale (2-D) and colour (3-D) take different scalar shapes for
+        # cv2.rectangle / putText — branch once instead of guessing.
+        if annotated.ndim == 2:
+            cv2.rectangle(
+                annotated,
+                (x - pad, y - th - pad),
+                (x + tw + pad, y + baseline),
+                0, -1,
+            )
+            cv2.putText(annotated, text, (x, y), font, scale, 255, thick, cv2.LINE_AA)
+        else:
+            cv2.rectangle(
+                annotated,
+                (x - pad, y - th - pad),
+                (x + tw + pad, y + baseline),
+                (0, 0, 0), -1,
+            )
+            cv2.putText(
+                annotated, text, (x, y), font, scale,
+                (255, 255, 255), thick, cv2.LINE_AA,
+            )
+        return annotated

--- a/src/nodes/filters/flip.py
+++ b/src/nodes/filters/flip.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from enum import IntEnum
+
+import cv2
+from typing_extensions import override
+
+from core.io_data import IMAGE_TYPES
+from core.node_base import NodeBase, NodeParam, NodeParamType
+from core.port import InputPort, OutputPort
+
+
+class FlipMode(IntEnum):
+    """Direction passed to :func:`cv2.flip`.
+
+    Values mirror OpenCV's ``flipCode`` convention exactly so the enum
+    member can be passed to :func:`cv2.flip` without a lookup table:
+    ``HORIZONTAL = 1`` (mirror around the vertical axis, left↔right),
+    ``VERTICAL = 0`` (mirror around the horizontal axis, top↔bottom),
+    ``BOTH = -1`` (equivalent to a 180° rotation).
+    """
+    HORIZONTAL = 1
+    VERTICAL   = 0
+    BOTH       = -1
+
+
+class Flip(NodeBase):
+    """Mirror an image horizontally, vertically, or both."""
+
+    def __init__(self) -> None:
+        super().__init__("Flip", section="Transform")
+        self._mode: FlipMode = FlipMode.HORIZONTAL
+
+        self._add_input(InputPort("image", set(IMAGE_TYPES)))
+        self._add_output(OutputPort("image", set(IMAGE_TYPES)))
+
+        self._apply_default_params()
+
+    @property
+    @override
+    def params(self) -> list[NodeParam]:
+        return [
+            NodeParam(
+                "mode",
+                NodeParamType.ENUM,
+                {"default": FlipMode.HORIZONTAL, "enum": FlipMode},
+            ),
+        ]
+
+    @property
+    def mode(self) -> FlipMode:
+        return self._mode
+
+    @mode.setter
+    def mode(self, value: int | FlipMode) -> None:
+        try:
+            self._mode = FlipMode(value)
+        except ValueError as e:
+            raise ValueError(
+                f"mode must be one of {[m.value for m in FlipMode]} "
+                f"(got {value!r})"
+            ) from e
+
+    @override
+    def process_impl(self) -> None:
+        in_data = self.inputs[0].data
+        flipped = cv2.flip(in_data.image, int(self._mode))
+        self.outputs[0].send(in_data.with_image(flipped))

--- a/src/nodes/filters/frame_difference.py
+++ b/src/nodes/filters/frame_difference.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import cv2
+import numpy as np
+from typing_extensions import override
+
+from core.io_data import IMAGE_TYPES
+from core.node_base import NodeBase, NodeParam
+from core.port import InputPort, OutputPort
+
+
+class FrameDifference(NodeBase):
+    """Per-pixel absolute difference between the current and previous frame.
+
+    A baseline change-detector for video streams. Holds the previous
+    frame internally; the buffer is reset at the start of every flow
+    run. The first frame in a stream emits an all-zero image (same
+    shape and dtype as the input) because there is no prior frame to
+    diff against. Frames whose shape changes mid-stream also reset the
+    buffer rather than raising.
+    """
+
+    def __init__(self) -> None:
+        super().__init__("Frame Difference", section="Temporal")
+        self._prev_frame: np.ndarray | None = None
+
+        self._add_input(InputPort("image", set(IMAGE_TYPES)))
+        self._add_output(OutputPort("image", set(IMAGE_TYPES)))
+
+    @property
+    @override
+    def params(self) -> list[NodeParam]:
+        return []
+
+    @override
+    def _before_run_impl(self) -> None:
+        super()._before_run_impl()
+        self._prev_frame = None
+
+    @override
+    def process_impl(self) -> None:
+        in_data = self.inputs[0].data
+        image: np.ndarray = in_data.image
+
+        if self._prev_frame is None or self._prev_frame.shape != image.shape:
+            diff = np.zeros_like(image)
+        else:
+            diff = cv2.absdiff(image, self._prev_frame)
+
+        self._prev_frame = image.copy()
+        self.outputs[0].send(in_data.with_image(diff))

--- a/src/nodes/filters/gaussian_blur.py
+++ b/src/nodes/filters/gaussian_blur.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import cv2
+from typing_extensions import override
+
+from core.io_data import IMAGE_TYPES
+from core.node_base import NodeBase, NodeParam, NodeParamType
+from core.port import InputPort, OutputPort
+
+
+class GaussianBlur(NodeBase):
+    """Smooth an image with an isotropic Gaussian kernel.
+
+    Wraps :func:`cv2.GaussianBlur`. ``ksize`` is the kernel side length
+    in pixels (must be odd; even values are bumped up to the next odd
+    integer the way :class:`Median` does it). ``sigma`` is the standard
+    deviation of the Gaussian; the OpenCV convention of ``sigma == 0``
+    "derive from kernel size" is preserved.
+    """
+
+    def __init__(self) -> None:
+        super().__init__("Gaussian Blur", section="Processing")
+        self._ksize: int   = 5
+        self._sigma: float = 0.0
+
+        self._add_input(InputPort("image", set(IMAGE_TYPES)))
+        self._add_output(OutputPort("image", set(IMAGE_TYPES)))
+
+        self._apply_default_params()
+
+    @property
+    @override
+    def params(self) -> list[NodeParam]:
+        return [
+            NodeParam("ksize", NodeParamType.INT,   {"default": 5}),
+            NodeParam("sigma", NodeParamType.FLOAT, {"default": 0.0}),
+        ]
+
+    @property
+    def ksize(self) -> int:
+        return self._ksize
+
+    @ksize.setter
+    def ksize(self, value: int) -> None:
+        v = int(value)
+        if v < 1:
+            raise ValueError(f"ksize must be >= 1 (got {v})")
+        if v % 2 == 0:
+            v += 1
+        self._ksize = v
+
+    @property
+    def sigma(self) -> float:
+        return self._sigma
+
+    @sigma.setter
+    def sigma(self, value: float) -> None:
+        v = float(value)
+        if v < 0.0:
+            raise ValueError(f"sigma must be >= 0 (got {v})")
+        self._sigma = v
+
+    @override
+    def process_impl(self) -> None:
+        in_data = self.inputs[0].data
+        blurred = cv2.GaussianBlur(
+            in_data.image,
+            (self._ksize, self._ksize),
+            self._sigma,
+        )
+        self.outputs[0].send(in_data.with_image(blurred))

--- a/src/nodes/filters/invert.py
+++ b/src/nodes/filters/invert.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import cv2
+from typing_extensions import override
+
+from core.io_data import IMAGE_TYPES
+from core.node_base import NodeBase, NodeParam
+from core.port import InputPort, OutputPort
+
+
+class Invert(NodeBase):
+    """Per-channel image inversion (``255 - pixel``).
+
+    No parameters. Accepts colour or greyscale and emits the same type.
+    Wraps :func:`cv2.bitwise_not` so it stays cheap on large frames.
+    """
+
+    def __init__(self) -> None:
+        super().__init__("Invert", section="Processing")
+
+        self._add_input(InputPort("image", set(IMAGE_TYPES)))
+        self._add_output(OutputPort("image", set(IMAGE_TYPES)))
+
+    @property
+    @override
+    def params(self) -> list[NodeParam]:
+        return []
+
+    @override
+    def process_impl(self) -> None:
+        in_data = self.inputs[0].data
+        inverted = cv2.bitwise_not(in_data.image)
+        self.outputs[0].send(in_data.with_image(inverted))

--- a/src/nodes/filters/rotate.py
+++ b/src/nodes/filters/rotate.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import cv2
+import numpy as np
+from typing_extensions import override
+
+from core.io_data import IMAGE_TYPES
+from core.node_base import NodeBase, NodeParam, NodeParamType
+from core.port import InputPort, OutputPort
+
+
+class Rotate(NodeBase):
+    """Rotate an image around its centre by ``angle`` degrees.
+
+    Positive ``angle`` rotates counter-clockwise (matching
+    :func:`cv2.getRotationMatrix2D` and the existing Overlay node).
+    With ``expand=True`` the output canvas grows to fit the rotated
+    image so no pixels are clipped; with ``expand=False`` the output
+    keeps the input dimensions and corners may fall outside.
+    """
+
+    def __init__(self) -> None:
+        super().__init__("Rotate", section="Transform")
+        self._angle:  float = 0.0
+        self._expand: bool  = True
+
+        self._add_input(InputPort("image", set(IMAGE_TYPES)))
+        self._add_output(OutputPort("image", set(IMAGE_TYPES)))
+
+        self._apply_default_params()
+
+    @property
+    @override
+    def params(self) -> list[NodeParam]:
+        return [
+            NodeParam("angle",  NodeParamType.FLOAT, {"default": 0.0}),
+            NodeParam("expand", NodeParamType.BOOL,  {"default": True}),
+        ]
+
+    @property
+    def angle(self) -> float:
+        return self._angle
+
+    @angle.setter
+    def angle(self, value: float) -> None:
+        self._angle = float(value)
+
+    @property
+    def expand(self) -> bool:
+        return self._expand
+
+    @expand.setter
+    def expand(self, value: bool) -> None:
+        self._expand = bool(value)
+
+    @override
+    def process_impl(self) -> None:
+        in_data = self.inputs[0].data
+        image: np.ndarray = in_data.image
+        h, w = image.shape[:2]
+        cx, cy = w * 0.5, h * 0.5
+
+        m = cv2.getRotationMatrix2D((cx, cy), self._angle, 1.0)
+
+        if self._expand:
+            cos = abs(m[0, 0])
+            sin = abs(m[0, 1])
+            new_w = int(round(h * sin + w * cos))
+            new_h = int(round(h * cos + w * sin))
+            m[0, 2] += (new_w * 0.5) - cx
+            m[1, 2] += (new_h * 0.5) - cy
+            out_size = (new_w, new_h)
+        else:
+            out_size = (w, h)
+
+        rotated = cv2.warpAffine(image, m, out_size, flags=cv2.INTER_LINEAR)
+        self.outputs[0].send(in_data.with_image(rotated))

--- a/src/nodes/filters/temporal_mean.py
+++ b/src/nodes/filters/temporal_mean.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import numpy as np
+from typing_extensions import override
+
+from core.io_data import IMAGE_TYPES
+from core.node_base import NodeBase, NodeParam, NodeParamType
+from core.port import InputPort, OutputPort
+
+
+class TemporalMean(NodeBase):
+    """Rolling per-pixel arithmetic mean over the last ``window`` frames.
+
+    Reduces additive Gaussian-style noise on a static scene. Maintains
+    a buffer of the most recent ``window`` frames and emits their
+    per-pixel mean each tick. Until the buffer is full, the mean of
+    however many frames have been seen so far is emitted (so the very
+    first frame passes through unchanged).
+
+    Shape changes mid-run (e.g. an upstream Crop param edited live)
+    flush the buffer rather than raising — the next emitted frame is
+    just the new input.
+    """
+
+    def __init__(self) -> None:
+        super().__init__("Temporal Mean", section="Temporal")
+        self._window: int = 5
+        self._buffer: list[np.ndarray] = []
+
+        self._add_input(InputPort("image", set(IMAGE_TYPES)))
+        self._add_output(OutputPort("image", set(IMAGE_TYPES)))
+
+        self._apply_default_params()
+
+    @property
+    @override
+    def params(self) -> list[NodeParam]:
+        return [
+            NodeParam("window", NodeParamType.INT, {"default": 5}),
+        ]
+
+    @property
+    def window(self) -> int:
+        return self._window
+
+    @window.setter
+    def window(self, value: int) -> None:
+        v = int(value)
+        if v < 1:
+            raise ValueError(f"window must be >= 1 (got {v})")
+        self._window = v
+
+    @override
+    def _before_run_impl(self) -> None:
+        super()._before_run_impl()
+        self._buffer = []
+
+    @override
+    def process_impl(self) -> None:
+        in_data = self.inputs[0].data
+        image: np.ndarray = in_data.image
+
+        if self._buffer and self._buffer[0].shape != image.shape:
+            self._buffer.clear()
+
+        self._buffer.append(image)
+        while len(self._buffer) > self._window:
+            self._buffer.pop(0)
+
+        # Float intermediate to avoid uint8 overflow on the sum, cast back
+        # to the input dtype so downstream nodes get the type they expect.
+        stack = np.stack(self._buffer, axis=0).astype(np.float32)
+        mean = stack.mean(axis=0).astype(image.dtype)
+        self.outputs[0].send(in_data.with_image(mean))

--- a/src/nodes/filters/temporal_median.py
+++ b/src/nodes/filters/temporal_median.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import numpy as np
+from typing_extensions import override
+
+from core.io_data import IMAGE_TYPES
+from core.node_base import NodeBase, NodeParam, NodeParamType
+from core.port import InputPort, OutputPort
+
+
+class TemporalMedian(NodeBase):
+    """Rolling per-pixel median over the last ``window`` frames.
+
+    Strong against transient outliers — single-frame noise spikes,
+    flicker, salt-and-pepper noise — where a temporal mean would
+    smear the spike across several frames. Maintains a buffer of the
+    most recent ``window`` frames and emits the per-pixel median each
+    tick. Until the buffer is full, the median over however many
+    frames have been seen so far is emitted (the first frame passes
+    through unchanged).
+
+    Shape changes mid-run (e.g. an upstream Crop param edited live)
+    flush the buffer rather than raising.
+    """
+
+    def __init__(self) -> None:
+        super().__init__("Temporal Median", section="Temporal")
+        self._window: int = 5
+        self._buffer: list[np.ndarray] = []
+
+        self._add_input(InputPort("image", set(IMAGE_TYPES)))
+        self._add_output(OutputPort("image", set(IMAGE_TYPES)))
+
+        self._apply_default_params()
+
+    @property
+    @override
+    def params(self) -> list[NodeParam]:
+        return [
+            NodeParam("window", NodeParamType.INT, {"default": 5}),
+        ]
+
+    @property
+    def window(self) -> int:
+        return self._window
+
+    @window.setter
+    def window(self, value: int) -> None:
+        v = int(value)
+        if v < 1:
+            raise ValueError(f"window must be >= 1 (got {v})")
+        self._window = v
+
+    @override
+    def _before_run_impl(self) -> None:
+        super()._before_run_impl()
+        self._buffer = []
+
+    @override
+    def process_impl(self) -> None:
+        in_data = self.inputs[0].data
+        image: np.ndarray = in_data.image
+
+        if self._buffer and self._buffer[0].shape != image.shape:
+            self._buffer.clear()
+
+        self._buffer.append(image)
+        while len(self._buffer) > self._window:
+            self._buffer.pop(0)
+
+        # np.median always returns float64 — cast back to the input
+        # dtype so downstream nodes get the type they expect.
+        stack = np.stack(self._buffer, axis=0)
+        median = np.median(stack, axis=0).astype(image.dtype)
+        self.outputs[0].send(in_data.with_image(median))

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -133,22 +133,16 @@ def test_display_forwards_finish() -> None:
     assert node.outputs[0].finished
 
 
-def test_display_exposes_show_fps_param() -> None:
-    # Display has exactly one user-facing param: an FPS-overlay toggle.
-    # It defaults off so the historical pass-through-only behaviour is
-    # preserved out of the box.
-    params = Display().params
-    assert [p.name for p in params] == ["show_fps"]
-    assert params[0].metadata["default"] is False
-    assert Display().show_fps is False
+def test_display_has_no_params() -> None:
+    # FPS overlay is unconditional — no user-facing knobs to expose.
+    assert Display().params == []
 
 
-def test_display_show_fps_overlay_does_not_leak_to_output() -> None:
+def test_display_fps_overlay_does_not_leak_to_output() -> None:
     # The overlay is for the preview only; the output port must still
     # forward the original IoData byte-for-byte so downstream sinks
     # (e.g. VideoSink) record clean frames.
     node = Display()
-    node.show_fps = True
     up, captured = _wire(node)
 
     received: list[np.ndarray] = []
@@ -170,12 +164,11 @@ def test_display_show_fps_overlay_does_not_leak_to_output() -> None:
         assert int(f[-1, -1, 0]) == v
 
 
-def test_display_show_fps_overlay_writes_visible_pixels_on_preview() -> None:
+def test_display_fps_overlay_writes_visible_pixels_on_preview() -> None:
     # Sanity-check that the overlay actually paints something. The first
     # frame has no measurable dt → overlay can't render yet, but every
     # frame after that should have a black rectangle in the top-left.
     node = Display()
-    node.show_fps = True
     received: list[np.ndarray] = []
     node.set_frame_callback(received.append)
     up, _ = _wire(node)

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -133,7 +133,59 @@ def test_display_forwards_finish() -> None:
     assert node.outputs[0].finished
 
 
-def test_display_has_no_params() -> None:
-    # An inline preview makes window_title meaningless — Display
-    # deliberately exposes no params so it stays purely a live view.
-    assert Display().params == []
+def test_display_exposes_show_fps_param() -> None:
+    # Display has exactly one user-facing param: an FPS-overlay toggle.
+    # It defaults off so the historical pass-through-only behaviour is
+    # preserved out of the box.
+    params = Display().params
+    assert [p.name for p in params] == ["show_fps"]
+    assert params[0].metadata["default"] is False
+    assert Display().show_fps is False
+
+
+def test_display_show_fps_overlay_does_not_leak_to_output() -> None:
+    # The overlay is for the preview only; the output port must still
+    # forward the original IoData byte-for-byte so downstream sinks
+    # (e.g. VideoSink) record clean frames.
+    node = Display()
+    node.show_fps = True
+    up, captured = _wire(node)
+
+    received: list[np.ndarray] = []
+    node.set_frame_callback(received.append)
+
+    node.before_run()
+    # Big enough that the FPS rect (≈ 90 × 25 px in the top-left) leaves
+    # plenty of unmodified canvas for the leak check.
+    big = lambda v: np.full((128, 256, 3), v, dtype=np.uint8)
+    for v in (60, 120, 200):
+        up.send(IoData.from_image(big(v)))
+
+    # Output is unmodified everywhere.
+    for c, v in zip(captured, (60, 120, 200)):
+        np.testing.assert_array_equal(c.image, big(v))
+    # Preview callback gets the annotated frame, but the bottom-right
+    # corner (well outside the overlay box) is still untouched.
+    for f, v in zip(received, (60, 120, 200)):
+        assert int(f[-1, -1, 0]) == v
+
+
+def test_display_show_fps_overlay_writes_visible_pixels_on_preview() -> None:
+    # Sanity-check that the overlay actually paints something. The first
+    # frame has no measurable dt → overlay can't render yet, but every
+    # frame after that should have a black rectangle in the top-left.
+    node = Display()
+    node.show_fps = True
+    received: list[np.ndarray] = []
+    node.set_frame_callback(received.append)
+    up, _ = _wire(node)
+
+    node.before_run()
+    for _ in range(3):
+        up.send(IoData.from_image(_bgr(100, h=64, w=128)))
+
+    np.testing.assert_array_equal(received[0], _bgr(100, h=64, w=128))
+    # On the second frame the overlay rect lives in the top-left.
+    # Pixel (5, 50) sits in the rect's clear space above the text glyphs
+    # so it should be solid black, distinct from the input fill of 100.
+    assert int(received[1][5, 50, 0]) == 0

--- a/tests/test_new_filters.py
+++ b/tests/test_new_filters.py
@@ -1,0 +1,310 @@
+"""Tests for the filter nodes added in v0.1.20.
+
+Covers Flip, Crop, Rotate, Gaussian Blur, Invert, Frame Difference,
+Temporal Mean and Temporal Median. Same pattern as ``test_filters.py``
+— a private ``_run`` helper feeds a single ``IoData`` into the node's
+first input and reads the first output back.
+"""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from core.io_data import IoData
+from nodes.filters.crop import Crop
+from nodes.filters.flip import Flip, FlipMode
+from nodes.filters.frame_difference import FrameDifference
+from nodes.filters.gaussian_blur import GaussianBlur
+from nodes.filters.invert import Invert
+from nodes.filters.rotate import Rotate
+from nodes.filters.temporal_mean import TemporalMean
+from nodes.filters.temporal_median import TemporalMedian
+
+
+def _bgr(h: int = 16, w: int = 16, value: int = 100) -> np.ndarray:
+    return np.full((h, w, 3), value, dtype=np.uint8)
+
+
+def _grey(h: int = 16, w: int = 16, value: int = 100) -> np.ndarray:
+    return np.full((h, w), value, dtype=np.uint8)
+
+
+def _run(node, image: np.ndarray) -> np.ndarray:
+    node.inputs[0].receive(IoData.from_image(image))
+    out = node.outputs[0].last_emitted
+    assert out is not None, "node did not emit on output 0"
+    return out.image
+
+
+# ── Flip ──────────────────────────────────────────────────────────────────────
+
+def test_flip_horizontal_mirrors_left_right() -> None:
+    image = np.zeros((4, 4, 3), dtype=np.uint8)
+    image[0, 0] = (255, 255, 255)
+
+    node = Flip()
+    node.mode = FlipMode.HORIZONTAL
+    out = _run(node, image)
+
+    np.testing.assert_array_equal(out[0, 3], (255, 255, 255))
+    np.testing.assert_array_equal(out[0, 0], (0, 0, 0))
+
+
+def test_flip_vertical_mirrors_top_bottom() -> None:
+    image = np.zeros((4, 4, 3), dtype=np.uint8)
+    image[0, 0] = (255, 255, 255)
+
+    node = Flip()
+    node.mode = FlipMode.VERTICAL
+    out = _run(node, image)
+
+    np.testing.assert_array_equal(out[3, 0], (255, 255, 255))
+    np.testing.assert_array_equal(out[0, 0], (0, 0, 0))
+
+
+def test_flip_both_is_180_rotation() -> None:
+    image = np.zeros((4, 4, 3), dtype=np.uint8)
+    image[0, 0] = (255, 255, 255)
+
+    node = Flip()
+    node.mode = FlipMode.BOTH
+    out = _run(node, image)
+
+    np.testing.assert_array_equal(out[3, 3], (255, 255, 255))
+    np.testing.assert_array_equal(out[0, 0], (0, 0, 0))
+
+
+def test_flip_mode_setter_rejects_invalid_value() -> None:
+    node = Flip()
+    with pytest.raises(ValueError):
+        node.mode = 99
+
+
+# ── Crop ──────────────────────────────────────────────────────────────────────
+
+def test_crop_returns_requested_roi() -> None:
+    image = np.arange(8 * 8 * 3, dtype=np.uint8).reshape(8, 8, 3)
+    node = Crop()
+    node.x, node.y, node.width, node.height = 2, 1, 4, 3
+    out = _run(node, image)
+
+    assert out.shape == (3, 4, 3)
+    np.testing.assert_array_equal(out, image[1:4, 2:6])
+
+
+def test_crop_clamps_oversized_roi_to_input_bounds() -> None:
+    image = _bgr(8, 8, 50)
+    node = Crop()
+    node.x, node.y, node.width, node.height = 4, 4, 100, 100
+    out = _run(node, image)
+
+    assert out.shape == (4, 4, 3)
+
+
+def test_crop_produces_at_least_one_pixel_for_off_canvas_roi() -> None:
+    image = _bgr(8, 8)
+    node = Crop()
+    node.x, node.y, node.width, node.height = 50, 50, 4, 4
+    out = _run(node, image)
+
+    assert out.size > 0
+    assert out.shape == (1, 1, 3)
+
+
+def test_crop_rejects_zero_or_negative_size() -> None:
+    node = Crop()
+    with pytest.raises(ValueError):
+        node.width = 0
+    with pytest.raises(ValueError):
+        node.height = -3
+
+
+# ── Rotate ────────────────────────────────────────────────────────────────────
+
+def test_rotate_zero_degrees_is_identity_when_expand_off() -> None:
+    image = _bgr(10, 20, 77)
+    node = Rotate()
+    node.angle = 0.0
+    node.expand = False
+    out = _run(node, image)
+
+    assert out.shape == image.shape
+    np.testing.assert_array_equal(out, image)
+
+
+def test_rotate_90_with_expand_swaps_dimensions() -> None:
+    image = _bgr(10, 20)
+    node = Rotate()
+    node.angle = 90.0
+    node.expand = True
+    out = _run(node, image)
+
+    # 90° rotation of a 20×10 (W×H) image yields 10×20.
+    assert out.shape == (20, 10, 3)
+
+
+def test_rotate_keeps_input_dimensions_when_expand_off() -> None:
+    image = _bgr(12, 24)
+    node = Rotate()
+    node.angle = 30.0
+    node.expand = False
+    out = _run(node, image)
+
+    assert out.shape == image.shape
+
+
+# ── Gaussian Blur ─────────────────────────────────────────────────────────────
+
+def test_gaussian_blur_smooths_high_contrast_edge() -> None:
+    image = np.zeros((8, 8, 3), dtype=np.uint8)
+    image[:, 4:] = 255
+
+    node = GaussianBlur()
+    node.ksize = 5
+    node.sigma = 0.0
+    out = _run(node, image)
+
+    # The hard edge column 4 was 255 against a 0 neighbour; after the
+    # blur the same column pulls in dark pixels and falls below 255.
+    assert int(out[4, 4, 0]) < 255
+    assert int(out[4, 4, 0]) > 0
+
+
+def test_gaussian_blur_even_ksize_is_rounded_up_to_odd() -> None:
+    node = GaussianBlur()
+    node.ksize = 6
+    assert node.ksize == 7
+
+
+def test_gaussian_blur_rejects_negative_sigma() -> None:
+    node = GaussianBlur()
+    with pytest.raises(ValueError):
+        node.sigma = -1.0
+
+
+# ── Invert ────────────────────────────────────────────────────────────────────
+
+def test_invert_returns_complement_of_each_pixel() -> None:
+    image = _bgr(4, 4, 30)
+    out = _run(Invert(), image)
+
+    np.testing.assert_array_equal(out, 255 - image)
+
+
+def test_invert_passes_through_greyscale_type() -> None:
+    node = Invert()
+    node.inputs[0].receive(IoData.from_greyscale(_grey(4, 4, 200)))
+    emitted = node.outputs[0].last_emitted
+    assert emitted is not None
+    np.testing.assert_array_equal(emitted.image, 255 - _grey(4, 4, 200))
+
+
+def test_invert_has_no_params() -> None:
+    assert Invert().params == []
+
+
+# ── Frame Difference ──────────────────────────────────────────────────────────
+
+def test_frame_difference_first_frame_is_all_zero() -> None:
+    image = _bgr(4, 4, 100)
+    node = FrameDifference()
+    node.before_run()
+    out = _run(node, image)
+
+    np.testing.assert_array_equal(out, np.zeros_like(image))
+
+
+def test_frame_difference_emits_absdiff_for_subsequent_frames() -> None:
+    a = _bgr(4, 4, 30)
+    b = _bgr(4, 4, 90)
+    node = FrameDifference()
+    node.before_run()
+
+    _run(node, a)
+    out = _run(node, b)
+
+    expected = np.full_like(a, 60)
+    np.testing.assert_array_equal(out, expected)
+
+
+def test_frame_difference_resets_buffer_between_runs() -> None:
+    node = FrameDifference()
+    node.before_run()
+    _run(node, _bgr(4, 4, 50))
+
+    node.before_run()
+    out = _run(node, _bgr(4, 4, 200))
+
+    # Second run starts cold — first frame again emits zeros, not the
+    # difference against the previous run's leftover frame.
+    np.testing.assert_array_equal(out, np.zeros_like(_bgr(4, 4)))
+
+
+# ── Temporal Mean ─────────────────────────────────────────────────────────────
+
+def test_temporal_mean_first_frame_passes_through() -> None:
+    image = _bgr(4, 4, 100)
+    node = TemporalMean()
+    node.window = 3
+    node.before_run()
+    out = _run(node, image)
+
+    np.testing.assert_array_equal(out, image)
+
+
+def test_temporal_mean_averages_buffered_frames() -> None:
+    node = TemporalMean()
+    node.window = 3
+    node.before_run()
+
+    _run(node, _bgr(4, 4, 30))
+    _run(node, _bgr(4, 4, 90))
+    out = _run(node, _bgr(4, 4, 150))
+
+    # Mean of {30, 90, 150} == 90 across every pixel/channel.
+    expected = _bgr(4, 4, 90)
+    np.testing.assert_array_equal(out, expected)
+
+
+def test_temporal_mean_drops_oldest_when_window_full() -> None:
+    node = TemporalMean()
+    node.window = 2
+    node.before_run()
+
+    _run(node, _bgr(4, 4, 0))
+    _run(node, _bgr(4, 4, 100))
+    out = _run(node, _bgr(4, 4, 200))
+
+    # Only the last two are in the window: mean(100, 200) == 150.
+    np.testing.assert_array_equal(out, _bgr(4, 4, 150))
+
+
+def test_temporal_mean_rejects_zero_window() -> None:
+    with pytest.raises(ValueError):
+        TemporalMean().window = 0
+
+
+# ── Temporal Median ───────────────────────────────────────────────────────────
+
+def test_temporal_median_picks_middle_value() -> None:
+    node = TemporalMedian()
+    node.window = 3
+    node.before_run()
+
+    _run(node, _bgr(4, 4, 10))
+    _run(node, _bgr(4, 4, 200))
+    out = _run(node, _bgr(4, 4, 50))
+
+    # Median of {10, 200, 50} == 50 — robust against the 200 outlier
+    # that would have biased a mean to ~86.
+    np.testing.assert_array_equal(out, _bgr(4, 4, 50))
+
+
+def test_temporal_median_first_frame_passes_through() -> None:
+    image = _bgr(4, 4, 70)
+    node = TemporalMedian()
+    node.window = 3
+    node.before_run()
+    out = _run(node, image)
+
+    np.testing.assert_array_equal(out, image)


### PR DESCRIPTION
## Summary

Adds the eight nodes you picked from the gap survey, plus an always-on FPS read-out on the existing Display node.

### New nodes

| Section     | Name              | Notes |
|-------------|-------------------|-------|
| Transform   | **Flip**          | `cv2.flip` wrapper; enum mirrors OpenCV's `flipCode` (`HORIZONTAL=1`, `VERTICAL=0`, `BOTH=-1`). |
| Transform   | **Crop**          | ROI by `(x, y, width, height)`; clamps off-canvas rectangles to ≥ 1 px so the node always emits a positive-area image. |
| Transform   | **Rotate**        | Free-angle rotation around the centre. `expand=True` grows the canvas to fit so corners are never clipped; `expand=False` keeps the input dimensions. |
| Processing  | **Gaussian Blur** | `cv2.GaussianBlur`; even `ksize` is bumped up to the next odd integer the same way `Median` already does. |
| Processing  | **Invert**        | Per-channel `255 - pixel` via `cv2.bitwise_not`. No params. |
| Temporal *(new section)* | **Frame Difference** | `\|current - previous\|`; first frame emits zero, buffer resets on each run. |
| Temporal    | **Temporal Mean**   | Rolling per-pixel mean over the last `window` frames. Good for additive Gaussian noise. |
| Temporal    | **Temporal Median** | Rolling per-pixel median. Robust against single-frame outliers where mean would smear them. |

All three Temporal nodes also flush their buffer if the input shape changes mid-run, so an upstream Crop/Scale edit during a live run can't blow up the reduction with mismatched shapes.

### Display: FPS overlay (always on)

- The preview now shows a small black rectangle with white `FPS xx.x` in the top-left corner. Value is an EMA (α = 0.2) over per-frame `dt`, so it stays readable on jittery sources.
- No toggle parameter — live timing is the kind of information you only ever notice when it's missing.
- The first tick has no measurable `dt`, so the overlay only kicks in from the second frame onwards.
- The overlay is **preview-only** — the output port still forwards the original `IoData`. A downstream VideoSink records a clean frame, not the debug overlay.

### Tests

- `tests/test_new_filters.py` — 26 new tests, one block per node (Flip / Crop / Rotate / Gaussian Blur / Invert / Frame Difference / Temporal Mean / Temporal Median). Cover core behaviour, parameter validation, and shape edge cases.
- `tests/test_display.py` — 2 new tests for the FPS overlay (no-leak-to-output + overlay actually paints visible pixels). `test_display_has_no_params` is back, since Display has no params again.
- Full suite: **151 passed, 3 skipped** (skips unchanged from baseline, Qt-dependent).

### Bookkeeping

- `APP_VERSION` 0.1.19 → 0.1.20.
- `doc/welcome.html` — hero version span + new "What's new in v0.1.20" entry summarising the new nodes and the FPS overlay.
- `CHANGELOG.md` — `## [0.1.20]` entry under `### Added`.

## Test plan

- [x] `pytest tests/` — green locally.
- [ ] **Drop each new node** onto the canvas via the palette to confirm it appears in its declared section (Transform / Processing / Temporal).
- [ ] **Flip / Rotate / Crop**: wire to a still image, watch the viewer update as you change params. Rotate with `expand=False` should clip; `expand=True` should grow the canvas.
- [ ] **Gaussian Blur**: verify the slider/spinbox round-trips through saved flows; even `ksize` should round up to odd.
- [ ] **Frame Difference / Temporal Mean / Temporal Median**: wire to VideoSource. Frame Difference should highlight motion against a black background; Temporal Median should suppress brief flickers a Temporal Mean would smear.
- [ ] **Display FPS overlay**: open any flow with a Display node, confirm the FPS counter appears in the preview from the second frame onwards. Record downstream via VideoSink and verify the output file does *not* contain the overlay.