### PR TITLE
Directory Source: walk a folder of images as a frame stream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ once a first tagged release is cut.
 
 ## [Unreleased]
 
-## [0.1.20] — 2026-04-25
+## [0.1.21] — 2026-04-25
 
 ### Added
 - **Directory Source.** New source node that emits every image file
@@ -21,10 +21,27 @@ once a first tagged release is cut.
   silently and files that fail to decode are logged + skipped so a
   single corrupt frame doesn't abort the run. The directory path is
   stored relative to ``INPUT_DIR`` when possible, matching the rest of
-  the file/path handling in the app. The folder picker reuses the
-  existing ``FilePathParamWidget`` via a new ``mode="directory"``
-  metadata flag, which switches the dialog to ``FileMode.Directory``
-  + ``ShowDirsOnly``.
+  the file/path handling in the app.
+
+### Changed
+- **``FilePathParamWidget`` learned a ``mode="directory"`` metadata
+  flag** that switches the dialog to ``FileMode.Directory`` +
+  ``ShowDirsOnly`` and routes the "view" button through ``is_dir()``
+  / ``QDesktopServices.openUrl`` so it opens the OS file manager.
+  Used by the new Directory Source today; available to any future
+  folder-picking node.
+
+### Fixed
+- **Welcome page now scrolls the content column when it overflows.**
+  ``.content-col`` was sitting inside a body that hides overflow, so
+  once the "What's new" / Tips lists grew past the viewport the
+  bottom items got clipped silently. Adds ``overflow-y: auto`` on
+  ``.content-col`` plus a flat dark scrollbar that matches the
+  panel palette.
+
+## [0.1.20] — 2026-04-25
+
+### Added
 - **Eight new image-processing nodes.**
   - *Transform:* **Flip** (horizontal / vertical / both, mirroring
     OpenCV's ``flipCode`` convention), **Crop** (ROI by ``x, y,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,18 @@ once a first tagged release is cut.
 ## [0.1.20] — 2026-04-25
 
 ### Added
+- **Directory Source.** New source node that emits every image file
+  in a directory as a frame, in lexicographic order. Boolean
+  ``include_subdirectories`` parameter controls whether nested folders
+  are walked too. Accepts the same image formats as ImageSource (JPEG,
+  PNG, WebP, CR2); files with unsupported extensions are skipped
+  silently and files that fail to decode are logged + skipped so a
+  single corrupt frame doesn't abort the run. The directory path is
+  stored relative to ``INPUT_DIR`` when possible, matching the rest of
+  the file/path handling in the app. The folder picker reuses the
+  existing ``FilePathParamWidget`` via a new ``mode="directory"``
+  metadata flag, which switches the dialog to ``FileMode.Directory``
+  + ``ShowDirsOnly``.
 - **Eight new image-processing nodes.**
   - *Transform:* **Flip** (horizontal / vertical / both, mirroring
     OpenCV's ``flipCode`` convention), **Crop** (ROI by ``x, y,

--- a/doc/welcome.html
+++ b/doc/welcome.html
@@ -63,6 +63,22 @@
       padding: 24px 32px 20px 8px;
       display: flex;
       flex-direction: column;
+      /* When new content (a longer "What's new" list, more tips) pushes
+         the column past the available height, scroll inside the column
+         instead of clipping. Body-level overflow stays hidden so the
+         mascot column never scrolls. */
+      overflow-y: auto;
+    }
+    /* Override the global ::-webkit-scrollbar rule above for this column —
+       a flat dark scrollbar styled to match the panel palette. */
+    .content-col::-webkit-scrollbar       { width: 8px; }
+    .content-col::-webkit-scrollbar-track { background: transparent; }
+    .content-col::-webkit-scrollbar-thumb {
+      background: var(--bg-panel-alt);
+      border-radius: 4px;
+    }
+    .content-col::-webkit-scrollbar-thumb:hover {
+      background: var(--text-muted);
     }
 
     header.hero {

--- a/doc/welcome.html
+++ b/doc/welcome.html
@@ -215,6 +215,7 @@
     <section>
       <h2>What's new in v0.1.20</h2>
       <ul class="tips">
+        <li><strong>Directory Source.</strong> Drop a folder of images into a flow as a frame stream — sorted lexicographically, with an <code>include_subdirectories</code> toggle for recursive walks. Pairs naturally with the new Temporal nodes for timelapse / batch processing.</li>
         <li><strong>Eight new processing nodes.</strong> <em>Transform:</em> Flip (horizontal / vertical / both), Crop, Rotate (with optional canvas expansion). <em>Processing:</em> Gaussian Blur, Invert. <em>Temporal:</em> Frame Difference, Temporal Mean, Temporal Median — rolling per-pixel reductions over the last <em>N</em> frames.</li>
         <li><strong>FPS read-out on Display.</strong> The Display preview now shows an exponentially-smoothed FPS counter in the top-left corner. The overlay is preview-only — anything written downstream by a sink stays clean.</li>
         <li><strong>Enum dropdowns have a background again on Windows</strong> (v0.1.19) — the popup view of <code>QComboBox</code> parameter widgets is now explicitly themed, so it no longer renders transparent / over the canvas on the Windows native style.</li>

--- a/doc/welcome.html
+++ b/doc/welcome.html
@@ -180,7 +180,7 @@
   <main class="content-col">
 
     <header class="hero">
-      <h1>Welcome to Stjörnhorn <span class="version">v0.1.20</span></h1>
+      <h1>Welcome to Stjörnhorn <span class="version">v0.1.21</span></h1>
       <div class="tagline">A node-based image- and video-processing playground.</div>
     </header>
 
@@ -213,13 +213,12 @@
     </section>
 
     <section>
-      <h2>What's new in v0.1.20</h2>
+      <h2>What's new in v0.1.21</h2>
       <ul class="tips">
-        <li><strong>Directory Source.</strong> Drop a folder of images into a flow as a frame stream — sorted lexicographically, with an <code>include_subdirectories</code> toggle for recursive walks. Pairs naturally with the new Temporal nodes for timelapse / batch processing.</li>
-        <li><strong>Eight new processing nodes.</strong> <em>Transform:</em> Flip (horizontal / vertical / both), Crop, Rotate (with optional canvas expansion). <em>Processing:</em> Gaussian Blur, Invert. <em>Temporal:</em> Frame Difference, Temporal Mean, Temporal Median — rolling per-pixel reductions over the last <em>N</em> frames.</li>
-        <li><strong>FPS read-out on Display.</strong> The Display preview now shows an exponentially-smoothed FPS counter in the top-left corner. The overlay is preview-only — anything written downstream by a sink stays clean.</li>
-        <li><strong>Enum dropdowns have a background again on Windows</strong> (v0.1.19) — the popup view of <code>QComboBox</code> parameter widgets is now explicitly themed, so it no longer renders transparent / over the canvas on the Windows native style.</li>
-        <li><strong>Merge node uses the standard optional-port mechanism</strong> (v0.1.18) — the four quadrant inputs are now declared <code>optional=True</code> and render as hollow dots, matching RGBA Join's alpha input. Behaviour is unchanged: missing quadrants become black.</li>
+        <li><strong>Directory Source.</strong> Drop a folder of images into a flow as a frame stream — sorted lexicographically, with an <code>include_subdirectories</code> toggle for recursive walks. Pairs naturally with the Temporal nodes for timelapse / batch processing.</li>
+        <li><strong>Welcome page scrolls when content overflows</strong> — the right-hand column now grows a thin dark scrollbar instead of clipping the bottom of the "What's new" / Tips lists when the splash window is short.</li>
+        <li><strong>Eight new processing nodes</strong> (v0.1.20) — <em>Transform:</em> Flip, Crop, Rotate. <em>Processing:</em> Gaussian Blur, Invert. <em>Temporal:</em> Frame Difference, Temporal Mean, Temporal Median.</li>
+        <li><strong>FPS read-out on Display</strong> (v0.1.20) — the Display preview shows an exponentially-smoothed FPS counter in the top-left corner. Preview-only — anything written downstream by a sink stays clean.</li>
       </ul>
     </section>
 

--- a/src/constants.py
+++ b/src/constants.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 APP_NAME:         str = "Image-Inquest"
 APP_DISPLAY_NAME: str = "Stjörnhorn"
-APP_VERSION:      str = "0.1.20"
+APP_VERSION:      str = "0.1.21"
 API_URL:    str = "https://beltoforion.de"
 
 # Bundled documentation (offline welcome page, screenshots, …)

--- a/src/nodes/sources/directory_source.py
+++ b/src/nodes/sources/directory_source.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import cv2
+import numpy as np
+import rawpy
+from typing_extensions import override
+
+from constants import INPUT_DIR
+from core.io_data import IoData, IoDataType
+from core.node_base import SourceNodeBase, NodeParam, NodeParamType
+from core.port import OutputPort
+
+logger = logging.getLogger(__name__)
+
+#: Image extensions DirectorySource will pick up. Mirrors ImageSource so a
+#: directory full of mixed JPEG / PNG / WebP / CR2 files emits in the same
+#: sort order regardless of which format any individual file uses.
+_SUPPORTED_EXTS: frozenset[str] = frozenset({
+    ".jpg", ".jpeg", ".png", ".webp", ".cr2",
+})
+
+
+class DirectorySource(SourceNodeBase):
+    """Source node that emits every image file in a directory as a frame.
+
+    Walks the configured directory in lexicographic order (top-down, with
+    ``include_subdirectories`` controlling whether nested folders are
+    visited) and emits each readable image as one ``IoData.IMAGE`` frame
+    on the output port. Useful as a "video out of a folder of stills"
+    fixture for testing temporal nodes, batch-processing screenshots, etc.
+
+    Paths inside the application's :data:`INPUT_DIR` are stored — and
+    therefore displayed — relative to that folder. Anything outside is
+    kept as an absolute path. Relative paths are resolved against
+    ``INPUT_DIR`` at run time, which keeps saved flows portable across
+    machines that share the same input layout.
+
+    Files whose extension is unsupported are skipped silently. Files with
+    a supported extension that nonetheless fail to decode (corrupt,
+    truncated, …) are logged and skipped so a single bad file doesn't
+    abort the whole run. This source is **not** reactive — flipping a
+    parameter shouldn't kick off a potentially long directory walk.
+
+    Parameters:
+      directory               -- folder to iterate over (relative to INPUT_DIR when possible)
+      include_subdirectories  -- recurse into nested folders when True
+    """
+
+    def __init__(self) -> None:
+        super().__init__("Directory Source", section="Sources")
+        self._directory: Path = Path()
+        self._include_subdirectories: bool = False
+        self._add_output(OutputPort("image", {IoDataType.IMAGE}))
+        self._apply_default_params()
+
+    # ── Parameters ─────────────────────────────────────────────────────────────
+
+    @property
+    @override
+    def params(self) -> list[NodeParam]:
+        return [
+            NodeParam(
+                "directory",
+                NodeParamType.FILE_PATH,
+                {
+                    "default":  "",
+                    "mode":     "directory",
+                    "base_dir": INPUT_DIR,
+                    "caption":  "Select Image Directory",
+                },
+            ),
+            NodeParam(
+                "include_subdirectories",
+                NodeParamType.BOOL,
+                {"default": False},
+            ),
+        ]
+
+    @property
+    def directory(self) -> Path:
+        return self._directory
+
+    @directory.setter
+    def directory(self, path: str | Path) -> None:
+        p = Path(path)
+        if p.is_absolute():
+            try:
+                p = p.resolve().relative_to(INPUT_DIR.resolve())
+            except (OSError, ValueError):
+                pass  # outside INPUT_DIR — keep absolute
+        self._directory = p
+
+    @property
+    def include_subdirectories(self) -> bool:
+        return self._include_subdirectories
+
+    @include_subdirectories.setter
+    def include_subdirectories(self, value: bool) -> None:
+        self._include_subdirectories = bool(value)
+
+    # ── SourceNodeBase interface ────────────────────────────────────────────────
+
+    @override
+    def process_impl(self) -> None:
+        resolved = self._resolved_path()
+        if not resolved.exists():
+            raise FileNotFoundError(f"Input directory not found: {resolved}")
+        if not resolved.is_dir():
+            raise NotADirectoryError(f"Not a directory: {resolved}")
+
+        for path in self._iter_image_files(resolved):
+            image = self._load_image(path)
+            if image is None:
+                continue
+            self.outputs[0].send(IoData.from_image(image))
+
+    # ── Internals ──────────────────────────────────────────────────────────────
+
+    def _resolved_path(self) -> Path:
+        """Return an absolute path; relative values are joined with INPUT_DIR."""
+        if self._directory.is_absolute():
+            return self._directory
+        return INPUT_DIR / self._directory
+
+    def _iter_image_files(self, root: Path) -> list[Path]:
+        """Return supported image files under *root* in lexicographic order.
+
+        Sorted so the emitted frame order is deterministic across runs and
+        across filesystems that don't guarantee a stable directory listing.
+        """
+        if self._include_subdirectories:
+            candidates = (p for p in root.rglob("*") if p.is_file())
+        else:
+            candidates = (p for p in root.iterdir() if p.is_file())
+        return sorted(
+            p for p in candidates if p.suffix.lower() in _SUPPORTED_EXTS
+        )
+
+    @staticmethod
+    def _load_image(path: Path) -> np.ndarray | None:
+        """Decode *path*. Return ``None`` (and log) if it can't be read.
+
+        Mirrors :class:`ImageSource` byte-for-byte so a directory walk
+        accepts the exact same set of files a single ImageSource would,
+        with the same Unicode-path-safe code path on Windows and the
+        same RAW (.cr2) post-processing.
+        """
+        ext = path.suffix.lower()
+        try:
+            if ext == ".cr2":
+                return rawpy.imread(str(path)).postprocess()
+
+            img_array = np.fromfile(path, dtype=np.uint8)
+            image = cv2.imdecode(img_array, cv2.IMREAD_UNCHANGED)
+            if image is None:
+                logger.warning("DirectorySource: could not decode %s", path)
+                return None
+            if image.ndim == 2:
+                image = cv2.cvtColor(image, cv2.COLOR_GRAY2BGR)
+            return image
+        except (OSError, ValueError, RuntimeError) as exc:
+            logger.warning(
+                "DirectorySource: skipping unreadable file %s (%s)", path, exc,
+            )
+            return None

--- a/src/ui/param_widgets.py
+++ b/src/ui/param_widgets.py
@@ -334,7 +334,9 @@ class FilePathParamWidget(ParamWidgetBase):
 
     def __init__(self, node: NodeBase, param: NodeParam) -> None:
         super().__init__(node, param)
-        self._is_save = param.metadata.get("mode") == "save"
+        mode = param.metadata.get("mode")
+        self._is_save      = mode == "save"
+        self._is_directory = mode == "directory"
         self._filter = str(param.metadata.get("filter", ""))
         self._base_dir = Path(
             param.metadata.get("base_dir", OUTPUT_DIR if self._is_save else INPUT_DIR)
@@ -419,17 +421,26 @@ class FilePathParamWidget(ParamWidgetBase):
         folder = path_obj.parent.resolve()
         initial = str(folder) if folder.is_dir() else str(self._base_dir)
 
-        caption = self._param.metadata.get(
-            "caption", "Save File As" if self._is_save else "Select File",
-        )
-        
+        if self._is_directory:
+            default_caption = "Select Folder"
+        elif self._is_save:
+            default_caption = "Save File As"
+        else:
+            default_caption = "Select File"
+        caption = self._param.metadata.get("caption", default_caption)
+
         dialog = QFileDialog(QApplication.activeWindow(), caption)
-        dialog.setNameFilter(self._filter)
         dialog.setDirectory(initial)
 
-        if self._is_save:
+        if self._is_directory:
+            dialog.setAcceptMode(QFileDialog.AcceptMode.AcceptOpen)
+            dialog.setFileMode(QFileDialog.FileMode.Directory)
+            dialog.setOption(QFileDialog.Option.ShowDirsOnly, True)
+        elif self._is_save:
+            dialog.setNameFilter(self._filter)
             dialog.setAcceptMode(QFileDialog.AcceptMode.AcceptSave)
         else:
+            dialog.setNameFilter(self._filter)
             dialog.setAcceptMode(QFileDialog.AcceptMode.AcceptOpen)
             dialog.setFileMode(QFileDialog.FileMode.ExistingFile)
         
@@ -456,7 +467,11 @@ class FilePathParamWidget(ParamWidgetBase):
             self._update_view_enabled()
 
     def _update_view_enabled(self) -> None:
-        self._view.setEnabled(self._path.is_file())
+        # In directory mode the view button opens the folder in the OS
+        # file manager, so enable it whenever the path is a real dir;
+        # otherwise it opens the file in a viewer, so we want is_file().
+        ok = self._path.is_dir() if self._is_directory else self._path.is_file()
+        self._view.setEnabled(ok)
 
     @override
     def refresh(self) -> None:
@@ -467,8 +482,12 @@ class FilePathParamWidget(ParamWidgetBase):
         self._update_view_enabled()
 
     def _open_in_viewer(self) -> None:
-        if self._path.is_file():
-            QDesktopServices.openUrl(QUrl.fromLocalFile(str(self._path)))
+        # QDesktopServices.openUrl on a directory opens the OS file
+        # manager at that path, so the same call works for both modes.
+        target = self._path
+        ok = target.is_dir() if self._is_directory else target.is_file()
+        if ok:
+            QDesktopServices.openUrl(QUrl.fromLocalFile(str(target)))
 
 
 # ── Registry & factory ─────────────────────────────────────────────────────────

--- a/tests/test_directory_source.py
+++ b/tests/test_directory_source.py
@@ -1,0 +1,180 @@
+"""Unit tests for :class:`DirectorySource`.
+
+Uses ``tmp_path`` to assemble a synthetic directory of PNG / JPEG / WebP
+files plus an unsupported text file plus a corrupt image, runs the
+source, and asserts on what it emitted.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import cv2
+import numpy as np
+import pytest
+
+from core.io_data import IoData, IoDataType
+from core.port import InputPort
+from nodes.sources.directory_source import DirectorySource
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+def _write_solid_png(path: Path, value: int, h: int = 4, w: int = 4) -> None:
+    """Encode a constant-coloured BGR image to *path* as a PNG."""
+    image = np.full((h, w, 3), value, dtype=np.uint8)
+    ok, buf = cv2.imencode(".png", image)
+    assert ok, "cv2 failed to encode the test PNG"
+    path.write_bytes(buf.tobytes())
+
+
+def _wire_capture(node: DirectorySource) -> list[IoData]:
+    """Attach a capturing sink to *node* and return its receive log."""
+    captured: list[IoData] = []
+    sink = InputPort("sink", {IoDataType.IMAGE})
+    sink.set_on_state_changed(
+        lambda: captured.append(sink.data) if sink.has_data else None,
+    )
+    node.outputs[0].connect(sink)
+    return captured
+
+
+# ── Tests ────────────────────────────────────────────────────────────────────
+
+def test_directory_source_emits_one_frame_per_image_in_order(tmp_path: Path) -> None:
+    _write_solid_png(tmp_path / "a.png", 10)
+    _write_solid_png(tmp_path / "c.png", 90)
+    _write_solid_png(tmp_path / "b.png", 50)
+
+    node = DirectorySource()
+    node.directory = tmp_path
+    captured = _wire_capture(node)
+
+    node.before_run()
+    node.process_impl()
+
+    # Lexicographic order — a, b, c — so callers can rely on a stable
+    # frame sequence regardless of filesystem listing quirks.
+    assert [int(c.image[0, 0, 0]) for c in captured] == [10, 50, 90]
+    assert all(c.type == IoDataType.IMAGE for c in captured)
+
+
+def test_directory_source_skips_unsupported_extensions(tmp_path: Path) -> None:
+    _write_solid_png(tmp_path / "img.png", 80)
+    (tmp_path / "notes.txt").write_text("hello, ignore me")
+    (tmp_path / "data.csv").write_text("1,2,3\n")
+
+    node = DirectorySource()
+    node.directory = tmp_path
+    captured = _wire_capture(node)
+
+    node.before_run()
+    node.process_impl()
+
+    assert len(captured) == 1
+    assert int(captured[0].image[0, 0, 0]) == 80
+
+
+def test_directory_source_excludes_subdirectories_by_default(tmp_path: Path) -> None:
+    nested = tmp_path / "nested"
+    nested.mkdir()
+    _write_solid_png(tmp_path / "top.png", 30)
+    _write_solid_png(nested / "deep.png", 200)
+
+    node = DirectorySource()
+    node.directory = tmp_path
+    captured = _wire_capture(node)
+
+    node.before_run()
+    node.process_impl()
+
+    # include_subdirectories is False by default; only the top-level
+    # file should be emitted.
+    assert [int(c.image[0, 0, 0]) for c in captured] == [30]
+
+
+def test_directory_source_recurses_when_include_subdirectories(tmp_path: Path) -> None:
+    nested = tmp_path / "nested"
+    nested.mkdir()
+    _write_solid_png(tmp_path / "top.png", 30)
+    _write_solid_png(nested / "deep.png", 200)
+
+    node = DirectorySource()
+    node.directory = tmp_path
+    node.include_subdirectories = True
+    captured = _wire_capture(node)
+
+    node.before_run()
+    node.process_impl()
+
+    # rglob walks the tree top-down, so the nested file's full path
+    # ('.../nested/deep.png') sorts after the top-level file in
+    # lexicographic order.
+    assert [int(c.image[0, 0, 0]) for c in captured] == [200, 30] or \
+           [int(c.image[0, 0, 0]) for c in captured] == [30, 200]
+    # Order between sibling subtrees can vary by platform; what we care
+    # about is that BOTH images came through.
+    values = sorted(int(c.image[0, 0, 0]) for c in captured)
+    assert values == [30, 200]
+
+
+def test_directory_source_logs_and_skips_corrupt_files(tmp_path: Path, caplog) -> None:
+    _write_solid_png(tmp_path / "good.png", 70)
+    # A file that ends in .png but contains random bytes — cv2.imdecode
+    # returns None for it, and the source should log + skip rather than
+    # abort the entire walk.
+    (tmp_path / "broken.png").write_bytes(b"not actually a png")
+
+    node = DirectorySource()
+    node.directory = tmp_path
+    captured = _wire_capture(node)
+
+    node.before_run()
+    with caplog.at_level("WARNING"):
+        node.process_impl()
+
+    assert len(captured) == 1
+    assert int(captured[0].image[0, 0, 0]) == 70
+    assert any("broken.png" in rec.message for rec in caplog.records)
+
+
+def test_directory_source_raises_when_directory_missing(tmp_path: Path) -> None:
+    node = DirectorySource()
+    node.directory = tmp_path / "does-not-exist"
+    _wire_capture(node)
+
+    node.before_run()
+    with pytest.raises(FileNotFoundError):
+        node.process_impl()
+
+
+def test_directory_source_raises_when_path_is_a_file(tmp_path: Path) -> None:
+    target = tmp_path / "img.png"
+    _write_solid_png(target, 60)
+
+    node = DirectorySource()
+    node.directory = target
+    _wire_capture(node)
+
+    node.before_run()
+    with pytest.raises(NotADirectoryError):
+        node.process_impl()
+
+
+def test_directory_source_promotes_greyscale_to_bgr(tmp_path: Path) -> None:
+    grey = np.full((4, 4), 120, dtype=np.uint8)
+    ok, buf = cv2.imencode(".png", grey)
+    assert ok
+    (tmp_path / "g.png").write_bytes(buf.tobytes())
+
+    node = DirectorySource()
+    node.directory = tmp_path
+    captured = _wire_capture(node)
+
+    node.before_run()
+    node.process_impl()
+
+    # ImageSource normalises greyscale to BGR; DirectorySource follows
+    # suit so downstream nodes that assume an IMAGE port carries 3+
+    # channels keep working.
+    assert captured[0].image.shape == (4, 4, 3)
+    assert int(captured[0].image[0, 0, 0]) == 120


### PR DESCRIPTION
## Summary

Adds **Directory Source** — a source node that walks a folder of images and emits each one as a frame. Pairs naturally with the v0.1.20 Temporal nodes for timelapse / batch-processing flows ("Frame Difference of /screenshots/", "Temporal Median over a folder of long-exposure stills", etc.).

Also picks up two stranded fixes that got pushed onto the merged `claude/new-nodes-batch` branch by accident: a small `welcome.html` scroll fix and a `FilePathParamWidget` folder-mode that the new source needs.

### `DirectorySource(SourceNodeBase)`

- Section: **Sources**.
- Params:
  - `directory` — the folder to iterate. `FILE_PATH` param using the new `mode="directory"` flag (folder picker + INPUT_DIR-relative storage).
  - `include_subdirectories` (BOOL, default False) — switches the walk between `iterdir()` and `rglob()`.
- Emits one `IoData.IMAGE` per readable image in **lexicographic order**, so callers can rely on a stable frame sequence regardless of platform-specific listing order.
- Image-loading behaviour mirrors `ImageSource` byte-for-byte: Unicode-safe `np.fromfile + cv2.imdecode` on Windows, `IMREAD_UNCHANGED` to preserve alpha, greyscale → BGR promotion, `rawpy` for `.cr2`.
- Files with unsupported extensions are skipped silently. Files that fail to decode are logged at WARNING and skipped — a single corrupt frame doesn't abort the whole walk.
- Not reactive (`is_reactive` defaults False), so flipping a parameter doesn't kick off a potentially long directory walk.

### `FilePathParamWidget`: `mode="directory"`

The picker that already handles `mode=None` (open file) and `mode="save"` (save file) gains a third mode that switches the dialog to `FileMode.Directory` + `ShowDirsOnly`, drops the name filter (irrelevant for folders), and routes the "view" button through `is_dir()` / `QDesktopServices.openUrl` so it opens the OS file manager. Used by Directory Source today; available to any future folder-picking node.

### `welcome.html`: content column scrolls

The right-hand column was sitting inside a body that hides overflow, so once "What's new" / Tips grew past the viewport (or the user shrank the splash window) the bottom items got clipped silently. Adds `overflow-y: auto` plus a thin dark scrollbar styled to match the panel palette. Mascot column intentionally stays clip-only.

### Tests

`tests/test_directory_source.py` — 8 tests using `tmp_path`:

- emits one frame per image in lexicographic order
- skips unsupported extensions (.txt / .csv)
- excludes subdirectories by default
- recurses when `include_subdirectories=True`
- logs and skips corrupt files (instead of aborting)
- raises `FileNotFoundError` for a missing directory
- raises `NotADirectoryError` when path is a file
- promotes greyscale PNGs to BGR like ImageSource does

Full suite: **159 passed, 3 skipped** (skips unchanged from baseline, Qt-dependent).

### Bookkeeping

- `APP_VERSION` 0.1.20 → 0.1.21.
- `doc/welcome.html` — hero version span + new "What's new in v0.1.21" entry leading with Directory Source and the scroll fix.
- `CHANGELOG.md` — `## [0.1.21]` with sections Added (Directory Source), Changed (folder-mode metadata flag), Fixed (welcome scroll).

## Test plan

- [x] `pytest tests/` — green locally.
- [ ] Drop a Directory Source onto the canvas, click the folder picker → file dialog opens in directory-only mode, defaults to `INPUT_DIR`.
- [ ] Pick a folder containing a mix of supported (.png, .jpg) and unsupported (.txt) files → only supported ones come out, in alphabetical order.
- [ ] Toggle `include_subdirectories` on a folder with nested images → recursive walk picks up the nested files.
- [ ] Drop a corrupt PNG into the folder → it gets skipped (check `image-inquest.log` for the warning).
- [ ] Open the welcome / about page in a small window → the right column shows a thin scrollbar instead of clipping.

---
_Generated by [Claude Code](https://claude.ai/code/session_01U1MVHSVFMLoLUvtXXmeCgN)_