### PR TITLE
Deduplicate relative-path normalisation across file-IO nodes (#174)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,22 @@ once a first tagged release is cut.
 
 ## [Unreleased]
 
+## [0.2.10] — 2026-04-26
+
+### Changed
+- **Relative-path normalisation deduplicated.** Six file-IO nodes
+  (``ImageSource``, ``VideoSource``, ``DirectorySource``,
+  ``FileSink``, ``VideoSink``, ``Ncc``) used to carry their own
+  copy of the same five-line "store relative when inside the
+  well-known base dir, otherwise keep absolute" snippet plus a
+  paired three-line resolver. Both halves now live in
+  ``core/path_utils.py`` as ``store_relative_to(value, base_dir)``
+  + ``resolve_against(path, base_dir)``; every setter and
+  ``_resolved_path`` call through it. Behaviour is unchanged
+  (covered by the existing path-normalisation and node-IO test
+  suites plus a new dedicated ``tests/test_path_utils.py``).
+  Issue: #174
+
 ## [0.2.9] — 2026-04-26
 
 ### Added

--- a/doc/welcome.html
+++ b/doc/welcome.html
@@ -180,7 +180,7 @@
   <main class="content-col">
 
     <header class="hero">
-      <h1>Welcome to Stjörnhorn <span class="version">v0.2.9</span></h1>
+      <h1>Welcome to Stjörnhorn <span class="version">v0.2.10</span></h1>
       <div class="tagline">A node-based image- and video-processing playground.</div>
     </header>
 
@@ -210,6 +210,13 @@
           <p>Write frames to image files or encode video (MP4V, XVID) with live preview via the Display node.</p>
         </div>
       </div>
+    </section>
+
+    <section>
+      <h2>What's new in v0.2.10</h2>
+      <ul class="tips">
+        <li><strong>Internal cleanup: relative-path normalisation deduplicated.</strong> Six file-IO nodes (<em>ImageSource</em>, <em>VideoSource</em>, <em>DirectorySource</em>, <em>FileSink</em>, <em>VideoSink</em>, <em>Ncc</em>) used to carry their own copy of the same "store relative when inside <code>INPUT_DIR</code>/<code>OUTPUT_DIR</code>, otherwise keep absolute" snippet plus a paired resolver. Now centralised in <code>core/path_utils.py</code> as <code>store_relative_to(value, base_dir)</code> + <code>resolve_against(path, base_dir)</code>; every setter and resolver call through it. No behaviour change. Issue #174.</li>
+      </ul>
     </section>
 
     <section>

--- a/src/constants.py
+++ b/src/constants.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 APP_NAME:         str = "Image-Inquest"
 APP_DISPLAY_NAME: str = "Stjörnhorn"
-APP_VERSION:      str = "0.2.9"
+APP_VERSION:      str = "0.2.10"
 API_URL:    str = "https://beltoforion.de"
 
 # Path resolution -----------------------------------------------------------

--- a/src/core/path_utils.py
+++ b/src/core/path_utils.py
@@ -1,0 +1,53 @@
+"""Helpers for the relative-path normalisation that file-IO nodes share.
+
+Five nodes (``ImageSource`` / ``VideoSource`` / ``DirectorySource`` /
+``FileSink`` / ``VideoSink``) all want the same trick: when the user
+picks a path inside a "well-known" base directory (``INPUT_DIR`` for
+sources, ``OUTPUT_DIR`` for sinks), persist it relative to that base
+so saved flows stay portable across machines that share the same
+input / output layout — but keep paths outside the base absolute, so
+arbitrary user files still round-trip. This module is the single
+source of truth for that policy; each node passes its own base dir.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def store_relative_to(value: str | Path, base_dir: Path) -> Path:
+    """Return *value* as a :class:`Path`, rewriting it as a path
+    relative to ``base_dir`` whenever it lives inside that directory.
+
+    Behaviour:
+      * Absolute paths inside ``base_dir`` → relative to ``base_dir``.
+      * Absolute paths outside ``base_dir`` → kept absolute.
+      * Already-relative paths → returned unchanged (no
+        ``base_dir`` poke; the path may legitimately reach outside
+        the dev tree via ``../foo`` and we don't want to anchor it).
+
+    The relative-isation goes through :meth:`Path.resolve` so symlinks
+    and ``..`` segments are normalised before the comparison; ``OSError``
+    (a missing intermediate directory) and ``ValueError`` (the resolved
+    target is genuinely outside ``base_dir``) are both treated as
+    "keep the absolute form" rather than failures, since the path may
+    still be perfectly valid for the node to read / write later.
+    """
+    p = Path(value)
+    if not p.is_absolute():
+        return p
+    try:
+        return p.resolve().relative_to(base_dir.resolve())
+    except (OSError, ValueError):
+        return p
+
+
+def resolve_against(path: Path, base_dir: Path) -> Path:
+    """Return an absolute :class:`Path` for *path*.
+
+    Joins ``base_dir`` for relative inputs (so a flow stored with
+    ``"video.mp4"`` resolves to ``INPUT_DIR / "video.mp4"`` at run
+    time); passes absolute inputs through unchanged.
+    """
+    if path.is_absolute():
+        return path
+    return base_dir / path

--- a/src/nodes/filters/ncc.py
+++ b/src/nodes/filters/ncc.py
@@ -9,6 +9,7 @@ from typing_extensions import override
 from constants import INPUT_DIR
 from core.io_data import IoData, IoDataType
 from core.node_base import NodeBase, NodeParamType
+from core.path_utils import resolve_against, store_relative_to
 from core.port import InputPort, OutputPort
 
 _SUPPORTED_EXTS = {".jpg", ".jpeg", ".png", ".webp", ".bmp", ".tif", ".tiff"}
@@ -73,13 +74,7 @@ class Ncc(NodeBase):
 
     @template.setter
     def template(self, path: str | Path) -> None:
-        p = Path(path)
-        if p.is_absolute():
-            try:
-                p = p.resolve().relative_to(INPUT_DIR.resolve())
-            except (OSError, ValueError):
-                pass  # outside INPUT_DIR — keep absolute
-        self._template_path = p
+        self._template_path = store_relative_to(path, INPUT_DIR)
 
     # ── NodeBase interface ─────────────────────────────────────────────────────
 
@@ -125,9 +120,7 @@ class Ncc(NodeBase):
     # ── Internals ──────────────────────────────────────────────────────────────
 
     def _resolved_template_path(self) -> Path:
-        if self._template_path.is_absolute():
-            return self._template_path
-        return INPUT_DIR / self._template_path
+        return resolve_against(self._template_path, INPUT_DIR)
 
     def _load_template(self) -> np.ndarray:
         resolved = self._resolved_template_path()

--- a/src/nodes/sinks/file_sink.py
+++ b/src/nodes/sinks/file_sink.py
@@ -9,6 +9,7 @@ from typing_extensions import override
 from constants import OUTPUT_DIR
 from core.io_data import IMAGE_TYPES
 from core.node_base import NodeParam, NodeParamType, SinkNodeBase
+from core.path_utils import resolve_against, store_relative_to
 from core.port import InputPort
 
 
@@ -60,13 +61,7 @@ class FileSink(SinkNodeBase):
 
     @output_path.setter
     def output_path(self, output_path: str | Path) -> None:
-        p = Path(output_path)
-        if p.is_absolute():
-            try:
-                p = p.resolve().relative_to(OUTPUT_DIR.resolve())
-            except (OSError, ValueError):
-                pass  # outside OUTPUT_DIR — keep absolute
-        self._output_path = p
+        self._output_path = store_relative_to(output_path, OUTPUT_DIR)
 
     # ── SinkNodeBase interface ──────────────────────────────────────────────────
 
@@ -87,6 +82,4 @@ class FileSink(SinkNodeBase):
 
     def _resolved_path(self) -> Path:
         """Return an absolute path; relative values are joined with OUTPUT_DIR."""
-        if self._output_path.is_absolute():
-            return self._output_path
-        return OUTPUT_DIR / self._output_path
+        return resolve_against(self._output_path, OUTPUT_DIR)

--- a/src/nodes/sinks/video_sink.py
+++ b/src/nodes/sinks/video_sink.py
@@ -10,6 +10,7 @@ from typing_extensions import override
 from constants import OUTPUT_DIR
 from core.io_data import IMAGE_TYPES
 from core.node_base import NodeParam, NodeParamType, SinkNodeBase
+from core.path_utils import resolve_against, store_relative_to
 from core.port import InputPort
 
 
@@ -85,13 +86,7 @@ class VideoSink(SinkNodeBase):
 
     @output_path.setter
     def output_path(self, output_path: str | Path) -> None:
-        p = Path(output_path)
-        if p.is_absolute():
-            try:
-                p = p.resolve().relative_to(OUTPUT_DIR.resolve())
-            except (OSError, ValueError):
-                pass  # outside OUTPUT_DIR — keep absolute
-        self._output_path = p
+        self._output_path = store_relative_to(output_path, OUTPUT_DIR)
 
     @property
     def fps(self) -> float:
@@ -163,9 +158,7 @@ class VideoSink(SinkNodeBase):
     # ── Internals ──────────────────────────────────────────────────────────────
 
     def _resolved_path(self) -> Path:
-        if self._output_path.is_absolute():
-            return self._output_path
-        return OUTPUT_DIR / self._output_path
+        return resolve_against(self._output_path, OUTPUT_DIR)
 
     def _open_writer(self, frame: np.ndarray) -> None:
         h, w = frame.shape[:2]

--- a/src/nodes/sources/directory_source.py
+++ b/src/nodes/sources/directory_source.py
@@ -12,6 +12,7 @@ from typing_extensions import override
 from constants import INPUT_DIR
 from core.io_data import IoData, IoDataType
 from core.node_base import NodeParam, NodeParamType, SourceNodeBase
+from core.path_utils import resolve_against, store_relative_to
 from core.port import OutputPort
 
 
@@ -79,13 +80,7 @@ class DirectorySource(SourceNodeBase):
 
     @directory.setter
     def directory(self, path: str | Path) -> None:
-        p = Path(path)
-        if p.is_absolute():
-            try:
-                p = p.resolve().relative_to(INPUT_DIR.resolve())
-            except (OSError, ValueError):
-                pass  # outside INPUT_DIR — keep absolute
-        self._directory = p
+        self._directory = store_relative_to(path, INPUT_DIR)
 
     @property
     def include_subdirectories(self) -> bool:
@@ -123,9 +118,7 @@ class DirectorySource(SourceNodeBase):
 
     def _resolved_path(self) -> Path:
         """Return an absolute path; relative values are joined with INPUT_DIR."""
-        if self._directory.is_absolute():
-            return self._directory
-        return INPUT_DIR / self._directory
+        return resolve_against(self._directory, INPUT_DIR)
 
     def _iter_image_files(self, root: Path) -> list[Path]:
         """Return supported image files under *root* in lexicographic order.

--- a/src/nodes/sources/image_source.py
+++ b/src/nodes/sources/image_source.py
@@ -10,6 +10,7 @@ from typing_extensions import override
 from constants import INPUT_DIR
 from core.io_data import IoData, IoDataType
 from core.node_base import NodeParam, NodeParamType, SourceNodeBase
+from core.path_utils import resolve_against, store_relative_to
 from core.port import OutputPort
 
 _SUPPORTED_EXTS = {".jpg", ".jpeg", ".png", ".webp", ".cr2"}
@@ -55,13 +56,7 @@ class ImageSource(SourceNodeBase):
 
     @file_path.setter
     def file_path(self, path: str | Path) -> None:
-        p = Path(path)
-        if p.is_absolute():
-            try:
-                p = p.resolve().relative_to(INPUT_DIR.resolve())
-            except (OSError, ValueError):
-                pass  # outside INPUT_DIR — keep absolute
-        self._file_path = p
+        self._file_path = store_relative_to(path, INPUT_DIR)
 
     # ── SourceNodeBase interface ────────────────────────────────────────────────
 
@@ -105,6 +100,4 @@ class ImageSource(SourceNodeBase):
 
     def _resolved_path(self) -> Path:
         """Return an absolute path; relative values are joined with INPUT_DIR."""
-        if self._file_path.is_absolute():
-            return self._file_path
-        return INPUT_DIR / self._file_path
+        return resolve_against(self._file_path, INPUT_DIR)

--- a/src/nodes/sources/video_source.py
+++ b/src/nodes/sources/video_source.py
@@ -9,6 +9,7 @@ from typing_extensions import override
 from constants import INPUT_DIR
 from core.io_data import IoData, IoDataType
 from core.node_base import NodeParam, NodeParamType, SourceNodeBase
+from core.path_utils import resolve_against, store_relative_to
 from core.port import OutputPort
 
 _SUPPORTED_EXTS = {".mp4", ".avi", ".mov", ".mkv"}
@@ -61,13 +62,7 @@ class VideoSource(SourceNodeBase):
 
     @file_path.setter
     def file_path(self, path: str | Path) -> None:
-        p = Path(path)
-        if p.is_absolute():
-            try:
-                p = p.resolve().relative_to(INPUT_DIR.resolve())
-            except (OSError, ValueError):
-                pass  # outside INPUT_DIR — keep absolute
-        self._file_path = p
+        self._file_path = store_relative_to(path, INPUT_DIR)
 
     @property
     def max_num_frames(self) -> int:
@@ -123,6 +118,4 @@ class VideoSource(SourceNodeBase):
 
     def _resolved_path(self) -> Path:
         """Return an absolute path; relative values are joined with INPUT_DIR."""
-        if self._file_path.is_absolute():
-            return self._file_path
-        return INPUT_DIR / self._file_path
+        return resolve_against(self._file_path, INPUT_DIR)

--- a/tests/test_path_utils.py
+++ b/tests/test_path_utils.py
@@ -1,0 +1,104 @@
+"""Unit tests for the relative-path helpers used by file-IO nodes."""
+from __future__ import annotations
+
+from pathlib import Path
+
+from core.path_utils import resolve_against, store_relative_to
+
+
+# ── store_relative_to ────────────────────────────────────────────────────────
+
+
+def test_absolute_inside_base_is_made_relative(tmp_path: Path) -> None:
+    """An absolute path inside ``base_dir`` round-trips as a relative
+    path so saved flows stay portable across machines that share the
+    same input/output layout."""
+    target = tmp_path / "ship.jpg"
+    target.write_bytes(b"")  # resolve() needs the path to exist for symlinks
+    out = store_relative_to(target, tmp_path)
+    assert out == Path("ship.jpg")
+    assert not out.is_absolute()
+
+
+def test_absolute_inside_subdirectory_keeps_subdirectory(tmp_path: Path) -> None:
+    sub = tmp_path / "subset"
+    sub.mkdir()
+    target = sub / "frame.png"
+    target.write_bytes(b"")
+    out = store_relative_to(target, tmp_path)
+    assert out == Path("subset") / "frame.png"
+
+
+def test_absolute_outside_base_is_kept_absolute(tmp_path: Path) -> None:
+    """A path that doesn't live under ``base_dir`` must round-trip
+    unchanged — flattening it would silently relocate the user's
+    file at run time."""
+    other_root = tmp_path / "elsewhere"
+    other_root.mkdir()
+    target = other_root / "video.mp4"
+    target.write_bytes(b"")
+    base_dir = tmp_path / "input"
+    base_dir.mkdir()
+    out = store_relative_to(target, base_dir)
+    assert out.is_absolute()
+    assert out == target.resolve()
+
+
+def test_relative_input_returned_unchanged() -> None:
+    """Already-relative input is passed through verbatim — even when
+    it contains traversal (``../foo``) or refers to a missing file.
+    The helper's job is to normalise the *absolute* case; relative
+    input is the user's explicit choice and we don't anchor it."""
+    p = Path("../sibling/frame.png")
+    out = store_relative_to(p, Path("/some/base"))
+    assert out == p
+
+
+def test_missing_base_dir_keeps_absolute(tmp_path: Path) -> None:
+    """If ``base_dir`` itself doesn't exist on disk, ``resolve()`` on
+    a path inside it can fail — we treat that as 'keep absolute'
+    rather than raising, since the path may still be valid for the
+    caller to use later (e.g. INPUT_DIR is created lazily)."""
+    target = tmp_path / "ghost.jpg"
+    target.write_bytes(b"")
+    nonexistent_base = tmp_path / "does_not_exist"
+    out = store_relative_to(target, nonexistent_base)
+    # Either kept absolute (the ValueError branch) or rewritten — we
+    # accept both as long as no exception leaks out.
+    assert isinstance(out, Path)
+
+
+def test_string_input_is_coerced_to_path() -> None:
+    """The setters that wrap this helper accept ``str | Path`` —
+    the helper handles both."""
+    out = store_relative_to("relative/dir", Path("/some/base"))
+    assert out == Path("relative/dir")
+
+
+# ── resolve_against ──────────────────────────────────────────────────────────
+
+
+def test_resolve_relative_joins_base() -> None:
+    out = resolve_against(Path("frame.png"), Path("/input"))
+    assert out == Path("/input/frame.png")
+    assert out.is_absolute()
+
+
+def test_resolve_absolute_passes_through() -> None:
+    """An already-absolute path must not be re-anchored against
+    ``base_dir`` — the user explicitly picked a location outside
+    the well-known root."""
+    abs_path = Path("/elsewhere/video.mp4")
+    out = resolve_against(abs_path, Path("/input"))
+    assert out == abs_path
+
+
+def test_round_trip_inside_base(tmp_path: Path) -> None:
+    """``store_relative_to`` followed by ``resolve_against`` returns
+    a path that points at the same file, even when the original was
+    absolute and the intermediate stored form was relative."""
+    target = tmp_path / "frame.png"
+    target.write_bytes(b"")
+    stored = store_relative_to(target, tmp_path)
+    resolved = resolve_against(stored, tmp_path)
+    assert resolved.resolve() == target.resolve()


### PR DESCRIPTION
## Summary

Hoists the "store relative when the path is inside a well-known base dir, else keep absolute" snippet (and its paired resolver) out of every file-IO node and into a single shared module.

## Before / after

Every setter / resolver pair across **six** nodes used to look like this (six copies, two snippets each):

```python
@file_path.setter
def file_path(self, path: str | Path) -> None:
    p = Path(path)
    if p.is_absolute():
        try:
            p = p.resolve().relative_to(INPUT_DIR.resolve())
        except (OSError, ValueError):
            pass  # outside INPUT_DIR — keep absolute
    self._file_path = p

def _resolved_path(self) -> Path:
    if self._file_path.is_absolute():
        return self._file_path
    return INPUT_DIR / self._file_path
```

After this PR:

```python
from core.path_utils import resolve_against, store_relative_to

@file_path.setter
def file_path(self, path: str | Path) -> None:
    self._file_path = store_relative_to(path, INPUT_DIR)

def _resolved_path(self) -> Path:
    return resolve_against(self._file_path, INPUT_DIR)
```

## Sites converted

| Node | Base dir |
|---|---|
| `ImageSource.file_path` | `INPUT_DIR` |
| `VideoSource.file_path` | `INPUT_DIR` |
| `DirectorySource.directory` | `INPUT_DIR` |
| `FileSink.output_path` | `OUTPUT_DIR` |
| `VideoSink.output_path` | `OUTPUT_DIR` |
| `Ncc.template` | `INPUT_DIR` (the issue listed 5; this 6th turned up in the pass) |

## New module

`src/core/path_utils.py`:

- `store_relative_to(value: str | Path, base_dir: Path) -> Path` — absolute inside `base_dir` → relative; absolute outside → kept absolute; relative input → returned unchanged. `OSError` and `ValueError` from `resolve()` are both treated as "keep absolute" rather than failures.
- `resolve_against(path: Path, base_dir: Path) -> Path` — joins `base_dir` for relative input; passes absolute through.

## Test plan

- [x] New `tests/test_path_utils.py` (9 cases): absolute inside base, absolute inside subdir, absolute outside base, already-relative input, missing base dir, string-input coercion, both halves of `resolve_against`, and a round-trip test.
- [x] Existing per-node IO tests still pass — no behaviour change.
- [x] Full repo: 270 passed.
- [ ] Manual: open a flow that uses each of the six nodes, save it, inspect the on-disk JSON — paths inside the matching base dir round-trip as relative; paths outside stay absolute.

Fixes #174

https://claude.ai/code/session_01Jk8ZRK8uZsYMMUaFcjfHiH

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jk8ZRK8uZsYMMUaFcjfHiH)_