### PR TITLE
Couple param-widget focus and node selection (#170)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,26 @@ once a first tagged release is cut.
 
 ## [Unreleased]
 
+## [0.2.8] — 2026-04-26
+
+### Fixed
+- **Param-widget focus and node selection were decoupled.** Clicking
+  inside a spinbox / line-edit / combo / checkbox on a node body
+  gave the *widget* keyboard focus but did not select the *node* —
+  the Output Inspector kept showing whatever was selected before,
+  and ``FlowScene.keyPressEvent``'s Delete-routing branch (which
+  decides between deleting the selected node and forwarding the key
+  to the focused widget) targeted the wrong thing once focus and
+  selection drifted apart. ``NodeItem`` now installs a focus event
+  filter on every embedded ``ParamWidgetBase`` and its focusable
+  descendants: a ``QEvent.FocusIn`` makes the owning node the *only*
+  selected item (collapsing any prior multi-selection). The inverse
+  also holds — ``NodeItem.itemChange`` watches for
+  ``ItemSelectedHasChanged → False`` and clears keyboard focus from
+  every embedded widget that still has it, so the next keystroke
+  can't edit a control whose owning node is no longer active.
+  Issue: #170
+
 ## [0.2.7] — 2026-04-26
 
 ### Changed

--- a/doc/welcome.html
+++ b/doc/welcome.html
@@ -180,7 +180,7 @@
   <main class="content-col">
 
     <header class="hero">
-      <h1>Welcome to Stjörnhorn <span class="version">v0.2.7</span></h1>
+      <h1>Welcome to Stjörnhorn <span class="version">v0.2.8</span></h1>
       <div class="tagline">A node-based image- and video-processing playground.</div>
     </header>
 
@@ -210,6 +210,13 @@
           <p>Write frames to image files or encode video (MP4V, XVID) with live preview via the Display node.</p>
         </div>
       </div>
+    </section>
+
+    <section>
+      <h2>What's new in v0.2.8</h2>
+      <ul class="tips">
+        <li><strong>Param-widget focus selects its node.</strong> Clicking inside a spinbox / line-edit / combo / checkbox on a node body now selects the owning node (replacing whatever else was selected) — so the Output Inspector and any other selection-driven panel stays in sync with what you're editing. Inverse direction too: when a node is unselected, any of its param widgets that still hold keyboard focus drop it, so the next keystroke can't edit a control whose owning node is no longer "active". Issue #170.</li>
+      </ul>
     </section>
 
     <section>

--- a/src/constants.py
+++ b/src/constants.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 APP_NAME:         str = "Image-Inquest"
 APP_DISPLAY_NAME: str = "Stjörnhorn"
-APP_VERSION:      str = "0.2.7"
+APP_VERSION:      str = "0.2.8"
 API_URL:    str = "https://beltoforion.de"
 
 # Path resolution -----------------------------------------------------------

--- a/src/ui/node_item.py
+++ b/src/ui/node_item.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING
 
-from PySide6.QtCore import QObject, QPointF, QRectF, Qt, QTimer, Signal
+from typing_extensions import override
+
+from PySide6.QtCore import QEvent, QObject, QPointF, QRectF, Qt, QTimer, Signal
 from PySide6.QtGui import (
     QBrush,
     QColor,
@@ -55,6 +57,54 @@ class _NodeSignals(QObject):
 
     #: Emitted when any parameter widget on the owning node changes value.
     param_changed = Signal()
+
+
+class _SelectOnParamFocusFilter(QObject):
+    """Promote the owning ``NodeItem`` to the only selected node when
+    any descendant param widget gains keyboard focus.
+
+    Without this, clicking inside a spinbox / line edit / combo on a
+    node body gives that *widget* keyboard focus but does not select
+    the *node* — the Output Inspector and any other selection-driven
+    panel keeps showing whatever was selected before, and the
+    ``Delete`` key dispatcher in :meth:`FlowScene.keyPressEvent` (which
+    branches on whether the focus item is a proxy widget) ends up
+    targeting the wrong thing. Issue: #170
+
+    Installed by :meth:`NodeItem._wire_param_focus_to_selection` on
+    each ParamWidgetBase wrapper *and* every focusable child inside it
+    (``QSpinBox``, ``QLineEdit``, etc.) — the wrapper is never
+    keyboard-focusable itself, so a filter on it alone would never
+    fire.
+    """
+
+    def __init__(self, owner_node_item: "NodeItem") -> None:
+        # ``NodeItem`` is a ``QGraphicsItem`` (not a ``QObject``) so we
+        # can't parent the filter to it the QObject way. Lifetime is
+        # tied to the editor's ``_stjornhorn_focus_filter`` strong-ref
+        # in :meth:`NodeItem._wire_param_focus_to_selection`.
+        super().__init__()
+        self._owner = owner_node_item
+
+    @override
+    def eventFilter(self, obj: QObject, event: QEvent) -> bool:  # type: ignore[override]
+        if event.type() == QEvent.Type.FocusIn:
+            scene = self._owner.scene()
+            if scene is not None:
+                # Focus is single-target — make the owner the only
+                # selected item, even if it was already part of a
+                # multi-selection. Skip the no-op case (owner is the
+                # *only* selected item already) so we don't fire a
+                # spurious selectionChanged that would re-trigger every
+                # selection-driven panel update.
+                others = [
+                    item for item in scene.selectedItems()
+                    if item is not self._owner
+                ]
+                if others or not self._owner.isSelected():
+                    scene.clearSelection()
+                    self._owner.setSelected(True)
+        return False  # never consume — let Qt do its normal focus work.
 
 
 class _ResizeGripItem(QGraphicsItem):
@@ -557,8 +607,67 @@ class NodeItem(QGraphicsItem):
         # glued to the port dots.
         if change == QGraphicsItem.GraphicsItemChange.ItemScenePositionHasChanged:
             self.refresh_all_links()
-            
+
+        # Selection and keyboard focus must stay in lock-step: when
+        # this node loses selection, drop focus from any of its
+        # embedded param widgets that still hold it. Otherwise the
+        # user's next keystroke would edit a control on a node that
+        # no longer "looks" selected. Issue: #170
+        if change == QGraphicsItem.GraphicsItemChange.ItemSelectedHasChanged:
+            if not bool(value):
+                self._clear_param_widget_focus()
+
         return super().itemChange(change, value)
+
+    def _wire_param_focus_to_selection(self, editor: QWidget) -> None:
+        """Install a focus filter that selects this NodeItem when the
+        embedded *editor* (or any focusable widget inside it) gains
+        keyboard focus.
+
+        Filters every keyboard-focusable descendant rather than the
+        wrapper alone — ParamWidgetBase wrappers are
+        ``WA_TranslucentBackground`` containers whose actual focusable
+        controls are children (``QSpinBox``, ``QLineEdit``,
+        ``QComboBox``, ``QCheckBox``). A filter on the wrapper alone
+        would never see a ``FocusIn`` event. Issue: #170
+        """
+        filt = _SelectOnParamFocusFilter(self)
+        editor.installEventFilter(filt)
+        for child in editor.findChildren(QWidget):
+            child.installEventFilter(filt)
+        # Hold a strong reference on the editor so the filter QObject
+        # outlives the local — without this the filter is GC'd
+        # immediately after this method returns and Qt silently drops
+        # the installation.
+        editor._stjornhorn_focus_filter = filt  # type: ignore[attr-defined]
+
+    def _clear_param_widget_focus(self) -> None:
+        """Drop keyboard focus from every embedded param widget on
+        this node that currently has it.
+
+        Called from :meth:`itemChange` on a selection→unselected
+        transition. Iterates the param-port editors, the constant-
+        param editors and the preview proxy; each may host either a
+        single focusable control or a layout of several
+        (FilePathParamWidget has line-edit + two buttons), so we ask
+        Qt for the actual ``focusWidget()`` inside the wrapper rather
+        than guessing. Issue: #170
+        """
+        proxies: list[QGraphicsProxyWidget] = []
+        proxies.extend(self._param_proxies_by_row.values())
+        proxies.extend(self._constant_proxies_by_row.values())
+        if self._preview_proxy is not None:
+            proxies.append(self._preview_proxy)
+
+        for proxy in proxies:
+            wrapper = proxy.widget()
+            if wrapper is None:
+                continue
+            focused = wrapper.focusWidget()
+            if focused is not None:
+                focused.clearFocus()
+            elif wrapper.hasFocus():
+                wrapper.clearFocus()
 
     # ── Internals ──────────────────────────────────────────────────────────────
 
@@ -754,6 +863,7 @@ class NodeItem(QGraphicsItem):
             editor.setEnabled(port_model.upstream is None)
             proxy = QGraphicsProxyWidget(self)
             proxy.setWidget(editor)
+            self._wire_param_focus_to_selection(editor)
             self._param_widgets_by_row[i] = editor
             self._param_proxies_by_row[i] = proxy
             self._param_widgets.append(editor)
@@ -780,6 +890,7 @@ class NodeItem(QGraphicsItem):
             )
             proxy = QGraphicsProxyWidget(self)
             proxy.setWidget(editor)
+            self._wire_param_focus_to_selection(editor)
             self._constant_widgets_by_row[row] = editor
             self._constant_proxies_by_row[row] = proxy
             self._param_widgets.append(editor)

--- a/tests/test_param_focus_selects_node.py
+++ b/tests/test_param_focus_selects_node.py
@@ -1,0 +1,198 @@
+"""Tests for the focus ↔ selection coupling on a NodeItem (issue #170).
+
+Two contracts are exercised:
+
+* **Focus → selection.** When a param widget on a node body gains
+  keyboard focus, the owning ``NodeItem`` becomes the only selected
+  item — even if focus arrives via code (``QWidget.setFocus``) rather
+  than a physical mouse click, since both go through the same
+  ``QEvent.FocusIn`` path.
+
+* **Deselection → focus drop.** When a node loses selection, every
+  embedded param widget on it that currently holds keyboard focus
+  must drop it, so the next keystroke doesn't edit a control whose
+  owning node is no longer "active".
+
+Headless Qt: ``QT_QPA_PLATFORM=offscreen`` is set before PySide6
+imports, mirroring the rest of the UI test suite.
+"""
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+# Headless Qt: must be set before PySide6 is imported anywhere.
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+pytest.importorskip("PySide6")
+
+from PySide6.QtCore import QEvent, QPointF, Qt
+from PySide6.QtGui import QFocusEvent
+from PySide6.QtWidgets import (
+    QApplication,
+    QGraphicsProxyWidget,
+    QGraphicsView,
+    QWidget,
+)
+
+from core.flow import Flow
+from nodes.filters.overlay import Overlay
+from ui.flow_scene import FlowScene
+from ui.node_item import NodeItem
+
+
+@pytest.fixture(scope="module")
+def qapp() -> QApplication:
+    return QApplication.instance() or QApplication(sys.argv)
+
+
+def _scene_with_two_nodes(qapp: QApplication) -> tuple[FlowScene, NodeItem, NodeItem]:
+    """Two Overlay nodes on a fresh scene — Overlay has several
+    param-style ports (angle / scale / xpos / ypos / alpha) so we
+    have something focusable to drive the tests with."""
+    scene = FlowScene()
+    scene.set_flow(Flow(name="focus_test"))
+    a = scene.add_node(Overlay(), QPointF(0, 0))
+    b = scene.add_node(Overlay(), QPointF(300, 0))
+    return scene, a, b
+
+
+def _first_focusable_inner(node_item: NodeItem) -> QWidget:
+    """Return the first focusable child widget hosted inside any of
+    *node_item*'s param widgets — that's what actually receives
+    keyboard focus when the user clicks a spinbox / line-edit /
+    combo, not the wrapper."""
+    for proxy in node_item._param_proxies_by_row.values():
+        wrapper = proxy.widget()
+        if wrapper is None:
+            continue
+        for child in wrapper.findChildren(QWidget):
+            if child.focusPolicy() != Qt.FocusPolicy.NoFocus:
+                return child
+        return wrapper
+    raise RuntimeError("Overlay node has no param widgets to focus on")
+
+
+def _send_focus_in(widget: QWidget) -> None:
+    """Synthesise the ``QEvent.FocusIn`` a real click would produce.
+
+    ``QWidget.setFocus()`` is a no-op when the widget isn't part of a
+    realised, active window — which is the case for proxy-hosted
+    widgets in an offscreen-platform test that doesn't show a
+    :class:`QGraphicsView`. Sending the event directly tests exactly
+    what the production filter listens for and keeps the test
+    independent of Qt's screen / window-activation plumbing.
+    """
+    event = QFocusEvent(QEvent.Type.FocusIn, Qt.FocusReason.MouseFocusReason)
+    QApplication.sendEvent(widget, event)
+
+
+def _send_focus_out(widget: QWidget) -> None:
+    event = QFocusEvent(QEvent.Type.FocusOut, Qt.FocusReason.MouseFocusReason)
+    QApplication.sendEvent(widget, event)
+
+
+def test_focus_in_param_widget_selects_owner_node(qapp: QApplication) -> None:
+    """A FocusIn on a param widget belonging to node B → B becomes
+    the only selected node, even though A was selected before."""
+    scene, a, b = _scene_with_two_nodes(qapp)
+    a.setSelected(True)
+    assert a.isSelected() and not b.isSelected()
+
+    _send_focus_in(_first_focusable_inner(b))
+    qapp.processEvents()
+
+    assert b.isSelected(), "focusing B's param widget must select B"
+    assert not a.isSelected(), "previous selection must be cleared"
+
+
+def test_focus_in_widget_on_already_selected_node_is_noop(qapp: QApplication) -> None:
+    """Selecting the same node again would be wasteful (it would
+    fire `selectionChanged` and re-trigger every panel update). The
+    filter must short-circuit when the node is already selected."""
+    scene, a, _ = _scene_with_two_nodes(qapp)
+    a.setSelected(True)
+    selection_events: list[None] = []
+    scene.selectionChanged.connect(lambda: selection_events.append(None))
+
+    _send_focus_in(_first_focusable_inner(a))
+    qapp.processEvents()
+
+    assert a.isSelected()
+    assert selection_events == [], (
+        "no selectionChanged should fire when the focused widget is "
+        "already on the selected node"
+    )
+
+
+def test_focus_collapses_multi_selection_to_single_owner(qapp: QApplication) -> None:
+    """When several nodes are selected at once and the user clicks
+    into a widget on one of them, focus is single-target — the
+    selection must collapse to that one node so the panels don't
+    show stale multi-selection state."""
+    scene, a, b = _scene_with_two_nodes(qapp)
+    a.setSelected(True)
+    b.setSelected(True)
+    assert a.isSelected() and b.isSelected()
+
+    _send_focus_in(_first_focusable_inner(b))
+    qapp.processEvents()
+
+    assert b.isSelected()
+    assert not a.isSelected()
+
+
+def test_unselecting_node_clears_param_widget_focus(qapp: QApplication) -> None:
+    """Inverse direction: when the user moves selection to another
+    node (or clicks on the canvas background), any param widget on
+    the previously-selected node that still holds keyboard focus
+    must lose it.
+
+    Uses a real :class:`QGraphicsView` so the embedded widget can
+    hold actual keyboard focus — proxy-hosted widgets in a sceneless
+    scene can't, even with the offscreen Qt platform."""
+    scene, a, b = _scene_with_two_nodes(qapp)
+    view = QGraphicsView(scene)
+    view.show()
+    qapp.processEvents()
+
+    inner = _first_focusable_inner(a)
+    inner.setFocus()
+    qapp.processEvents()
+    assert inner.hasFocus(), "test precondition — widget must hold real focus"
+    a.setSelected(True)
+    qapp.processEvents()
+    assert a.isSelected()
+
+    # Move selection to B by code (the user would click B's body).
+    a.setSelected(False)
+    b.setSelected(True)
+    qapp.processEvents()
+
+    assert not inner.hasFocus(), (
+        "param widget on the now-unselected node must lose focus"
+    )
+    assert b.isSelected() and not a.isSelected()
+
+
+def test_clearing_all_selection_clears_param_widget_focus(qapp: QApplication) -> None:
+    """Clicking on empty canvas clears the whole selection — every
+    param widget that had focus must drop it too."""
+    scene, a, _ = _scene_with_two_nodes(qapp)
+    view = QGraphicsView(scene)
+    view.show()
+    qapp.processEvents()
+
+    inner = _first_focusable_inner(a)
+    inner.setFocus()
+    a.setSelected(True)
+    qapp.processEvents()
+    assert inner.hasFocus() and a.isSelected()
+
+    scene.clearSelection()
+    qapp.processEvents()
+
+    assert not inner.hasFocus()


### PR DESCRIPTION
## Summary

Couples param-widget keyboard focus with node selection so they stay in lock-step. Clicking inside a spinbox / line-edit / combo / checkbox on a node body now selects the owning node (replacing whatever else was selected); deselecting a node drops keyboard focus from any of its param widgets that still hold it.

## Why

Pre-fix, focus and selection drifted apart with two visible consequences:

1. The Output Inspector / preview panels track the editor's selected `NodeItem`. Clicking a param widget gave that widget focus but did **not** promote the node, so panels stayed stale until the user clicked the node body separately.
2. `FlowScene.keyPressEvent` routes the Delete key based on whether the focus item is a `QGraphicsProxyWidget`. With focus on widget A and selection on node B, hitting Delete deletes from the wrong target.

## Implementation

`src/ui/node_item.py`:

- **`_SelectOnParamFocusFilter`** — `QObject` event filter installed on every `ParamWidgetBase` wrapper *and* every focusable descendant (the wrappers themselves are `WA_TranslucentBackground` non-focusable; the actual focusable controls are the `QSpinBox` / `QLineEdit` / etc. children). On `QEvent.FocusIn`, makes the owning `NodeItem` the only selected item — collapsing any prior multi-selection so panels don't show stale state. Skips the no-op case where the owner is already the only selected item to avoid spurious `selectionChanged` re-fires.

- **`NodeItem.itemChange`** extended to watch `ItemSelectedHasChanged → False` and call `_clear_param_widget_focus`, which walks `_param_proxies_by_row`, `_constant_proxies_by_row`, and `_preview_proxy` and calls `clearFocus()` on whichever embedded widget currently has keyboard focus.

- **`_wire_param_focus_to_selection`** is invoked from `_build_ports` for both param-port editors and constant-param editors. Holds a strong reference to the filter via an attribute on the editor so it isn't GC'd after the local goes out of scope.

## Test plan

- [x] `pytest tests/test_param_focus_selects_node.py` — 5 tests:
  - Focus on a param widget on node B selects B (replacing A's selection).
  - Focusing a widget on the already-selected node fires no `selectionChanged`.
  - Focusing collapses a prior multi-selection (A and B both selected → only B).
  - Moving selection from A to B clears keyboard focus from A's param widgets.
  - Clearing all selection drops focus from every param widget.
- [x] Full UI suite still green (246 passed).
- [ ] Manual: open `flow/test_numeric.flowjs`, click into Math's `expression` line-edit on the Math node — Math becomes the selected node, Output Inspector switches to Math. Then click on the `ValueSource` body — keyboard focus drops from the Math line-edit.
- [ ] Manual: with two nodes selected (Ctrl-click), click into a spinbox on one of them — selection collapses to that one node.

Fixes #170

https://claude.ai/code/session_01Jk8ZRK8uZsYMMUaFcjfHiH

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jk8ZRK8uZsYMMUaFcjfHiH)_