### PR TITLE
Add Apply Colormap filter for greyscale image visualization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,20 @@ once a first tagged release is cut.
 
 ## [Unreleased]
 
+## [0.2.16] — 2026-04-27
+
+### Added
+- **Apply Colormap filter.** New ``ApplyColormap`` node under
+  *Color Spaces* that colorizes a single-channel ``IMAGE_GREY`` input
+  through one of eleven OpenCV palettes — VIRIDIS (default), PLASMA,
+  MAGMA, INFERNO, JET, TURBO, HOT, BONE, PARULA, OCEAN, COOL —
+  emitting a 3-channel BGR ``IMAGE``. Designed as the display-side
+  companion to producers of greyscale fields (FFT magnitude, depth
+  maps, channel splits) so visualization stays out of the producer
+  node. JET is the historically common spectrogram / FFT-magnitude
+  palette in MATLAB, Audacity and similar tools; TURBO is the modern
+  perceptually-improved drop-in.
+
 ## [0.2.15] — 2026-04-26
 
 ### Added

--- a/doc/welcome.html
+++ b/doc/welcome.html
@@ -180,7 +180,7 @@
   <main class="content-col">
 
     <header class="hero">
-      <h1>Welcome to Stjörnhorn <span class="version">v0.2.15</span></h1>
+      <h1>Welcome to Stjörnhorn <span class="version">v0.2.16</span></h1>
       <div class="tagline">A node-based image- and video-processing playground.</div>
     </header>
 
@@ -210,6 +210,13 @@
           <p>Write frames to image files or encode video (MP4V, XVID) with live preview via the Display node.</p>
         </div>
       </div>
+    </section>
+
+    <section>
+      <h2>What's new in v0.2.16</h2>
+      <ul class="tips">
+        <li><strong>Apply Colormap filter.</strong> A new node under <em>Color Spaces</em> that colorizes a greyscale image through one of eleven palettes — VIRIDIS / PLASMA / MAGMA / INFERNO (matplotlib's perceptually uniform family), JET and TURBO (the classic and modern FFT / spectrogram defaults), plus HOT, BONE, PARULA, OCEAN, COOL. Drop it after an <em>FFT 2D</em> node's <code>magnitude</code> output to view spectra in colour, or after any single-channel split to colour-code intensity fields.</li>
+      </ul>
     </section>
 
     <section>

--- a/flow/video_fft.flowjs
+++ b/flow/video_fft.flowjs
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "app_version": "0.2.15",
+  "app_version": "0.2.16",
   "name": "video_fft",
   "nodes": [
     {
@@ -21,8 +21,8 @@
       "module": "nodes.filters.fft2d",
       "class": "Fft2D",
       "position": [
-        -1584.0274858837504,
-        -878.4118597926628
+        -1585.4291259697588,
+        -879.813499878671
       ],
       "port_defaults": {}
     },
@@ -31,8 +31,8 @@
       "module": "nodes.filters.display",
       "class": "Display",
       "position": [
-        -2133.6710036198383,
-        -210.0785946694702
+        -1805.6872234939024,
+        -302.5868403460163
       ],
       "port_defaults": {},
       "size": [
@@ -75,8 +75,8 @@
       "module": "nodes.filters.merge",
       "class": "Merge",
       "position": [
-        -1264.7553621308723,
-        -757.883126876122
+        -1001.2470259613169,
+        -745.2683661020476
       ],
       "port_defaults": {}
     },
@@ -85,8 +85,8 @@
       "module": "nodes.filters.display",
       "class": "Display",
       "position": [
-        -1389.5490568311006,
-        -472.76090425726494
+        -1093.802998683355,
+        -534.433068041629
       ],
       "port_defaults": {},
       "size": [
@@ -113,6 +113,42 @@
         -458.41185979266277
       ],
       "port_defaults": {}
+    },
+    {
+      "id": 10,
+      "module": "nodes.filters.apply_colormap",
+      "class": "ApplyColormap",
+      "position": [
+        -1327.353161449836,
+        -843.7873317769812
+      ],
+      "port_defaults": {
+        "colormap": 13
+      }
+    },
+    {
+      "id": 11,
+      "module": "nodes.filters.apply_colormap",
+      "class": "ApplyColormap",
+      "position": [
+        -1327.353161449836,
+        -703.7873317769812
+      ],
+      "port_defaults": {
+        "colormap": 13
+      }
+    },
+    {
+      "id": 12,
+      "module": "nodes.filters.apply_colormap",
+      "class": "ApplyColormap",
+      "position": [
+        -1327.353161449836,
+        -563.7873317769812
+      ],
+      "port_defaults": {
+        "colormap": 13
+      }
     }
   ],
   "connections": [
@@ -147,24 +183,6 @@
       "dst_input": 0
     },
     {
-      "src_node": 4,
-      "src_output": 1,
-      "dst_node": 6,
-      "dst_input": 2
-    },
-    {
-      "src_node": 5,
-      "src_output": 1,
-      "dst_node": 6,
-      "dst_input": 3
-    },
-    {
-      "src_node": 1,
-      "src_output": 1,
-      "dst_node": 6,
-      "dst_input": 1
-    },
-    {
       "src_node": 6,
       "src_output": 0,
       "dst_node": 7,
@@ -187,6 +205,42 @@
       "src_output": 1,
       "dst_node": 6,
       "dst_input": 0
+    },
+    {
+      "src_node": 1,
+      "src_output": 1,
+      "dst_node": 10,
+      "dst_input": 0
+    },
+    {
+      "src_node": 4,
+      "src_output": 1,
+      "dst_node": 11,
+      "dst_input": 0
+    },
+    {
+      "src_node": 5,
+      "src_output": 1,
+      "dst_node": 12,
+      "dst_input": 0
+    },
+    {
+      "src_node": 10,
+      "src_output": 0,
+      "dst_node": 6,
+      "dst_input": 1
+    },
+    {
+      "src_node": 11,
+      "src_output": 0,
+      "dst_node": 6,
+      "dst_input": 2
+    },
+    {
+      "src_node": 12,
+      "src_output": 0,
+      "dst_node": 6,
+      "dst_input": 3
     }
   ],
   "backdrops": [
@@ -221,6 +275,23 @@
         70,
         60,
         40,
+        140
+      ]
+    },
+    {
+      "position": [
+        -1353.353161449836,
+        -891.7873317769812
+      ],
+      "size": [
+        221.984375,
+        474.0
+      ],
+      "title": "Color",
+      "color": [
+        70,
+        45,
+        70,
         140
       ]
     }

--- a/src/constants.py
+++ b/src/constants.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 APP_NAME:         str = "Image-Inquest"
 APP_DISPLAY_NAME: str = "Stjörnhorn"
-APP_VERSION:      str = "0.2.15"
+APP_VERSION:      str = "0.2.16"
 API_URL:    str = "https://beltoforion.de"
 
 # Path resolution -----------------------------------------------------------

--- a/src/nodes/filters/apply_colormap.py
+++ b/src/nodes/filters/apply_colormap.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+from enum import IntEnum
+
+import cv2
+import numpy as np
+from typing_extensions import override
+
+from core.io_data import IoData, IoDataType
+from core.node_base import NodeBase, NodeParamType
+from core.port import InputPort, OutputPort
+
+
+class Colormap(IntEnum):
+    """Colormap selection for :class:`ApplyColormap`.
+
+    Values mirror OpenCV's ``cv2.COLORMAP_*`` flags so the enum member
+    can be passed straight into :func:`cv2.applyColorMap`. Backed by
+    :class:`IntEnum` so the integer representation (persisted in saved
+    flows) round-trips cleanly: JSON stores the int, the setter accepts
+    both ints and enum members, and the ``ENUM`` param widget renders a
+    combo box of ``name``-based labels.
+
+    The selection covers the perceptually-uniform family popularised by
+    matplotlib (VIRIDIS / PLASMA / MAGMA / INFERNO), the
+    historically-common FFT / spectrogram palettes (JET, the MATLAB
+    default for ``imagesc(abs(fft2(x)))`` and Audacity-style spectrum
+    views; TURBO, Google's perceptually improved JET drop-in), plus a
+    handful of classics (HOT, BONE, PARULA, OCEAN, COOL).
+    """
+    VIRIDIS = cv2.COLORMAP_VIRIDIS
+    PLASMA  = cv2.COLORMAP_PLASMA
+    MAGMA   = cv2.COLORMAP_MAGMA
+    INFERNO = cv2.COLORMAP_INFERNO
+    JET     = cv2.COLORMAP_JET
+    TURBO   = cv2.COLORMAP_TURBO
+    HOT     = cv2.COLORMAP_HOT
+    BONE    = cv2.COLORMAP_BONE
+    PARULA  = cv2.COLORMAP_PARULA
+    OCEAN   = cv2.COLORMAP_OCEAN
+    COOL    = cv2.COLORMAP_COOL
+
+
+class ApplyColormap(NodeBase):
+    """Colorize a greyscale image with a chosen colormap.
+
+    Wraps :func:`cv2.applyColorMap`: maps each input intensity through
+    the selected lookup table and emits a 3-channel BGR image. Designed
+    as the display-side companion to nodes that produce single-channel
+    fields — e.g. the magnitude output of :class:`Fft2D`, depth maps,
+    individual channel splits — so the visualization concern stays out
+    of the producer node.
+
+    The node assumes the input has already been tonemapped to a
+    sensible 0..255 range. For high-dynamic-range sources like raw FFT
+    magnitudes, apply log compression upstream (``Fft2D`` does this)
+    rather than expecting the colormap step to handle it — combining
+    log-compressed data with a log-norm palette would compress twice
+    and crush the high end into a tiny color band.
+    """
+
+    def __init__(self) -> None:
+        super().__init__("Apply Colormap", section="Color Spaces")
+        self._colormap: Colormap = Colormap.VIRIDIS
+
+        self._add_input(InputPort("image", {IoDataType.IMAGE_GREY}))
+        self._add_input(InputPort(
+            "colormap",
+            {IoDataType.ENUM},
+            optional=True,
+            default_value=Colormap.VIRIDIS,
+            metadata={
+                "default": Colormap.VIRIDIS,
+                "enum": Colormap,
+                "param_type": NodeParamType.ENUM,
+            },
+        ))
+        self._add_output(OutputPort("image", {IoDataType.IMAGE}))
+
+        self._apply_default_params()
+
+    # ── Properties ─────────────────────────────────────────────────────────────
+
+    @property
+    def colormap(self) -> Colormap:
+        return self._colormap
+
+    @colormap.setter
+    def colormap(self, value: int | Colormap) -> None:
+        try:
+            self._colormap = Colormap(value)
+        except ValueError as e:
+            raise ValueError(
+                f"colormap must be one of {[m.value for m in Colormap]} (got {value!r})"
+            ) from e
+
+    # ── NodeBase interface ─────────────────────────────────────────────────────
+
+    @override
+    def process_impl(self) -> None:
+        image: np.ndarray = self.inputs[0].data.image
+        if image.ndim != 2:
+            raise ValueError(
+                f"ApplyColormap expects a single-channel image, got shape {image.shape}"
+            )
+        if image.dtype != np.uint8:
+            image = image.astype(np.uint8, copy=False)
+
+        coloured = cv2.applyColorMap(image, int(self._colormap))
+        self.outputs[0].send(IoData.from_image(coloured))

--- a/src/nodes/filters/apply_colormap.py
+++ b/src/nodes/filters/apply_colormap.py
@@ -7,7 +7,7 @@ import numpy as np
 from typing_extensions import override
 
 from core.io_data import IoData, IoDataType
-from core.node_base import NodeBase, NodeParamType
+from core.node_base import NodeBase, NodeParam, NodeParamType
 from core.port import InputPort, OutputPort
 
 
@@ -64,16 +64,16 @@ class ApplyColormap(NodeBase):
         self._colormap: Colormap = Colormap.VIRIDIS
 
         self._add_input(InputPort("image", {IoDataType.IMAGE_GREY}))
-        self._add_input(InputPort(
+        # ``colormap`` is a constant (NodeParam, not a port-style input)
+        # so it isn't drivable from upstream — the palette is a
+        # build-time visualization choice, not something a streaming
+        # source would animate per frame. Renders as an inline combo
+        # box above the input rows, with no socket dot.
+        self._add_param(NodeParam(
             "colormap",
-            {IoDataType.ENUM},
-            optional=True,
-            default_value=Colormap.VIRIDIS,
-            metadata={
-                "default": Colormap.VIRIDIS,
-                "enum": Colormap,
-                "param_type": NodeParamType.ENUM,
-            },
+            NodeParamType.ENUM,
+            default=Colormap.VIRIDIS,
+            metadata={"enum": Colormap},
         ))
         self._add_output(OutputPort("image", {IoDataType.IMAGE}))
 

--- a/tests/test_apply_colormap.py
+++ b/tests/test_apply_colormap.py
@@ -1,0 +1,100 @@
+"""Unit tests for the ApplyColormap filter."""
+from __future__ import annotations
+
+import cv2
+import numpy as np
+import pytest
+
+from core.io_data import IoData, IoDataType
+from nodes.filters.apply_colormap import ApplyColormap, Colormap
+
+
+def _ramp(h: int = 8, w: int = 256) -> np.ndarray:
+    """Deterministic 0..255 horizontal ramp; exercises the full LUT."""
+    row = (np.arange(w) % 256).astype(np.uint8)
+    return np.tile(row, (h, 1))
+
+
+def test_emits_bgr_image_with_same_spatial_shape() -> None:
+    node = ApplyColormap()
+    grey = _ramp(8, 16)
+    node.inputs[0].receive(IoData.from_greyscale(grey))
+
+    out = node.outputs[0].last_emitted
+    assert out is not None
+    assert out.type == IoDataType.IMAGE
+    assert out.image.shape == (8, 16, 3)
+    assert out.image.dtype == np.uint8
+
+
+def test_default_colormap_is_viridis() -> None:
+    node = ApplyColormap()
+    assert node.colormap == Colormap.VIRIDIS
+
+
+def test_output_matches_cv2_apply_colormap_directly() -> None:
+    """The node must be a thin wrapper — output must equal cv2.applyColorMap."""
+    node = ApplyColormap()
+    node.colormap = Colormap.JET
+    grey = _ramp()
+
+    node.inputs[0].receive(IoData.from_greyscale(grey))
+    out = node.outputs[0].last_emitted.image
+
+    expected = cv2.applyColorMap(grey, cv2.COLORMAP_JET)
+    np.testing.assert_array_equal(out, expected)
+
+
+@pytest.mark.parametrize("cmap", list(Colormap))
+def test_every_colormap_produces_valid_bgr(cmap: Colormap) -> None:
+    """Every enum member must round-trip through cv2.applyColorMap cleanly.
+
+    Guards against an enum value that doesn't correspond to a real
+    ``cv2.COLORMAP_*`` constant on the installed OpenCV.
+    """
+    node = ApplyColormap()
+    node.colormap = cmap
+    grey = _ramp(4, 32)
+
+    node.inputs[0].receive(IoData.from_greyscale(grey))
+    out = node.outputs[0].last_emitted
+    assert out is not None
+    assert out.image.shape == (4, 32, 3)
+    assert out.image.dtype == np.uint8
+
+
+def test_colormap_setter_accepts_int_values() -> None:
+    """Saved flows persist enums as ints; the setter must coerce back."""
+    node = ApplyColormap()
+    node.colormap = int(Colormap.MAGMA)
+    assert node.colormap == Colormap.MAGMA
+
+
+def test_colormap_setter_rejects_unknown_value() -> None:
+    node = ApplyColormap()
+    with pytest.raises(ValueError, match="colormap must be one of"):
+        node.colormap = 9999
+
+
+def test_rejects_three_channel_input_at_process_time() -> None:
+    """Colour input has no defined mapping; the node must refuse it."""
+    node = ApplyColormap()
+    bgr = np.zeros((4, 4, 3), dtype=np.uint8)
+    try:
+        node.inputs[0].receive(IoData.from_greyscale(bgr))
+    except Exception as exc:
+        assert "single-channel" in str(exc)
+    else:
+        raise AssertionError("ApplyColormap must reject 3-D input")
+
+
+def test_non_uint8_input_is_coerced() -> None:
+    """Float greyscale (e.g. from a normalized field) should still colorize."""
+    node = ApplyColormap()
+    grey = np.linspace(0, 255, 64, dtype=np.float32).reshape(8, 8)
+    node.inputs[0].receive(IoData.from_greyscale(grey))
+
+    out = node.outputs[0].last_emitted
+    assert out is not None
+    assert out.image.shape == (8, 8, 3)
+    assert out.image.dtype == np.uint8


### PR DESCRIPTION
## Summary
Introduces a new `ApplyColormap` node that colorizes single-channel greyscale images using OpenCV's colormap functionality. This enables visualization of FFT magnitudes, depth maps, and other intensity fields with perceptually-uniform or domain-standard color palettes.

## Key Changes
- **New `ApplyColormap` node** (`src/nodes/filters/apply_colormap.py`):
  - Wraps `cv2.applyColorMap` to convert greyscale `IMAGE_GREY` inputs to 3-channel BGR `IMAGE` outputs
  - Supports 11 colormaps via `Colormap` enum: VIRIDIS, PLASMA, MAGMA, INFERNO (matplotlib perceptually-uniform family), JET and TURBO (classic and modern FFT/spectrogram defaults), plus HOT, BONE, PARULA, OCEAN, COOL
  - Colormap selection is a build-time parameter (not frame-driven), rendered as an inline combo box
  - Automatically coerces non-uint8 input to uint8; rejects multi-channel input
  - Default colormap is VIRIDIS

- **Comprehensive test coverage** (`tests/test_apply_colormap.py`):
  - Validates output shape, dtype, and equivalence to raw `cv2.applyColorMap`
  - Parametrized tests for all 11 colormaps
  - Tests int/enum coercion for saved flow round-tripping
  - Validates rejection of invalid colormap values and multi-channel input

- **Updated example flow** (`flow/video_fft.flowjs`):
  - Refactored to insert three `ApplyColormap` nodes (IDs 10, 11, 12) between FFT outputs and the merge node
  - Applies colorization to magnitude, real, and imaginary FFT components before display
  - Reorganized node positions and added "Color" backdrop group for clarity

- **Version bump and documentation**:
  - Updated app version to 0.2.16 across `constants.py`, flow metadata, and welcome page
  - Added CHANGELOG entry and welcome page section describing the new feature

## Implementation Details
- The `Colormap` enum is backed by `IntEnum` so integer values (persisted in saved flows) round-trip cleanly through JSON serialization
- The node assumes input is already tonemapped to 0..255 range; it does not perform log compression (upstream nodes like `Fft2D` handle that)
- Designed as a display-side companion to greyscale producers, keeping visualization concerns out of the producer node

https://claude.ai/code/session_019B3fUM5oKU81e8YniLciT9