### PR TITLE
Seed user-data dirs and bundle sample inputs into the frozen build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,20 @@ once a first tagged release is cut.
 
 ## [Unreleased]
 
+## [0.2.4] — 2026-04-26
+
+### Fixed
+- **Frozen bundle was missing the `input/`, `output/`, and `logs/`
+  per-user directories on first launch, and the sample input images
+  shipped in the dev tree weren't bundled at all.** File dialogs
+  defaulted to non-existent paths and there was nothing to load. The
+  PyInstaller spec now bundles `input/` and `flow/` as data, and
+  `main._seed_user_data()` runs at startup to (a) `mkdir(exist_ok=True)`
+  every user-data directory and (b) copy the bundled sample images and
+  flows into the user dir on first launch. Idempotent — only seeds
+  files that aren't already present, so anything the user saves
+  persists across launches. Issue: #165
+
 ## [0.2.3] — 2026-04-26
 
 ### Fixed

--- a/doc/welcome.html
+++ b/doc/welcome.html
@@ -180,7 +180,7 @@
   <main class="content-col">
 
     <header class="hero">
-      <h1>Welcome to Stjörnhorn <span class="version">v0.2.3</span></h1>
+      <h1>Welcome to Stjörnhorn <span class="version">v0.2.4</span></h1>
       <div class="tagline">A node-based image- and video-processing playground.</div>
     </header>
 
@@ -213,7 +213,7 @@
     </section>
 
     <section>
-      <h2>What's new in v0.2.3</h2>
+      <h2>What's new in v0.2.4</h2>
       <ul class="tips">
         <li><strong>Every editable property is a socket (Blender-style).</strong> The <code>NodeParam</code> class is gone — each node declares its inputs directly as <code>InputPort</code>s with type, default and metadata. Numeric, boolean, enum and path params have inline widgets right next to their socket dots; wire any value source into any matching port and the streamed value drives that param per frame.</li>
         <li><strong>New numeric nodes: Value Source, Constant Value, Math, Clamp.</strong> Plus Display now renders SCALAR / MATRIX payloads as text, so a numeric pipeline can terminate at a Display without a sink — the inline preview <em>is</em> the result.</li>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "stjornhorn"
-version = "0.2.3"
+version = "0.2.4"
 description = "Stjörnhorn (Image-Inquest) — node-based image and video processing editor"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/constants.py
+++ b/src/constants.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 APP_NAME:         str = "Image-Inquest"
 APP_DISPLAY_NAME: str = "Stjörnhorn"
-APP_VERSION:      str = "0.2.3"
+APP_VERSION:      str = "0.2.4"
 API_URL:    str = "https://beltoforion.de"
 
 # Path resolution -----------------------------------------------------------

--- a/src/main.py
+++ b/src/main.py
@@ -4,6 +4,7 @@ import argparse
 import faulthandler
 import logging
 import os
+import shutil
 import sys
 from pathlib import Path
 
@@ -49,7 +50,9 @@ from constants import (
     APP_USER_MODEL_ID,
     APP_VERSION,
     FLOW_DIR,
+    INPUT_DIR,
     LOG_DIR,
+    OUTPUT_DIR,
     SPLASH_DURATION_MS,
     SPLASH_IMAGE_PATH,
 )
@@ -267,6 +270,54 @@ def _make_splash(screen: QScreen) -> QSplashScreen | None:
     return splash
 
 
+def _seed_user_data() -> None:
+    """Ensure the per-user writable directories exist, and on first launch
+    of a frozen build seed ``input/`` and ``flow/`` from the bundled
+    samples.
+
+    PyInstaller extracts data files under ``sys._MEIPASS`` (read-only),
+    so the user-facing directories live in a separate per-user data root
+    (``~/.local/share/Stjornhorn`` on Linux, ``%LOCALAPPDATA%/Stjornhorn``
+    on Windows). Without this, ``input/`` / ``output/`` / ``logs/`` don't
+    exist on first launch — file dialogs default to a path that isn't
+    there, and there's nothing to load. ``setup_logging`` already creates
+    ``LOG_DIR``; we do the rest here and seed the sample assets so the
+    welcome page's example flows and the file dialog's default input
+    actually work out of the box.
+
+    Idempotent: only copies files that aren't already present in the
+    user dir, so anything the user saves persists across launches.
+    Issue: #165
+    """
+    for d in (INPUT_DIR, OUTPUT_DIR, FLOW_DIR, LOG_DIR):
+        d.mkdir(parents=True, exist_ok=True)
+
+    bundle_root = getattr(sys, "_MEIPASS", None)
+    if not getattr(sys, "frozen", False) or bundle_root is None:
+        return
+
+    seeds = (
+        (Path(bundle_root) / "input", INPUT_DIR, ("*",)),
+        (Path(bundle_root) / "flow",  FLOW_DIR,  ("*.flowjs",)),
+    )
+    for src_dir, dst_dir, patterns in seeds:
+        if not src_dir.is_dir():
+            continue
+        for pattern in patterns:
+            for src in src_dir.glob(pattern):
+                if not src.is_file():
+                    continue
+                dst = dst_dir / src.name
+                if dst.exists():
+                    continue
+                try:
+                    shutil.copy2(src, dst)
+                except OSError:
+                    # Best-effort seeding — don't kill startup over a
+                    # single asset that couldn't be copied.
+                    logger.exception("Failed to seed %s → %s", src, dst)
+
+
 def main(argv: list[str]) -> int:
     parser = argparse.ArgumentParser(description="Image Inquest Application")
     parser.add_argument("--no-splash", action="store_true", help="Skip the startup splash screen")
@@ -279,6 +330,7 @@ def main(argv: list[str]) -> int:
     args, qt_args = parser.parse_known_args(argv)
 
     setup_logging(LOG_DIR)
+    _seed_user_data()
     logger.info("Starting %s v%s", APP_NAME, APP_VERSION)
     # Record the interpreter the app is bound to — handy when triaging
     # bug reports where behaviour depends on the Python version (e.g.

--- a/stjornhorn.spec
+++ b/stjornhorn.spec
@@ -81,6 +81,12 @@ a = Analysis(
         # discover node classes, then importlib imports them. Both halves
         # need to be present in the frozen bundle.
         ('src/nodes',            'src/nodes'),
+        # Sample input images and flow files. Seeded into the user's
+        # writable data dir on first launch (see ``main._seed_user_data``)
+        # so file dialogs land on something useful out of the box.
+        # Issue: #165
+        ('input',                'input'),
+        ('flow',                 'flow'),
     ],
     hiddenimports=hiddenimports,
     hookspath=[],


### PR DESCRIPTION
## Summary

- Bundles `input/` (sample images) and `flow/` (sample flows) into the PyInstaller artifact via `stjornhorn.spec`.
- Adds `main._seed_user_data()`: `mkdir(exist_ok=True)` for `INPUT_DIR` / `OUTPUT_DIR` / `FLOW_DIR` / `LOG_DIR` on every launch, plus a first-launch copy of the bundled samples into the user data dir (`~/.local/share/Stjornhorn/...` on Linux, `%LOCALAPPDATA%/Stjornhorn/...` on Windows). Idempotent — only seeds files not already present, so anything the user saves persists across launches.
- Bumps `APP_VERSION` to 0.2.4 with matching `welcome.html` + `CHANGELOG.md` updates.

Dev mode (`sys.frozen` False) is unaffected — directories are repo-relative as before and the `input/` samples already sit in the working tree.

Fixes #165

## Test plan

- [x] Local PyInstaller rebuild succeeds; `dist/stjornhorn/_internal/input/*` shows all six sample images, `dist/stjornhorn/_internal/flow/*.flowjs` shows all 16 sample flows.
- [x] Bundle size 23 MB → 32 MB (8 MB increase from `video.mp4`, expected).
- [ ] CI release workflow on `v0.2.4` tag produces a Windows zip + Linux AppImage that, on first launch, populate `~/.local/share/Stjornhorn/{input,flow}` with the samples.
- [ ] Second launch keeps the seeded files but doesn't overwrite anything the user has since modified or added.

---
_Generated by [Claude Code](https://claude.ai/code/session_01D8ogsofMmki4gpFv9CzsPL)_