### PR TITLE
fix: ImageSource default ship.jpg; add input-default regression test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ once a first tagged release is cut.
 
 ## [Unreleased]
 
+## [0.2.11] — 2026-04-26
+
+### Fixed
+- **ImageSource default file fixed.** The `file_path` default was
+  `"example.jpg"`, which was never bundled under `input/` — dropping a
+  fresh `ImageSource` node and pressing Run raised a `FileNotFoundError`
+  immediately. Default is now `"ship.jpg"`, which ships with the
+  application. A new regression test (`tests/test_default_inputs_exist.py`)
+  asserts that every read-side source node's file-path default resolves to
+  an existing file under `INPUT_DIR`. Issue: #173
+
 ## [0.2.10] — 2026-04-26
 
 ### Changed

--- a/doc/welcome.html
+++ b/doc/welcome.html
@@ -180,7 +180,7 @@
   <main class="content-col">
 
     <header class="hero">
-      <h1>Welcome to Stjörnhorn <span class="version">v0.2.10</span></h1>
+      <h1>Welcome to Stjörnhorn <span class="version">v0.2.11</span></h1>
       <div class="tagline">A node-based image- and video-processing playground.</div>
     </header>
 
@@ -210,6 +210,13 @@
           <p>Write frames to image files or encode video (MP4V, XVID) with live preview via the Display node.</p>
         </div>
       </div>
+    </section>
+
+    <section>
+      <h2>What's new in v0.2.11</h2>
+      <ul class="tips">
+        <li><strong>ImageSource default fixed.</strong> The default <code>file_path</code> for <em>ImageSource</em> was <code>example.jpg</code>, which was never bundled — dropping a fresh node and pressing Run raised a <code>FileNotFoundError</code>. Changed to <code>ship.jpg</code>, which ships under <code>input/</code>. Issue #173.</li>
+      </ul>
     </section>
 
     <section>

--- a/src/constants.py
+++ b/src/constants.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 APP_NAME:         str = "Image-Inquest"
 APP_DISPLAY_NAME: str = "Stjörnhorn"
-APP_VERSION:      str = "0.2.10"
+APP_VERSION:      str = "0.2.11"
 API_URL:    str = "https://beltoforion.de"
 
 # Path resolution -----------------------------------------------------------

--- a/src/nodes/sources/image_source.py
+++ b/src/nodes/sources/image_source.py
@@ -41,7 +41,7 @@ class ImageSource(SourceNodeBase):
         self._add_param(NodeParam(
             "file_path",
             NodeParamType.FILE_PATH,
-            default="example.jpg",
+            default="ship.jpg",
             metadata={
                 "filter": "Images (*.webp *.png *.jpg *.jpeg *.cr2)",
                 "base_dir": INPUT_DIR,

--- a/tests/test_default_inputs_exist.py
+++ b/tests/test_default_inputs_exist.py
@@ -1,0 +1,27 @@
+"""Regression test: every read-side source node's file-path default must
+resolve to a file that actually ships under INPUT_DIR.
+
+Fixes Issue #173 — ImageSource used "example.jpg" which was never bundled.
+"""
+from __future__ import annotations
+
+import pytest
+
+from constants import INPUT_DIR
+from core.path_utils import resolve_against
+from nodes.sources.image_source import ImageSource
+from nodes.sources.video_source import VideoSource
+
+
+@pytest.mark.parametrize("node_cls,attr", [
+    (ImageSource, "file_path"),
+    (VideoSource, "file_path"),
+])
+def test_source_default_resolves(node_cls: type, attr: str) -> None:
+    node = node_cls()
+    default = getattr(node, attr)
+    resolved = resolve_against(default, INPUT_DIR)
+    assert resolved.exists(), (
+        f"{node_cls.__name__}.{attr} default {str(default)!r} does not exist "
+        f"under INPUT_DIR ({INPUT_DIR})"
+    )


### PR DESCRIPTION
Fix #173: `ImageSource.file_path` default was `"example.jpg"` which was never bundled under `input/` — a fresh node failed immediately on Run with FileNotFoundError. Changed to `ship.jpg` which ships with the app.

Adds `tests/test_default_inputs_exist.py`: parametrised test that instantiates every read-side source node and asserts its file-path default resolves to an existing file under `INPUT_DIR`.

Fixes #173

Generated with [Claude Code](https://claude.ai/code)