### PR TITLE
Convert Node List from QListWidget to QTreeWidget with expand/collapse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ once a first tagged release is cut.
 
 ## [Unreleased]
 
+## [0.1.22] — 2026-04-26
+
+### Changed
+- **Node List is now a tree view.** Each palette section is a
+  collapsible group with the section name + node count as the parent
+  and the individual nodes as children. The dock toolbar gained two
+  icon buttons — *expand all* (``unfold_more``) and *collapse all*
+  (``unfold_less``) — so the user can sweep every group open or
+  closed in one click without clicking each disclosure triangle. The
+  search box auto-expands any group that still has visible matches
+  while typing, so leaves never hide behind a collapsed section.
+
 ## [0.1.21] — 2026-04-25
 
 ### Added

--- a/doc/welcome.html
+++ b/doc/welcome.html
@@ -180,7 +180,7 @@
   <main class="content-col">
 
     <header class="hero">
-      <h1>Welcome to Stjörnhorn <span class="version">v0.1.21</span></h1>
+      <h1>Welcome to Stjörnhorn <span class="version">v0.1.22</span></h1>
       <div class="tagline">A node-based image- and video-processing playground.</div>
     </header>
 
@@ -213,9 +213,10 @@
     </section>
 
     <section>
-      <h2>What's new in v0.1.21</h2>
+      <h2>What's new in v0.1.22</h2>
       <ul class="tips">
-        <li><strong>Directory Source.</strong> Drop a folder of images into a flow as a frame stream — sorted lexicographically, with an <code>include_subdirectories</code> toggle for recursive walks. Pairs naturally with the Temporal nodes for timelapse / batch processing.</li>
+        <li><strong>Node List is now a tree.</strong> Each palette section is a collapsible group with expand-all / collapse-all buttons in the dock toolbar. The search box auto-expands matching groups so leaves never hide behind a closed section.</li>
+        <li><strong>Directory Source</strong> (v0.1.21) — drop a folder of images into a flow as a frame stream, sorted lexicographically, with an <code>include_subdirectories</code> toggle for recursive walks.</li>
         <li><strong>Welcome page scrolls when content overflows</strong> — the right-hand column now grows a thin dark scrollbar instead of clipping the bottom of the "What's new" / Tips lists when the splash window is short.</li>
         <li><strong>Eight new processing nodes</strong> (v0.1.20) — <em>Transform:</em> Flip, Crop, Rotate. <em>Processing:</em> Gaussian Blur, Invert. <em>Temporal:</em> Frame Difference, Temporal Mean, Temporal Median.</li>
         <li><strong>FPS read-out on Display</strong> (v0.1.20) — the Display preview shows an exponentially-smoothed FPS counter in the top-left corner. Preview-only — anything written downstream by a sink stays clean.</li>

--- a/src/constants.py
+++ b/src/constants.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 APP_NAME:         str = "Image-Inquest"
 APP_DISPLAY_NAME: str = "Stjörnhorn"
-APP_VERSION:      str = "0.1.21"
+APP_VERSION:      str = "0.1.22"
 API_URL:    str = "https://beltoforion.de"
 
 # Bundled documentation (offline welcome page, screenshots, …)

--- a/src/ui/icons.py
+++ b/src/ui/icons.py
@@ -50,6 +50,8 @@ _CODEPOINTS: Final[dict[str, str]] = {
     "refresh":      "e5d5",
     "push_pin":     "f10d",
     "select_all":   "e162",
+    "unfold_more":  "e5d7",
+    "unfold_less":  "e5d6",
 }
 
 

--- a/src/ui/node_list.py
+++ b/src/ui/node_list.py
@@ -7,12 +7,17 @@ from PySide6.QtCore import QMimeData, QSize, Qt
 from PySide6.QtGui import QDrag
 from PySide6.QtWidgets import (
     QAbstractItemView,
+    QHBoxLayout,
+    QHeaderView,
     QLineEdit,
-    QListWidget,
-    QListWidgetItem,
+    QToolButton,
+    QTreeWidget,
+    QTreeWidgetItem,
     QVBoxLayout,
     QWidget,
 )
+
+from ui.icons import material_icon
 
 if TYPE_CHECKING:
     from core.node_registry import NodeRegistry
@@ -37,13 +42,16 @@ class NodeList(QWidget):
     """Palette listing every registered node grouped by the ``section``
     string each node declares in its constructor.
 
-    Each entry is a :class:`QListWidgetItem` that emits a drag with the
+    The widget is a :class:`QTreeWidget` where each section is a
+    collapsible top-level item and its nodes are children. A toolbar
+    above the tree exposes "expand all" / "collapse all" affordances and
+    a live search box that hides non-matching leaves while always
+    keeping the section headers visible.
+
+    Each leaf is a :class:`QTreeWidgetItem` that emits a drag with the
     :data:`NODE_LIST_MIME_TYPE` MIME type carrying a JSON descriptor of
     the node (module, class_name, display_name, category, section). The
     flow canvas reads that payload on drop and instantiates the node.
-
-    A search box filters the list live; matching falls back to case-
-    insensitive ``in`` on display names.
     """
 
     def __init__(self, registry: NodeRegistry, parent: QWidget | None = None) -> None:
@@ -53,15 +61,38 @@ class NodeList(QWidget):
         layout.setContentsMargins(4, 4, 4, 4)
         layout.setSpacing(4)
 
+        # Toolbar: expand-all / collapse-all + search. Buttons are kept
+        # narrow (icon-only) so the search field gets the rest of the row.
+        toolbar = QHBoxLayout()
+        toolbar.setContentsMargins(0, 0, 0, 0)
+        toolbar.setSpacing(4)
+
+        self._expand_btn = QToolButton()
+        self._expand_btn.setIcon(material_icon("unfold_more"))
+        self._expand_btn.setToolTip("Expand all groups")
+        self._expand_btn.setAutoRaise(True)
+        self._expand_btn.clicked.connect(self._expand_all)
+        toolbar.addWidget(self._expand_btn)
+
+        self._collapse_btn = QToolButton()
+        self._collapse_btn.setIcon(material_icon("unfold_less"))
+        self._collapse_btn.setToolTip("Collapse all groups")
+        self._collapse_btn.setAutoRaise(True)
+        self._collapse_btn.clicked.connect(self._collapse_all)
+        toolbar.addWidget(self._collapse_btn)
+
         self._search = QLineEdit()
         self._search.setPlaceholderText("Search…")
         self._search.textChanged.connect(self._on_search)
-        layout.addWidget(self._search)
+        toolbar.addWidget(self._search, 1)
 
-        self._list = _DraggableList()
-        layout.addWidget(self._list, 1)
+        layout.addLayout(toolbar)
+
+        self._tree = _DraggableTree()
+        layout.addWidget(self._tree, 1)
 
         self._populate(registry)
+        self._tree.expandAll()
 
     # ── Internals ──────────────────────────────────────────────────────────────
 
@@ -82,24 +113,26 @@ class NodeList(QWidget):
 
         for section in ordered_sections:
             entries = grouped.get(section, [])
-            # Section header is a non-selectable, non-draggable item.
-            header = QListWidgetItem(f"{section}  ({len(entries)})")
-            font = header.font()
+            header = QTreeWidgetItem([f"{section}  ({len(entries)})"])
+            font = header.font(0)
             font.setBold(True)
-            header.setFont(font)
-            header.setFlags(Qt.ItemFlag.NoItemFlags)
-            header.setData(Qt.ItemDataRole.UserRole, None)
-            self._list.addItem(header)
+            header.setFont(0, font)
+            # Section rows are organisational only — no drag payload, no
+            # selection. Keeping them enabled lets the user click the
+            # row (not just the disclosure triangle) to toggle expansion.
+            header.setFlags(Qt.ItemFlag.ItemIsEnabled)
+            header.setData(0, Qt.ItemDataRole.UserRole, None)
+            self._tree.addTopLevelItem(header)
 
             if not entries:
-                placeholder = QListWidgetItem("    (none)")
+                placeholder = QTreeWidgetItem(["(none)"])
                 placeholder.setFlags(Qt.ItemFlag.NoItemFlags)
-                placeholder.setForeground(Qt.GlobalColor.gray)
-                self._list.addItem(placeholder)
+                placeholder.setForeground(0, Qt.GlobalColor.gray)
+                header.addChild(placeholder)
                 continue
 
             for entry in entries:
-                item = QListWidgetItem(f"  {entry.display_name}")
+                item = QTreeWidgetItem([entry.display_name])
                 payload = json.dumps({
                     "module":       entry.module,
                     "class_name":   entry.class_name,
@@ -107,43 +140,72 @@ class NodeList(QWidget):
                     "category":     entry.category,
                     "section":      entry.section,
                 })
-                item.setData(Qt.ItemDataRole.UserRole, payload)
-                item.setToolTip(f"{entry.module}.{entry.class_name}")
-                self._list.addItem(item)
+                item.setData(0, Qt.ItemDataRole.UserRole, payload)
+                item.setToolTip(0, f"{entry.module}.{entry.class_name}")
+                header.addChild(item)
 
     def _on_search(self, text: str) -> None:
         query = text.strip().lower()
-        for i in range(self._list.count()):
-            item = self._list.item(i)
-            # Never hide section headers — context matters.
-            if item.flags() == Qt.ItemFlag.NoItemFlags:
-                item.setHidden(False)
-                continue
-            item.setHidden(bool(query) and query not in item.text().lower())
+        for i in range(self._tree.topLevelItemCount()):
+            section = self._tree.topLevelItem(i)
+            any_visible = False
+            for j in range(section.childCount()):
+                child = section.child(j)
+                payload = child.data(0, Qt.ItemDataRole.UserRole)
+                if payload is None:
+                    # Placeholder "(none)" row — hide it during a search
+                    # so empty sections don't get a misleading match.
+                    child.setHidden(bool(query))
+                    continue
+                matches = (not query) or (query in child.text(0).lower())
+                child.setHidden(not matches)
+                any_visible = any_visible or matches
+            # Section headers stay visible (context matters), but expand
+            # automatically while a search is active so matches are not
+            # hidden behind a collapsed group.
+            section.setHidden(False)
+            if query:
+                section.setExpanded(any_visible)
+
+    def _expand_all(self) -> None:
+        self._tree.expandAll()
+
+    def _collapse_all(self) -> None:
+        self._tree.collapseAll()
 
 
-class _DraggableList(QListWidget):
-    """QListWidget that emits a NodeEntry drag when an item is dragged."""
+class _DraggableTree(QTreeWidget):
+    """QTreeWidget that emits a NodeEntry drag when a leaf is dragged."""
 
     def __init__(self) -> None:
         super().__init__()
+        self.setHeaderHidden(True)
+        self.setColumnCount(1)
+        self.setRootIsDecorated(True)
+        self.setIndentation(14)
+        self.setUniformRowHeights(True)
+        self.setExpandsOnDoubleClick(True)
+        self.setItemsExpandable(True)
+        self.setAnimated(False)
         self.setDragEnabled(True)
         self.setDragDropMode(QAbstractItemView.DragDropMode.DragOnly)
         self.setSelectionMode(QAbstractItemView.SelectionMode.SingleSelection)
         self.setFocusPolicy(Qt.FocusPolicy.NoFocus)
         self.setIconSize(QSize(0, 0))
+        # Single visible column should fill the viewport.
+        self.header().setSectionResizeMode(QHeaderView.ResizeMode.Stretch)
 
     def startDrag(self, supported_actions) -> None:  # type: ignore[override]
         item = self.currentItem()
         if item is None:
             return
-        payload = item.data(Qt.ItemDataRole.UserRole)
+        payload = item.data(0, Qt.ItemDataRole.UserRole)
         if not payload:
             return
 
         mime = QMimeData()
         mime.setData(NODE_LIST_MIME_TYPE, payload.encode("utf-8"))
-        mime.setText(item.text().strip())   # so plain drop targets still get something
+        mime.setText(item.text(0).strip())   # so plain drop targets still get something
 
         drag = QDrag(self)
         drag.setMimeData(mime)


### PR DESCRIPTION
## Summary
Refactored the Node List palette from a flat list view to a hierarchical tree view where each section becomes a collapsible group. Added toolbar buttons for expanding/collapsing all groups at once, and enhanced the search functionality to auto-expand matching sections.

## Key Changes

- **Replaced QListWidget with QTreeWidget**: The node palette now displays sections as top-level collapsible items with individual nodes as children, providing better visual organization and grouping.

- **Added toolbar with expand/collapse buttons**: Two new icon buttons (`unfold_more` and `unfold_less`) allow users to expand or collapse all section groups in a single click, eliminating the need to click individual disclosure triangles.

- **Enhanced search behavior**: The search box now automatically expands any section that contains matching nodes while a query is active, ensuring search results are never hidden behind a collapsed group. Empty sections are collapsed during search to avoid misleading matches.

- **Improved section headers**: Section headers now display the count of nodes in parentheses and are clickable (not just the disclosure triangle) to toggle expansion. They remain visible during searches for context.

- **Updated imports and styling**: Added necessary PySide6 imports (`QHBoxLayout`, `QHeaderView`, `QToolButton`, `QTreeWidget`, `QTreeWidgetItem`) and configured tree widget properties for consistent appearance (uniform row heights, single column with stretch resize, no header, etc.).

## Implementation Details

- The `_DraggableTree` class extends `QTreeWidget` and maintains the drag-and-drop functionality for node instantiation via MIME data.
- Search filtering now iterates through tree hierarchy (sections → children) rather than a flat list, with logic to show/hide both leaf nodes and placeholder items.
- Tree is expanded by default on initialization and auto-expands during active searches to keep matches visible.
- Version bumped to 0.1.22 and welcome documentation updated to reflect the new feature.

https://claude.ai/code/session_01G9bRQQfGdhuQtLcdEisuNW