### PR TITLE
Fix Windows windowed bundle crash on launch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ once a first tagged release is cut.
 
 ## [Unreleased]
 
+## [0.2.2] — 2026-04-26
+
+### Fixed
+- **Windows windowed bundle crashed at startup with `RuntimeError:
+  sys.stderr is None`.** PyInstaller's `console=False` Windows bootloader
+  leaves `sys.stdout` and `sys.stderr` as `None`, which broke
+  `faulthandler.enable(file=sys.stderr, ...)` at import time before
+  anything else could run. `src/main.py` now redirects either stream
+  to `os.devnull` if it's missing; `setup_logging` continues to re-point
+  faulthandler at the real log file once `LOG_DIR` is known. Linux
+  AppImage was unaffected. Issue: #161
+
 ## [0.2.1] — 2026-04-26
 
 ### Added

--- a/doc/welcome.html
+++ b/doc/welcome.html
@@ -180,7 +180,7 @@
   <main class="content-col">
 
     <header class="hero">
-      <h1>Welcome to Stjörnhorn <span class="version">v0.2.1</span></h1>
+      <h1>Welcome to Stjörnhorn <span class="version">v0.2.2</span></h1>
       <div class="tagline">A node-based image- and video-processing playground.</div>
     </header>
 
@@ -213,7 +213,7 @@
     </section>
 
     <section>
-      <h2>What's new in v0.2.1</h2>
+      <h2>What's new in v0.2.2</h2>
       <ul class="tips">
         <li><strong>Every editable property is a socket (Blender-style).</strong> The <code>NodeParam</code> class is gone — each node declares its inputs directly as <code>InputPort</code>s with type, default and metadata. Numeric, boolean, enum and path params have inline widgets right next to their socket dots; wire any value source into any matching port and the streamed value drives that param per frame.</li>
         <li><strong>New numeric nodes: Value Source, Constant Value, Math, Clamp.</strong> Plus Display now renders SCALAR / MATRIX payloads as text, so a numeric pipeline can terminate at a Display without a sink — the inline preview <em>is</em> the result.</li>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "stjornhorn"
-version = "0.2.1"
+version = "0.2.2"
 description = "Stjörnhorn (Image-Inquest) — node-based image and video processing editor"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/constants.py
+++ b/src/constants.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 APP_NAME:         str = "Image-Inquest"
 APP_DISPLAY_NAME: str = "Stjörnhorn"
-APP_VERSION:      str = "0.2.1"
+APP_VERSION:      str = "0.2.2"
 API_URL:    str = "https://beltoforion.de"
 
 # Path resolution -----------------------------------------------------------

--- a/src/main.py
+++ b/src/main.py
@@ -3,8 +3,22 @@ from __future__ import annotations
 import argparse
 import faulthandler
 import logging
+import os
 import sys
 from pathlib import Path
+
+# PyInstaller's Windows windowed bootloader (`console=False`) leaves
+# ``sys.stdout`` and ``sys.stderr`` as None — there is no console for the
+# interpreter to attach them to. That makes any code that touches the
+# streams crash before it can even run, including ``faulthandler.enable``
+# below, the ``logging.StreamHandler`` set up in ``log.py``, and stray
+# ``print()`` calls. Redirect to devnull as a safe import-time default;
+# ``setup_logging`` re-points faulthandler at the real log file once
+# LOG_DIR is known. Issue: #161
+if sys.stdout is None:
+    sys.stdout = open(os.devnull, "w", encoding="utf-8")
+if sys.stderr is None:
+    sys.stderr = open(os.devnull, "w", encoding="utf-8")
 
 # Enable as early as possible so crashes during Qt/plugin import or
 # QApplication construction (i.e. before setup_logging runs) still


### PR DESCRIPTION
PyInstaller's Windows windowed bootloader (`console=False`) leaves `sys.stdout` and `sys.stderr` as None, which crashed `faulthandler.enable(file=sys.stderr, ...)` at import time before anything else could run. Redirect either stream to `os.devnull` if it's None at the very top of `src/main.py`; `setup_logging()` continues to re-point faulthandler at the real log file once `LOG_DIR` is known.

Linux AppImage was unaffected (`console=False` only changes the Windows / macOS bootloaders).

Bumps APP_VERSION to 0.2.2.

Fixes #161