### PR TITLE
Bundle node module bytecode into the frozen PyInstaller artifact

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,24 @@ once a first tagged release is cut.
 
 ## [Unreleased]
 
+## [0.2.3] — 2026-04-26
+
+### Fixed
+- **Frozen bundle couldn't load any flow.** The PyInstaller spec used
+  `collect_submodules('nodes')` to enumerate the dynamically-imported
+  built-in node modules, but `nodes/` and its `filters/` / `sources/` /
+  `sinks/` subdirectories are PEP 420 namespace packages (no
+  `__init__.py`), and `pkgutil.iter_modules` — which `collect_submodules`
+  walks under the hood — silently skips namespace-package children of
+  namespace packages, so the resulting hidden-imports list contained
+  only the top-level `nodes` name. None of the node modules' bytecode
+  ended up in the bundle, and `flow_io._instantiate_node`'s runtime
+  `importlib.import_module("nodes.filters.dither")` calls all failed
+  with `ModuleNotFoundError`. The spec now walks `src/nodes/` directly
+  to enumerate every module name, and adds `src/` to its own `sys.path`
+  so the unrelated `collect_submodules('core'/'ui'/'ocvl')` calls also
+  resolve from a `src/` layout. Issue: #163
+
 ## [0.2.2] — 2026-04-26
 
 ### Fixed

--- a/doc/welcome.html
+++ b/doc/welcome.html
@@ -180,7 +180,7 @@
   <main class="content-col">
 
     <header class="hero">
-      <h1>Welcome to Stjörnhorn <span class="version">v0.2.2</span></h1>
+      <h1>Welcome to Stjörnhorn <span class="version">v0.2.3</span></h1>
       <div class="tagline">A node-based image- and video-processing playground.</div>
     </header>
 
@@ -213,7 +213,7 @@
     </section>
 
     <section>
-      <h2>What's new in v0.2.2</h2>
+      <h2>What's new in v0.2.3</h2>
       <ul class="tips">
         <li><strong>Every editable property is a socket (Blender-style).</strong> The <code>NodeParam</code> class is gone — each node declares its inputs directly as <code>InputPort</code>s with type, default and metadata. Numeric, boolean, enum and path params have inline widgets right next to their socket dots; wire any value source into any matching port and the streamed value drives that param per frame.</li>
         <li><strong>New numeric nodes: Value Source, Constant Value, Math, Clamp.</strong> Plus Display now renders SCALAR / MATRIX payloads as text, so a numeric pipeline can terminate at a Display without a sink — the inline preview <em>is</em> the result.</li>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "stjornhorn"
-version = "0.2.2"
+version = "0.2.3"
 description = "Stjörnhorn (Image-Inquest) — node-based image and video processing editor"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/constants.py
+++ b/src/constants.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 APP_NAME:         str = "Image-Inquest"
 APP_DISPLAY_NAME: str = "Stjörnhorn"
-APP_VERSION:      str = "0.2.2"
+APP_VERSION:      str = "0.2.3"
 API_URL:    str = "https://beltoforion.de"
 
 # Path resolution -----------------------------------------------------------

--- a/stjornhorn.spec
+++ b/stjornhorn.spec
@@ -2,9 +2,51 @@
 # Driven by .github/workflows/release.yml on a `v*` tag push. Issue: #157
 # pylint: disable=undefined-variable
 
+import os
+import sys
+
+# ``collect_submodules`` resolves a package through the build-time
+# interpreter's ``sys.path`` (via ``importlib.util.find_spec``). The
+# project uses a ``src/`` layout, so without this insert the ``core`` /
+# ``ui`` / ``ocvl`` packages aren't importable from where ``pyinstaller``
+# is invoked and ``collect_submodules`` returns nothing. ``pathex``
+# below only affects PyInstaller's *Analysis*, not this spec
+# interpreter. Issue: #163
+_HERE = os.path.dirname(os.path.abspath(SPEC))
+_SRC = os.path.join(_HERE, 'src')
+if _SRC not in sys.path:
+    sys.path.insert(0, _SRC)
+
 from PyInstaller.utils.hooks import collect_submodules
 
 block_cipher = None
+
+
+def _collect_node_modules() -> list[str]:
+    """Enumerate every ``nodes.*`` module under ``src/nodes`` by walking
+    the directory tree.
+
+    ``collect_submodules('nodes')`` doesn't pick these up: ``nodes`` and
+    its ``filters`` / ``sources`` / ``sinks`` subdirectories are PEP 420
+    namespace packages (no ``__init__.py``), and ``pkgutil.iter_modules``
+    — which ``collect_submodules`` walks under the hood — silently skips
+    namespace-package children of namespace packages. Doing the walk
+    ourselves sidesteps that quirk without forcing ``__init__.py`` files
+    into the source tree just to satisfy the build tooling.
+    """
+    nodes_root = os.path.join(_SRC, 'nodes')
+    out: list[str] = ['nodes']
+    for dirpath, _dirnames, filenames in os.walk(nodes_root):
+        rel_dir = os.path.relpath(dirpath, _SRC).replace(os.sep, '.')
+        if rel_dir != 'nodes':
+            out.append(rel_dir)  # the subpackage itself (nodes.filters, …)
+        for f in filenames:
+            if not f.endswith('.py') or f == '__init__.py':
+                continue
+            mod = f'{rel_dir}.{f[:-3]}'
+            out.append(mod)
+    return out
+
 
 # Built-in node modules are loaded via importlib at runtime (the registry
 # discovers them through an AST scan, then ``importlib.import_module(...)``s
@@ -13,7 +55,7 @@ block_cipher = None
 # packages, which are wired together through dynamic imports across the
 # scene / flow_io layer.
 hiddenimports = (
-    collect_submodules('nodes')
+    _collect_node_modules()
     + collect_submodules('core')
     + collect_submodules('ui')
     + collect_submodules('ocvl')


### PR DESCRIPTION
The spec used `collect_submodules('nodes')` to enumerate the dynamically-imported built-in node modules, but `nodes/` and its `filters/`/`sources/`/`sinks/` subdirectories are PEP 420 namespace packages (no `__init__.py`). `pkgutil.iter_modules` — which `collect_submodules` walks internally — skips namespace-package children of namespace packages, so the resulting list contained only the top-level `nodes` name. None of the node bytecode ended up in the PYZ, and `flow_io._instantiate_node`'s runtime `importlib.import_module("nodes.filters.dither")` calls all failed with `ModuleNotFoundError`.

Two changes in `stjornhorn.spec`:
- Walk `src/nodes/` directly to enumerate every module name. Verified locally: 34 node modules now land in `PYZ-00.pyz`.
- Insert `src/` into the spec interpreter's `sys.path` before the remaining `collect_submodules('core'/'ui'/'ocvl')` calls so they also resolve under the project's `src/` layout.

Bumps APP_VERSION to 0.2.3.

Fixes #163