### PR TITLE
Add GradientSource and MaskedBlend nodes with linear gradient mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,33 @@ once a first tagged release is cut.
 
 ## [Unreleased]
 
+## [0.2.17] — 2026-04-27
+
+### Added
+- **Masked Blend filter.** New ``MaskedBlend`` node under *Composit*
+  that blends two images through a separate greyscale mask:
+  ``out = base * (1 - m) + overlay * m`` with ``m = mask / 255``.
+  Fills the gap left by ``Overlay``, which only supports a uniform
+  alpha or a per-pixel alpha baked into a BGRA overlay's 4th channel
+  — ``MaskedBlend`` accepts the mask as a separate input so any
+  greyscale producer (procedural gradient, threshold output, distance
+  field, hand-painted PNG) can drive the blend. Mismatched mask
+  resolutions are auto-resized to the base's dimensions so a small
+  procedural gradient can mask a full-resolution video stream
+  without manual size matching.
+- **Gradient Source.** New procedural ``GradientSource`` node under
+  *Sources* that emits a single-channel ``IMAGE_GREY`` gradient
+  image. Configurable direction (``VERTICAL`` / ``HORIZONTAL`` /
+  ``RADIAL``), a central plateau width and a smooth-vs-linear ramp
+  toggle. Reactive, so size / direction / band edits live-update the
+  downstream preview. Designed as the procedural mask source for
+  ``MaskedBlend`` (tilt-shift, vignette, soft compositing) without
+  having to ship a pre-rendered PNG.
+- **Tilt-shift sample flow.** ``flow/video_tiltshift.flowjs`` chains
+  ``VideoSource`` → ``GaussianBlur`` → ``MaskedBlend`` driven by a
+  vertical ``GradientSource``, producing the classic miniature-faking
+  effect (sharp horizontal band, softly blurred top / bottom).
+
 ## [0.2.16] — 2026-04-27
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,20 @@ once a first tagged release is cut.
 
 ## [Unreleased]
 
+## [0.2.18] — 2026-04-27
+
+### Added
+- **Gradient Source: linear mode.** ``GradientSource`` gains a
+  ``mode`` parameter alongside ``direction``: ``SYMMETRIC`` (the
+  pre-existing centred double gradient — tilt-shift, vignette) and
+  ``LINEAR`` (a one-sided 0 → 255 ramp — cross-fades, day/night
+  transitions, soft-edge wipes). Defaults to ``SYMMETRIC`` so saved
+  flows from 0.2.17 keep their previous output. ``band_width`` also
+  works in linear mode, where it carves out a leading dead-zone
+  before the ramp starts. RADIAL ignores ``mode`` — a rotation-
+  symmetric "linear" radial has no meaningful interpretation, so
+  the node falls back to the symmetric ramp.
+
 ## [0.2.17] — 2026-04-27
 
 ### Added

--- a/doc/welcome.html
+++ b/doc/welcome.html
@@ -180,7 +180,7 @@
   <main class="content-col">
 
     <header class="hero">
-      <h1>Welcome to Stjörnhorn <span class="version">v0.2.16</span></h1>
+      <h1>Welcome to Stjörnhorn <span class="version">v0.2.17</span></h1>
       <div class="tagline">A node-based image- and video-processing playground.</div>
     </header>
 
@@ -210,6 +210,15 @@
           <p>Write frames to image files or encode video (MP4V, XVID) with live preview via the Display node.</p>
         </div>
       </div>
+    </section>
+
+    <section>
+      <h2>What's new in v0.2.17</h2>
+      <ul class="tips">
+        <li><strong>Masked Blend filter.</strong> A new node under <em>Composit</em> that blends two images through a separate greyscale mask: <code>out = base*(1-m) + overlay*m</code>. The mask can be any greyscale producer — a procedural gradient, a threshold output, a hand-painted PNG — so soft compositing no longer has to be baked into a BGRA overlay's alpha channel.</li>
+        <li><strong>Gradient Source.</strong> A new procedural source under <em>Sources</em> that emits a single-channel gradient image. Pick <em>vertical</em>, <em>horizontal</em> or <em>radial</em> direction, set a central plateau width and a smooth-vs-linear ramp, and feed it into <em>Masked Blend</em> for tilt-shift, vignette, soft-edged compositing, etc.</li>
+        <li><strong>Tilt-shift sample flow.</strong> ``video_tiltshift.flowjs`` chains a video source through a Gaussian blur and a Masked Blend driven by a vertical Gradient Source — the classic miniature-faking effect with a sharp horizontal band and softly blurred top / bottom.</li>
+      </ul>
     </section>
 
     <section>

--- a/doc/welcome.html
+++ b/doc/welcome.html
@@ -180,7 +180,7 @@
   <main class="content-col">
 
     <header class="hero">
-      <h1>Welcome to Stjörnhorn <span class="version">v0.2.17</span></h1>
+      <h1>Welcome to Stjörnhorn <span class="version">v0.2.18</span></h1>
       <div class="tagline">A node-based image- and video-processing playground.</div>
     </header>
 
@@ -210,6 +210,13 @@
           <p>Write frames to image files or encode video (MP4V, XVID) with live preview via the Display node.</p>
         </div>
       </div>
+    </section>
+
+    <section>
+      <h2>What's new in v0.2.18</h2>
+      <ul class="tips">
+        <li><strong>Linear gradient mode.</strong> The Gradient Source now exposes a <em>mode</em> selector — <em>SYMMETRIC</em> (the centred double gradient used by tilt-shift / vignette) and <em>LINEAR</em> (a one-sided 0 → 255 ramp for cross-fades, day-night transitions and soft-edge wipes). Defaults to SYMMETRIC so existing flows are unchanged. The <em>band_width</em> parameter now also acts as a leading dead-zone in LINEAR mode (skip the first N% of the axis before the ramp starts). RADIAL is always symmetric — a radial linear has no meaningful interpretation.</li>
+      </ul>
     </section>
 
     <section>

--- a/flow/video_tiltshift.flowjs
+++ b/flow/video_tiltshift.flowjs
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "app_version": "0.2.17",
+  "app_version": "0.2.18",
   "name": "video_tiltshift",
   "nodes": [
     {
@@ -8,8 +8,8 @@
       "module": "nodes.sources.video_source",
       "class": "VideoSource",
       "position": [
-        -1700.0,
-        -800.0
+        -1697.9622288212852,
+        -850.9442794678652
       ],
       "port_defaults": {
         "file_path": "video.mp4",
@@ -21,8 +21,8 @@
       "module": "nodes.filters.gaussian_blur",
       "class": "GaussianBlur",
       "position": [
-        -1340.0,
-        -640.0
+        -1307.0622741836935,
+        -507.0547842961979
       ],
       "port_defaults": {
         "ksize": 51,
@@ -38,14 +38,15 @@
       "module": "nodes.sources.gradient_source",
       "class": "GradientSource",
       "position": [
-        -1700.0,
-        -440.0
+        -1604.0323125847237,
+        -714.807453126518
       ],
       "port_defaults": {
         "width": 512,
         "height": 512,
         "direction": 0,
-        "band_width": 0.2,
+        "mode": 1,
+        "band_width": 0.6,
         "smooth": true
       }
     },
@@ -54,13 +55,13 @@
       "module": "nodes.filters.masked_blend",
       "class": "MaskedBlend",
       "position": [
-        -980.0,
-        -780.0
+        -1307.0622741836935,
+        -675.0547842961979
       ],
       "port_defaults": {},
       "size": [
         220.0,
-        140.0
+        148.0
       ]
     },
     {
@@ -68,8 +69,8 @@
       "module": "nodes.filters.display",
       "class": "Display",
       "position": [
-        -680.0,
-        -900.0
+        -870.8018994605613,
+        -725.3743453537172
       ],
       "port_defaults": {},
       "size": [
@@ -82,14 +83,24 @@
       "module": "nodes.sinks.video_sink",
       "class": "VideoSink",
       "position": [
-        140.0,
-        -640.0
+        -428.5266551332713,
+        -916.2024920777791
       ],
       "port_defaults": {
         "output_path": "out_tiltshift.mp4",
         "fps": 30.0,
         "codec": 0
       }
+    },
+    {
+      "id": 6,
+      "module": "nodes.filters.merge",
+      "class": "Merge",
+      "position": [
+        -867.071636543064,
+        -918.015916010929
+      ],
+      "port_defaults": {}
     }
   ],
   "connections": [
@@ -118,16 +129,40 @@
       "dst_input": 2
     },
     {
-      "src_node": 3,
+      "src_node": 4,
+      "src_output": 0,
+      "dst_node": 5,
+      "dst_input": 0
+    },
+    {
+      "src_node": 0,
+      "src_output": 0,
+      "dst_node": 6,
+      "dst_input": 0
+    },
+    {
+      "src_node": 6,
       "src_output": 0,
       "dst_node": 4,
       "dst_input": 0
     },
     {
-      "src_node": 4,
+      "src_node": 1,
       "src_output": 0,
-      "dst_node": 5,
-      "dst_input": 0
+      "dst_node": 6,
+      "dst_input": 2
+    },
+    {
+      "src_node": 3,
+      "src_output": 0,
+      "dst_node": 6,
+      "dst_input": 1
+    },
+    {
+      "src_node": 2,
+      "src_output": 0,
+      "dst_node": 6,
+      "dst_input": 3
     }
   ],
   "backdrops": [

--- a/flow/video_tiltshift.flowjs
+++ b/flow/video_tiltshift.flowjs
@@ -1,0 +1,152 @@
+{
+  "version": 1,
+  "app_version": "0.2.17",
+  "name": "video_tiltshift",
+  "nodes": [
+    {
+      "id": 0,
+      "module": "nodes.sources.video_source",
+      "class": "VideoSource",
+      "position": [
+        -1700.0,
+        -800.0
+      ],
+      "port_defaults": {
+        "file_path": "video.mp4",
+        "max_num_frames": -1
+      }
+    },
+    {
+      "id": 1,
+      "module": "nodes.filters.gaussian_blur",
+      "class": "GaussianBlur",
+      "position": [
+        -1340.0,
+        -640.0
+      ],
+      "port_defaults": {
+        "ksize": 51,
+        "sigma": 0.0
+      },
+      "size": [
+        220.0,
+        148.0
+      ]
+    },
+    {
+      "id": 2,
+      "module": "nodes.sources.gradient_source",
+      "class": "GradientSource",
+      "position": [
+        -1700.0,
+        -440.0
+      ],
+      "port_defaults": {
+        "width": 512,
+        "height": 512,
+        "direction": 0,
+        "band_width": 0.2,
+        "smooth": true
+      }
+    },
+    {
+      "id": 3,
+      "module": "nodes.filters.masked_blend",
+      "class": "MaskedBlend",
+      "position": [
+        -980.0,
+        -780.0
+      ],
+      "port_defaults": {},
+      "size": [
+        220.0,
+        140.0
+      ]
+    },
+    {
+      "id": 4,
+      "module": "nodes.filters.display",
+      "class": "Display",
+      "position": [
+        -680.0,
+        -900.0
+      ],
+      "port_defaults": {},
+      "size": [
+        720.0,
+        540.0
+      ]
+    },
+    {
+      "id": 5,
+      "module": "nodes.sinks.video_sink",
+      "class": "VideoSink",
+      "position": [
+        140.0,
+        -640.0
+      ],
+      "port_defaults": {
+        "output_path": "out_tiltshift.mp4",
+        "fps": 30.0,
+        "codec": 0
+      }
+    }
+  ],
+  "connections": [
+    {
+      "src_node": 0,
+      "src_output": 0,
+      "dst_node": 1,
+      "dst_input": 0
+    },
+    {
+      "src_node": 0,
+      "src_output": 0,
+      "dst_node": 3,
+      "dst_input": 0
+    },
+    {
+      "src_node": 1,
+      "src_output": 0,
+      "dst_node": 3,
+      "dst_input": 1
+    },
+    {
+      "src_node": 2,
+      "src_output": 0,
+      "dst_node": 3,
+      "dst_input": 2
+    },
+    {
+      "src_node": 3,
+      "src_output": 0,
+      "dst_node": 4,
+      "dst_input": 0
+    },
+    {
+      "src_node": 4,
+      "src_output": 0,
+      "dst_node": 5,
+      "dst_input": 0
+    }
+  ],
+  "backdrops": [
+    {
+      "position": [
+        -1740.0,
+        -880.0
+      ],
+      "size": [
+        720.0,
+        540.0
+      ],
+      "title": "Sharp + blurred branches",
+      "color": [
+        70,
+        60,
+        40,
+        140
+      ]
+    }
+  ]
+}

--- a/src/constants.py
+++ b/src/constants.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 APP_NAME:         str = "Image-Inquest"
 APP_DISPLAY_NAME: str = "Stjörnhorn"
-APP_VERSION:      str = "0.2.17"
+APP_VERSION:      str = "0.2.18"
 API_URL:    str = "https://beltoforion.de"
 
 # Path resolution -----------------------------------------------------------

--- a/src/constants.py
+++ b/src/constants.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 APP_NAME:         str = "Image-Inquest"
 APP_DISPLAY_NAME: str = "Stjörnhorn"
-APP_VERSION:      str = "0.2.16"
+APP_VERSION:      str = "0.2.17"
 API_URL:    str = "https://beltoforion.de"
 
 # Path resolution -----------------------------------------------------------

--- a/src/nodes/filters/masked_blend.py
+++ b/src/nodes/filters/masked_blend.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+import cv2
+import numpy as np
+from typing_extensions import override
+
+from core.io_data import IMAGE_TYPES, IoData, IoDataType
+from core.node_base import NodeBase
+from core.port import InputPort, OutputPort
+
+
+class MaskedBlend(NodeBase):
+    """Per-pixel blend of two images driven by a greyscale mask.
+
+    For every pixel ``out = base * (1 - m) + overlay * m`` with
+    ``m = mask / 255`` — the mask's intensity controls how much of
+    the overlay shows through. A black mask emits the base unchanged,
+    a white mask emits the overlay unchanged, and intermediate values
+    cross-fade smoothly. This is the missing primitive that
+    :class:`~nodes.filters.overlay.Overlay` doesn't cover: Overlay
+    blends with a *uniform* alpha (or a per-pixel alpha embedded in a
+    BGRA overlay), whereas this node accepts the mask as a separate
+    input — so you can drive the mask with any greyscale producer
+    (gradient image, threshold output, distance field, …) instead of
+    having to bake it into the overlay's alpha channel.
+
+    Type strategy:
+      If either ``base`` or ``overlay`` is colour
+      (:data:`IoDataType.IMAGE`), any greyscale image input is
+      promoted to BGR via ``cv2.cvtColor(..., COLOR_GRAY2BGR)`` and
+      the output is emitted as ``IMAGE``. If both are greyscale, the
+      output stays greyscale. The ``mask`` input accepts either type
+      and is reduced to a single channel internally — feeding a 3- or
+      4-channel image keeps the first channel (cheap, and matches the
+      common case of a greyscale gradient that
+      :class:`~nodes.sources.image_source.ImageSource` has promoted
+      to BGR).
+
+    Size strategy:
+      ``base`` and ``overlay`` must have identical ``H x W``. The
+      ``mask`` is resized to ``base``'s ``H x W`` if it differs, with
+      :data:`cv2.INTER_LINEAR` so a small procedural gradient can
+      drive a full-resolution stream without the user having to match
+      sizes manually.
+    """
+
+    def __init__(self) -> None:
+        super().__init__("Masked Blend", section="Composit")
+
+        self._add_input(InputPort("base", set(IMAGE_TYPES)))
+        self._add_input(InputPort("overlay", set(IMAGE_TYPES)))
+        self._add_input(InputPort("mask", set(IMAGE_TYPES)))
+        self._add_output(OutputPort("image", set(IMAGE_TYPES)))
+
+    @override
+    def process_impl(self) -> None:
+        base_data    = self.inputs[0].data
+        overlay_data = self.inputs[1].data
+        mask_data    = self.inputs[2].data
+
+        any_color = (
+            base_data.type == IoDataType.IMAGE
+            or overlay_data.type == IoDataType.IMAGE
+        )
+
+        def to_canvas(d: IoData) -> np.ndarray:
+            img = d.image
+            if any_color and d.type == IoDataType.IMAGE_GREY:
+                return cv2.cvtColor(img, cv2.COLOR_GRAY2BGR)
+            return img
+
+        def strip_alpha(img: np.ndarray) -> np.ndarray:
+            """Drop the alpha channel of a BGRA input so blend math holds."""
+            if img.ndim == 3 and img.shape[2] == 4:
+                return img[:, :, :3]
+            return img
+
+        base    = strip_alpha(to_canvas(base_data))
+        overlay = strip_alpha(to_canvas(overlay_data))
+
+        if base.shape != overlay.shape:
+            raise ValueError(
+                f"MaskedBlend: base shape {base.shape} != "
+                f"overlay shape {overlay.shape}"
+            )
+
+        # Reduce the mask to a single 2-D plane regardless of how it
+        # arrived. ImageSource promotes greyscale PNGs to BGR, so a
+        # gradient PNG dropped on the mask input arrives as a 3-channel
+        # IMAGE — keeping the first channel matches the common case
+        # where every channel carries the same gradient.
+        mask_img = mask_data.image
+        if mask_img.ndim == 3:
+            mask_img = mask_img[:, :, 0]
+
+        base_h, base_w = base.shape[:2]
+        if mask_img.shape[:2] != (base_h, base_w):
+            mask_img = cv2.resize(
+                mask_img, (base_w, base_h), interpolation=cv2.INTER_LINEAR
+            )
+
+        # Float32 intermediate — uint8 multiply would overflow, and
+        # float32 is cheap enough on the per-frame hot path.
+        m = mask_img.astype(np.float32) * (1.0 / 255.0)
+        if base.ndim == 3:
+            m = m[:, :, None]  # broadcast across BGR channels
+
+        blended = base.astype(np.float32) * (1.0 - m) \
+                + overlay.astype(np.float32) * m
+        result = np.clip(blended, 0.0, 255.0).astype(np.uint8)
+
+        if any_color:
+            self.outputs[0].send(IoData.from_image(result))
+        else:
+            self.outputs[0].send(IoData.from_greyscale(result))

--- a/src/nodes/sources/gradient_source.py
+++ b/src/nodes/sources/gradient_source.py
@@ -18,41 +18,70 @@ class GradientDirection(IntEnum):
     accepts both ints and enum members, and the ``ENUM`` param widget
     renders a combo box of ``name``-based labels.
     """
-    VERTICAL   = 0  # gradient runs along Y, plateau is a horizontal band
-    HORIZONTAL = 1  # gradient runs along X, plateau is a vertical band
-    RADIAL     = 2  # gradient runs from the centre outward
+    VERTICAL   = 0  # gradient runs along Y
+    HORIZONTAL = 1  # gradient runs along X
+    RADIAL     = 2  # gradient runs from the centre outward (always symmetric)
+
+
+class GradientMode(IntEnum):
+    """Symmetry selector for :class:`GradientSource`.
+
+    ``SYMMETRIC`` produces a "double" gradient that is mirrored around
+    the image centre — 0 in the middle, ramping to 255 at *both* ends
+    of the chosen axis. This is the right shape for tilt-shift,
+    vignette and any other compositing that needs to fade out toward
+    both edges.
+
+    ``LINEAR`` produces a single-sided gradient — 0 at one end of the
+    axis, 255 at the other — which is what cross-fades, day/night
+    transitions, soft-edge wipes and similar one-way blends need. Has
+    no effect when ``direction = RADIAL``: a radial gradient is
+    inherently rotation-symmetric, so a "linear radial" has no
+    meaningful interpretation; the node falls back to the symmetric
+    ramp in that case.
+    """
+    SYMMETRIC = 0  # 0 in the middle, 255 at both ends (the "double" gradient)
+    LINEAR    = 1  # 0 at one end, 255 at the other
 
 
 class GradientSource(SourceNodeBase):
     """Procedurally generates a single-channel greyscale gradient image.
 
     Emits a 2-D ``uint8`` image where each pixel encodes a normalised
-    distance from the centre of the chosen axis: 0 in the central
-    plateau, 255 at the far edge, with a configurable smooth ramp
-    in between. Designed as the procedural mask source that
-    :class:`~nodes.filters.masked_blend.MaskedBlend` consumes — drop
-    one in to soft-mask any per-frame compositing pipeline (tilt-shift
-    blur, vignette, tone-mapped centre highlights, …) without having
-    to ship a hand-painted PNG.
+    distance along the chosen axis, mapped through an optional
+    plateau + smooth ramp. Designed as the procedural mask source
+    that :class:`~nodes.filters.masked_blend.MaskedBlend` consumes —
+    drop one in to soft-mask any per-frame compositing pipeline
+    (tilt-shift blur, vignette, cross-fade, soft-edge wipe, …)
+    without having to ship a hand-painted PNG.
 
     Parameters:
       width, height -- output image size in pixels.
       direction     -- VERTICAL / HORIZONTAL / RADIAL axis along which
                        the gradient grows.
-      band_width    -- normalised half-width of the central plateau where
-                       the mask stays at 0. ``0.0`` = no plateau (immediate
-                       ramp from the centre outward), ``0.5`` = plateau
-                       fills the inner half of the image. Clamped to
-                       ``[0, 1)``.
-      smooth        -- when ``True`` (default) the ramp is cosine-eased so
-                       the transition feels photographic; when ``False``
-                       the ramp is linear, which is preferable when the
+      mode          -- SYMMETRIC (mirrored around the centre, the
+                       classic "double" gradient — tilt-shift,
+                       vignette) or LINEAR (one-sided 0 → 255 — cross
+                       fades, wipes). Ignored when ``direction =
+                       RADIAL``.
+      band_width    -- normalised plateau width where the mask stays
+                       at 0. In SYMMETRIC mode this is the half-width
+                       of a centre band: ``0.0`` = no plateau,
+                       ``0.5`` = inner half flat. In LINEAR mode this
+                       is the leading dead-zone before the ramp
+                       starts: ``0.0`` = ramp from the very first
+                       pixel, ``0.5`` = first half of the image
+                       stays at 0 then ramps to 255 over the second
+                       half. Clamped to ``[0, 1)``.
+      smooth        -- when ``True`` (default) the ramp is cosine-eased
+                       for a photographic falloff; when ``False`` the
+                       ramp is linear, which is preferable when the
                        mask drives a numeric blend that should stay
                        proportional to distance.
 
     Reactive: the node editor re-runs the flow whenever any parameter
-    on any node changes, so size / direction / band edits update the
-    downstream preview live without pressing Run.
+    on any node changes, so size / direction / mode / band edits
+    update the downstream preview live without pressing Run.
     """
 
     def __init__(self) -> None:
@@ -60,6 +89,7 @@ class GradientSource(SourceNodeBase):
         self._width:      int   = 512
         self._height:     int   = 512
         self._direction:  GradientDirection = GradientDirection.VERTICAL
+        self._mode:       GradientMode      = GradientMode.SYMMETRIC
         self._band_width: float = 0.2
         self._smooth:     bool  = True
 
@@ -70,6 +100,12 @@ class GradientSource(SourceNodeBase):
             NodeParamType.ENUM,
             default=GradientDirection.VERTICAL,
             metadata={"enum": GradientDirection},
+        ))
+        self._add_param(NodeParam(
+            "mode",
+            NodeParamType.ENUM,
+            default=GradientMode.SYMMETRIC,
+            metadata={"enum": GradientMode},
         ))
         self._add_param(NodeParam("band_width", NodeParamType.FLOAT, default=0.2))
         self._add_param(NodeParam("smooth",     NodeParamType.BOOL,  default=True))
@@ -116,6 +152,20 @@ class GradientSource(SourceNodeBase):
             ) from e
 
     @property
+    def mode(self) -> GradientMode:
+        return self._mode
+
+    @mode.setter
+    def mode(self, value: int | GradientMode) -> None:
+        try:
+            self._mode = GradientMode(value)
+        except ValueError as e:
+            raise ValueError(
+                f"mode must be one of {[m.value for m in GradientMode]} "
+                f"(got {value!r})"
+            ) from e
+
+    @property
     def band_width(self) -> float:
         return self._band_width
 
@@ -151,24 +201,39 @@ class GradientSource(SourceNodeBase):
     # ── Internals ──────────────────────────────────────────────────────────────
 
     def _build_gradient(self) -> np.ndarray:
-        """Return the configured gradient as a ``uint8`` (H, W) array."""
-        h, w = self._height, self._width
+        """Return the configured gradient as a ``uint8`` (H, W) array.
 
-        # Normalised distance from the image centre, in [0, 1] at the
-        # far edge along the relevant axis. The vertical / horizontal
-        # variants degenerate to a 1-D ramp tiled across the other
-        # axis; the radial variant is a true 2-D field.
+        Per-axis distance metric depends on ``mode``:
+
+        * SYMMETRIC — distance from the centre, normalised so the far
+          edge along the axis reads 1.0. Produces a double gradient
+          (mirrored around the centre).
+        * LINEAR — distance from the *start* of the axis, normalised
+          so the far end reads 1.0. Produces a single-sided gradient.
+
+        RADIAL ignores ``mode`` and always uses the centred metric;
+        a "linear" radial has no meaningful interpretation.
+        """
+        h, w = self._height, self._width
+        symmetric = (self._mode == GradientMode.SYMMETRIC)
+
         if self._direction == GradientDirection.VERTICAL:
-            cy = max((h - 1) / 2.0, 1e-9)
             y = np.arange(h, dtype=np.float32)
-            d = np.abs(y - cy) / cy            # shape (H,)
-            d = np.tile(d[:, None], (1, w))    # broadcast to (H, W)
+            if symmetric:
+                cy = max((h - 1) / 2.0, 1e-9)
+                d_axis = np.abs(y - cy) / cy
+            else:
+                d_axis = y / max(h - 1, 1)         # 0 at top, 1 at bottom
+            d = np.tile(d_axis[:, None], (1, w))
         elif self._direction == GradientDirection.HORIZONTAL:
-            cx = max((w - 1) / 2.0, 1e-9)
             x = np.arange(w, dtype=np.float32)
-            d = np.abs(x - cx) / cx
-            d = np.tile(d[None, :], (h, 1))
-        else:  # RADIAL
+            if symmetric:
+                cx = max((w - 1) / 2.0, 1e-9)
+                d_axis = np.abs(x - cx) / cx
+            else:
+                d_axis = x / max(w - 1, 1)         # 0 at left, 1 at right
+            d = np.tile(d_axis[None, :], (h, 1))
+        else:  # RADIAL — always symmetric (mode is irrelevant here)
             cx = max((w - 1) / 2.0, 1e-9)
             cy = max((h - 1) / 2.0, 1e-9)
             yy = (np.arange(h, dtype=np.float32) - cy) / cy
@@ -179,7 +244,7 @@ class GradientSource(SourceNodeBase):
             # corners read as the maximum 255.
             np.clip(d, 0.0, 1.0, out=d)
 
-        # Carve out the central plateau and remap the remainder to
+        # Carve out the leading plateau and remap the remainder to
         # [0, 1] so the ramp covers the full output range.
         bw = self._band_width
         ramp = np.clip((d - bw) / max(1.0 - bw, 1e-9), 0.0, 1.0)

--- a/src/nodes/sources/gradient_source.py
+++ b/src/nodes/sources/gradient_source.py
@@ -1,0 +1,189 @@
+from __future__ import annotations
+
+from enum import IntEnum
+
+import numpy as np
+from typing_extensions import override
+
+from core.io_data import IoData, IoDataType
+from core.node_base import NodeParam, NodeParamType, SourceNodeBase
+from core.port import OutputPort
+
+
+class GradientDirection(IntEnum):
+    """Axis selector for :class:`GradientSource`.
+
+    Backed by :class:`IntEnum` so the integer representation persists
+    cleanly across saved flow files: JSON stores the int, the setter
+    accepts both ints and enum members, and the ``ENUM`` param widget
+    renders a combo box of ``name``-based labels.
+    """
+    VERTICAL   = 0  # gradient runs along Y, plateau is a horizontal band
+    HORIZONTAL = 1  # gradient runs along X, plateau is a vertical band
+    RADIAL     = 2  # gradient runs from the centre outward
+
+
+class GradientSource(SourceNodeBase):
+    """Procedurally generates a single-channel greyscale gradient image.
+
+    Emits a 2-D ``uint8`` image where each pixel encodes a normalised
+    distance from the centre of the chosen axis: 0 in the central
+    plateau, 255 at the far edge, with a configurable smooth ramp
+    in between. Designed as the procedural mask source that
+    :class:`~nodes.filters.masked_blend.MaskedBlend` consumes — drop
+    one in to soft-mask any per-frame compositing pipeline (tilt-shift
+    blur, vignette, tone-mapped centre highlights, …) without having
+    to ship a hand-painted PNG.
+
+    Parameters:
+      width, height -- output image size in pixels.
+      direction     -- VERTICAL / HORIZONTAL / RADIAL axis along which
+                       the gradient grows.
+      band_width    -- normalised half-width of the central plateau where
+                       the mask stays at 0. ``0.0`` = no plateau (immediate
+                       ramp from the centre outward), ``0.5`` = plateau
+                       fills the inner half of the image. Clamped to
+                       ``[0, 1)``.
+      smooth        -- when ``True`` (default) the ramp is cosine-eased so
+                       the transition feels photographic; when ``False``
+                       the ramp is linear, which is preferable when the
+                       mask drives a numeric blend that should stay
+                       proportional to distance.
+
+    Reactive: the node editor re-runs the flow whenever any parameter
+    on any node changes, so size / direction / band edits update the
+    downstream preview live without pressing Run.
+    """
+
+    def __init__(self) -> None:
+        super().__init__("Gradient Source", section="Sources")
+        self._width:      int   = 512
+        self._height:     int   = 512
+        self._direction:  GradientDirection = GradientDirection.VERTICAL
+        self._band_width: float = 0.2
+        self._smooth:     bool  = True
+
+        self._add_param(NodeParam("width",  NodeParamType.INT,  default=512))
+        self._add_param(NodeParam("height", NodeParamType.INT,  default=512))
+        self._add_param(NodeParam(
+            "direction",
+            NodeParamType.ENUM,
+            default=GradientDirection.VERTICAL,
+            metadata={"enum": GradientDirection},
+        ))
+        self._add_param(NodeParam("band_width", NodeParamType.FLOAT, default=0.2))
+        self._add_param(NodeParam("smooth",     NodeParamType.BOOL,  default=True))
+        self._add_output(OutputPort("image", {IoDataType.IMAGE_GREY}))
+
+        self._apply_default_params()
+
+    # ── Properties ─────────────────────────────────────────────────────────────
+
+    @property
+    def width(self) -> int:
+        return self._width
+
+    @width.setter
+    def width(self, value: int) -> None:
+        v = int(value)
+        if v < 1:
+            raise ValueError(f"width must be >= 1 (got {v})")
+        self._width = v
+
+    @property
+    def height(self) -> int:
+        return self._height
+
+    @height.setter
+    def height(self, value: int) -> None:
+        v = int(value)
+        if v < 1:
+            raise ValueError(f"height must be >= 1 (got {v})")
+        self._height = v
+
+    @property
+    def direction(self) -> GradientDirection:
+        return self._direction
+
+    @direction.setter
+    def direction(self, value: int | GradientDirection) -> None:
+        try:
+            self._direction = GradientDirection(value)
+        except ValueError as e:
+            raise ValueError(
+                f"direction must be one of {[m.value for m in GradientDirection]} "
+                f"(got {value!r})"
+            ) from e
+
+    @property
+    def band_width(self) -> float:
+        return self._band_width
+
+    @band_width.setter
+    def band_width(self, value: float) -> None:
+        v = float(value)
+        # Clamp to [0, 1) — at exactly 1.0 the ramp denominator is zero,
+        # which would just produce an all-zero image; clip a hair below
+        # so the node still emits a meaningful gradient at the extreme.
+        self._band_width = max(0.0, min(0.999, v))
+
+    @property
+    def smooth(self) -> bool:
+        return self._smooth
+
+    @smooth.setter
+    def smooth(self, value: bool) -> None:
+        self._smooth = bool(value)
+
+    # ── SourceNodeBase interface ────────────────────────────────────────────────
+
+    @property
+    @override
+    def is_reactive(self) -> bool:
+        # Single deterministic frame: re-run on any param edit so the
+        # downstream preview tracks the gradient live.
+        return True
+
+    @override
+    def process_impl(self) -> None:
+        self.outputs[0].send(IoData.from_greyscale(self._build_gradient()))
+
+    # ── Internals ──────────────────────────────────────────────────────────────
+
+    def _build_gradient(self) -> np.ndarray:
+        """Return the configured gradient as a ``uint8`` (H, W) array."""
+        h, w = self._height, self._width
+
+        # Normalised distance from the image centre, in [0, 1] at the
+        # far edge along the relevant axis. The vertical / horizontal
+        # variants degenerate to a 1-D ramp tiled across the other
+        # axis; the radial variant is a true 2-D field.
+        if self._direction == GradientDirection.VERTICAL:
+            cy = max((h - 1) / 2.0, 1e-9)
+            y = np.arange(h, dtype=np.float32)
+            d = np.abs(y - cy) / cy            # shape (H,)
+            d = np.tile(d[:, None], (1, w))    # broadcast to (H, W)
+        elif self._direction == GradientDirection.HORIZONTAL:
+            cx = max((w - 1) / 2.0, 1e-9)
+            x = np.arange(w, dtype=np.float32)
+            d = np.abs(x - cx) / cx
+            d = np.tile(d[None, :], (h, 1))
+        else:  # RADIAL
+            cx = max((w - 1) / 2.0, 1e-9)
+            cy = max((h - 1) / 2.0, 1e-9)
+            yy = (np.arange(h, dtype=np.float32) - cy) / cy
+            xx = (np.arange(w, dtype=np.float32) - cx) / cx
+            d = np.sqrt(yy[:, None] ** 2 + xx[None, :] ** 2)
+            # Distance to a corner exceeds 1 in a non-square image —
+            # clip so the ramp denominator stays well-defined and the
+            # corners read as the maximum 255.
+            np.clip(d, 0.0, 1.0, out=d)
+
+        # Carve out the central plateau and remap the remainder to
+        # [0, 1] so the ramp covers the full output range.
+        bw = self._band_width
+        ramp = np.clip((d - bw) / max(1.0 - bw, 1e-9), 0.0, 1.0)
+        if self._smooth:
+            ramp = (1.0 - np.cos(ramp * np.pi)) * 0.5
+
+        return (ramp * 255.0).astype(np.uint8)

--- a/tests/test_gradient_source.py
+++ b/tests/test_gradient_source.py
@@ -5,7 +5,11 @@ import numpy as np
 import pytest
 
 from core.io_data import IoDataType
-from nodes.sources.gradient_source import GradientDirection, GradientSource
+from nodes.sources.gradient_source import (
+    GradientDirection,
+    GradientMode,
+    GradientSource,
+)
 
 
 def _emit(node: GradientSource) -> np.ndarray:
@@ -165,3 +169,110 @@ def test_direction_setter_rejects_unknown_value() -> None:
 def test_is_reactive_true() -> None:
     """Single-frame source — the editor should re-run on any param edit."""
     assert GradientSource().is_reactive is True
+
+
+# ── LINEAR mode ───────────────────────────────────────────────────────────────
+
+
+def test_default_mode_is_symmetric() -> None:
+    """Saved flows from before the mode parameter was added must keep
+    behaving like a centred double gradient — SYMMETRIC stays the default."""
+    assert GradientSource().mode == GradientMode.SYMMETRIC
+
+
+def test_linear_vertical_runs_top_to_bottom() -> None:
+    """One-sided gradient: 0 at the top, 255 at the bottom, no mirror."""
+    node = GradientSource()
+    node.width = 16
+    node.height = 64
+    node.direction = GradientDirection.VERTICAL
+    node.mode = GradientMode.LINEAR
+    node.band_width = 0.0
+    img = _emit(node)
+    assert img[0].max() == 0
+    assert img[-1].max() == 255
+    # Centre row sits roughly at the midpoint, *not* at zero (which is
+    # the SYMMETRIC behaviour). Cosine-eased ramp passes 0.5 at the
+    # midpoint, so the centre value is ~127.
+    assert 100 < int(img[32, 0]) < 155
+
+
+def test_linear_horizontal_runs_left_to_right() -> None:
+    node = GradientSource()
+    node.width = 64
+    node.height = 16
+    node.direction = GradientDirection.HORIZONTAL
+    node.mode = GradientMode.LINEAR
+    node.band_width = 0.0
+    img = _emit(node)
+    assert img[:, 0].max() == 0
+    assert img[:, -1].max() == 255
+
+
+def test_linear_is_monotonic_along_axis() -> None:
+    """A one-sided gradient never decreases as you move along the axis —
+    that's the defining property that distinguishes it from a double
+    gradient."""
+    node = GradientSource()
+    node.width = 16
+    node.height = 64
+    node.direction = GradientDirection.VERTICAL
+    node.mode = GradientMode.LINEAR
+    node.band_width = 0.0
+    node.smooth = False  # linear ramp gives strict monotonicity
+    img = _emit(node)
+    column = img[:, 0].astype(int)
+    diffs = np.diff(column)
+    assert (diffs >= 0).all(), f"non-monotonic column: {column.tolist()}"
+
+
+def test_linear_band_width_acts_as_leading_dead_zone() -> None:
+    """In LINEAR mode, ``band_width`` carves out a flat zero region at
+    the *start* of the axis (not centred), then the ramp covers the
+    rest."""
+    node = GradientSource()
+    node.width = 16
+    node.height = 100
+    node.direction = GradientDirection.VERTICAL
+    node.mode = GradientMode.LINEAR
+    node.band_width = 0.5  # first 50% of rows stay at 0
+    node.smooth = False
+    img = _emit(node)
+    # First half of rows are within the dead zone -> all zero.
+    assert img[:50].max() == 0
+    # Last row reaches the maximum.
+    assert img[-1].max() == 255
+
+
+def test_radial_ignores_mode() -> None:
+    """RADIAL has no meaningful linear variant — selecting LINEAR must
+    produce the same output as SYMMETRIC."""
+    sym = GradientSource()
+    sym.width = 33
+    sym.height = 33
+    sym.direction = GradientDirection.RADIAL
+    sym.mode = GradientMode.SYMMETRIC
+    img_sym = _emit(sym)
+
+    lin = GradientSource()
+    lin.width = 33
+    lin.height = 33
+    lin.direction = GradientDirection.RADIAL
+    lin.mode = GradientMode.LINEAR
+    img_lin = _emit(lin)
+
+    np.testing.assert_array_equal(img_sym, img_lin)
+
+
+def test_mode_setter_accepts_int_and_enum() -> None:
+    node = GradientSource()
+    node.mode = 1
+    assert node.mode == GradientMode.LINEAR
+    node.mode = GradientMode.SYMMETRIC
+    assert node.mode == GradientMode.SYMMETRIC
+
+
+def test_mode_setter_rejects_unknown_value() -> None:
+    node = GradientSource()
+    with pytest.raises(ValueError):
+        node.mode = 99

--- a/tests/test_gradient_source.py
+++ b/tests/test_gradient_source.py
@@ -1,0 +1,167 @@
+"""Unit tests for the GradientSource node."""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from core.io_data import IoDataType
+from nodes.sources.gradient_source import GradientDirection, GradientSource
+
+
+def _emit(node: GradientSource) -> np.ndarray:
+    node.process()
+    out = node.outputs[0].last_emitted
+    assert out is not None
+    assert out.type == IoDataType.IMAGE_GREY
+    return out.image
+
+
+def test_default_emits_uint8_grey_image_of_configured_size() -> None:
+    node = GradientSource()
+    node.width = 64
+    node.height = 32
+    img = _emit(node)
+    assert img.dtype == np.uint8
+    assert img.shape == (32, 64)
+
+
+def test_vertical_centre_row_is_zero_with_band() -> None:
+    """With a non-zero band_width, the centre row(s) sit on the plateau."""
+    node = GradientSource()
+    node.width = 64
+    node.height = 65  # odd height, exact centre row
+    node.direction = GradientDirection.VERTICAL
+    node.band_width = 0.2
+    img = _emit(node)
+    centre_row = img[32]
+    assert centre_row.max() == 0
+
+
+def test_vertical_outermost_rows_are_max() -> None:
+    node = GradientSource()
+    node.width = 16
+    node.height = 33
+    node.direction = GradientDirection.VERTICAL
+    node.band_width = 0.0
+    img = _emit(node)
+    # Top and bottom rows reach the maximum (255).
+    assert img[0].max() == 255
+    assert img[-1].max() == 255
+
+
+def test_vertical_is_constant_along_x() -> None:
+    """A vertical gradient varies only with Y — every column is identical."""
+    node = GradientSource()
+    node.width = 32
+    node.height = 32
+    node.direction = GradientDirection.VERTICAL
+    img = _emit(node)
+    np.testing.assert_array_equal(img[:, 0], img[:, 31])
+
+
+def test_horizontal_is_constant_along_y() -> None:
+    node = GradientSource()
+    node.width = 32
+    node.height = 32
+    node.direction = GradientDirection.HORIZONTAL
+    img = _emit(node)
+    np.testing.assert_array_equal(img[0, :], img[31, :])
+
+
+def test_radial_centre_is_zero_and_corners_are_max() -> None:
+    node = GradientSource()
+    node.width = 33
+    node.height = 33
+    node.direction = GradientDirection.RADIAL
+    node.band_width = 0.0
+    img = _emit(node)
+    # Exact centre pixel at (16, 16); distance is 0 → mask is 0.
+    assert img[16, 16] == 0
+    # Each corner sits at maximum normalised distance → 255.
+    assert img[0, 0] == 255
+    assert img[0, -1] == 255
+    assert img[-1, 0] == 255
+    assert img[-1, -1] == 255
+
+
+def test_band_width_widens_zero_plateau() -> None:
+    """Larger band_width → more pixels stay at zero in the centre."""
+    a = GradientSource()
+    a.width = 64
+    a.height = 64
+    a.direction = GradientDirection.VERTICAL
+    a.band_width = 0.1
+    img_a = _emit(a)
+
+    b = GradientSource()
+    b.width = 64
+    b.height = 64
+    b.direction = GradientDirection.VERTICAL
+    b.band_width = 0.5
+    img_b = _emit(b)
+
+    assert (img_b == 0).sum() > (img_a == 0).sum()
+
+
+def test_smooth_vs_linear_disagree_in_the_ramp() -> None:
+    """The cosine-eased ramp differs from the linear one in mid-ramp."""
+    a = GradientSource()
+    a.width = 64
+    a.height = 64
+    a.direction = GradientDirection.VERTICAL
+    a.band_width = 0.0
+    a.smooth = True
+    smooth = _emit(a)
+
+    b = GradientSource()
+    b.width = 64
+    b.height = 64
+    b.direction = GradientDirection.VERTICAL
+    b.band_width = 0.0
+    b.smooth = False
+    linear = _emit(b)
+
+    # Same shape, same endpoints (0 in centre, 255 at the edges) but
+    # different intermediate values.
+    assert smooth.shape == linear.shape
+    assert int(smooth[0, 0]) == int(linear[0, 0])
+    assert int(smooth[-1, 0]) == int(linear[-1, 0])
+    # Difference somewhere along the ramp.
+    assert not np.array_equal(smooth, linear)
+
+
+def test_invalid_size_raises() -> None:
+    node = GradientSource()
+    with pytest.raises(ValueError):
+        node.width = 0
+    with pytest.raises(ValueError):
+        node.height = -1
+
+
+def test_band_width_clamped_to_unit_interval() -> None:
+    node = GradientSource()
+    node.band_width = -0.5
+    assert node.band_width == 0.0
+    node.band_width = 5.0
+    # Clamped just below 1.0 to keep the ramp denominator positive.
+    assert node.band_width < 1.0
+    assert node.band_width >= 0.999
+
+
+def test_direction_setter_accepts_int_and_enum() -> None:
+    node = GradientSource()
+    node.direction = 1
+    assert node.direction == GradientDirection.HORIZONTAL
+    node.direction = GradientDirection.RADIAL
+    assert node.direction == GradientDirection.RADIAL
+
+
+def test_direction_setter_rejects_unknown_value() -> None:
+    node = GradientSource()
+    with pytest.raises(ValueError):
+        node.direction = 99
+
+
+def test_is_reactive_true() -> None:
+    """Single-frame source — the editor should re-run on any param edit."""
+    assert GradientSource().is_reactive is True

--- a/tests/test_masked_blend.py
+++ b/tests/test_masked_blend.py
@@ -1,0 +1,209 @@
+"""Unit tests for the MaskedBlend node."""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from core.io_data import IoData, IoDataType
+from core.port import OutputPort
+from nodes.filters.masked_blend import MaskedBlend
+
+
+def _bgr(h: int, w: int, value: int) -> np.ndarray:
+    return np.full((h, w, 3), value, dtype=np.uint8)
+
+
+def _grey(h: int, w: int, value: int) -> np.ndarray:
+    return np.full((h, w), value, dtype=np.uint8)
+
+
+def _wire(node: MaskedBlend, base: IoData, overlay: IoData, mask: IoData) -> None:
+    up_base = OutputPort("base", {base.type})
+    up_ov   = OutputPort("overlay", {overlay.type})
+    up_mask = OutputPort("mask", {mask.type})
+    up_base.connect(node.inputs[0])
+    up_ov.connect(node.inputs[1])
+    up_mask.connect(node.inputs[2])
+    up_base.send(base)
+    up_ov.send(overlay)
+    up_mask.send(mask)
+
+
+def test_black_mask_emits_base_unchanged() -> None:
+    node = MaskedBlend()
+    _wire(
+        node,
+        IoData.from_image(_bgr(4, 4, 100)),
+        IoData.from_image(_bgr(4, 4, 200)),
+        IoData.from_greyscale(_grey(4, 4, 0)),
+    )
+    out = node.outputs[0].last_emitted
+    assert out is not None
+    assert out.type == IoDataType.IMAGE
+    np.testing.assert_array_equal(out.image, _bgr(4, 4, 100))
+
+
+def test_white_mask_emits_overlay_unchanged() -> None:
+    node = MaskedBlend()
+    _wire(
+        node,
+        IoData.from_image(_bgr(4, 4, 100)),
+        IoData.from_image(_bgr(4, 4, 200)),
+        IoData.from_greyscale(_grey(4, 4, 255)),
+    )
+    out = node.outputs[0].last_emitted
+    assert out is not None
+    np.testing.assert_array_equal(out.image, _bgr(4, 4, 200))
+
+
+def test_half_mask_blends_50_50() -> None:
+    node = MaskedBlend()
+    _wire(
+        node,
+        IoData.from_image(_bgr(4, 4, 100)),
+        IoData.from_image(_bgr(4, 4, 200)),
+        IoData.from_greyscale(_grey(4, 4, 128)),
+    )
+    out = node.outputs[0].last_emitted
+    assert out is not None
+    # m = 128/255 ≈ 0.502; 100*(1-m) + 200*m ≈ 150 (±1 for rounding).
+    assert abs(int(out.image[0, 0, 0]) - 150) <= 1
+
+
+def test_per_pixel_mask_drives_per_pixel_blend() -> None:
+    """A mask with row 0 black and row 1 white must produce row 0 = base
+    and row 1 = overlay."""
+    node = MaskedBlend()
+    base = _bgr(2, 2, 50)
+    overlay = _bgr(2, 2, 250)
+    mask = np.array([[0, 0], [255, 255]], dtype=np.uint8)
+    _wire(
+        node,
+        IoData.from_image(base),
+        IoData.from_image(overlay),
+        IoData.from_greyscale(mask),
+    )
+    out = node.outputs[0].last_emitted
+    assert out is not None
+    np.testing.assert_array_equal(out.image[0], _bgr(1, 2, 50)[0])
+    np.testing.assert_array_equal(out.image[1], _bgr(1, 2, 250)[0])
+
+
+def test_mismatched_base_overlay_raises() -> None:
+    node = MaskedBlend()
+    with pytest.raises(ValueError, match="base shape"):
+        _wire(
+            node,
+            IoData.from_image(_bgr(4, 4, 0)),
+            IoData.from_image(_bgr(4, 5, 0)),
+            IoData.from_greyscale(_grey(4, 4, 128)),
+        )
+
+
+def test_mask_resized_to_base_when_shape_differs() -> None:
+    """A small mask must be resized to the base's H x W rather than
+    triggering a shape error — lets a small procedural gradient drive
+    a full-resolution stream."""
+    node = MaskedBlend()
+    base = _bgr(8, 8, 100)
+    overlay = _bgr(8, 8, 200)
+    # 4x4 mask, all white — after resize it stays all white.
+    mask = _grey(4, 4, 255)
+    _wire(
+        node,
+        IoData.from_image(base),
+        IoData.from_image(overlay),
+        IoData.from_greyscale(mask),
+    )
+    out = node.outputs[0].last_emitted
+    assert out is not None
+    np.testing.assert_array_equal(out.image, _bgr(8, 8, 200))
+
+
+def test_grey_base_and_overlay_stays_grey() -> None:
+    node = MaskedBlend()
+    _wire(
+        node,
+        IoData.from_greyscale(_grey(4, 4, 50)),
+        IoData.from_greyscale(_grey(4, 4, 200)),
+        IoData.from_greyscale(_grey(4, 4, 0)),
+    )
+    out = node.outputs[0].last_emitted
+    assert out is not None
+    assert out.type == IoDataType.IMAGE_GREY
+    assert out.image.shape == (4, 4)
+    np.testing.assert_array_equal(out.image, _grey(4, 4, 50))
+
+
+def test_mixed_types_promote_output_to_color() -> None:
+    node = MaskedBlend()
+    _wire(
+        node,
+        IoData.from_image(_bgr(4, 4, 0)),
+        IoData.from_greyscale(_grey(4, 4, 200)),
+        IoData.from_greyscale(_grey(4, 4, 255)),
+    )
+    out = node.outputs[0].last_emitted
+    assert out is not None
+    assert out.type == IoDataType.IMAGE
+    # Greyscale overlay 200 promoted to BGR (200, 200, 200).
+    np.testing.assert_array_equal(out.image, _bgr(4, 4, 200))
+
+
+def test_color_mask_uses_first_channel() -> None:
+    """ImageSource emits a BGR-promoted greyscale gradient as 3-channel
+    IMAGE. MaskedBlend reduces it to a single plane internally."""
+    node = MaskedBlend()
+    base = _bgr(4, 4, 0)
+    overlay = _bgr(4, 4, 255)
+    # 3-channel "mask" with B=255 in column 0, B=0 elsewhere — the
+    # first-channel reduction makes column 0 fully blend in the overlay.
+    mask = np.zeros((4, 4, 3), dtype=np.uint8)
+    mask[:, 0, 0] = 255
+    _wire(
+        node,
+        IoData.from_image(base),
+        IoData.from_image(overlay),
+        IoData.from_image(mask),
+    )
+    out = node.outputs[0].last_emitted
+    assert out is not None
+    np.testing.assert_array_equal(out.image[:, 0], _bgr(1, 4, 255)[0])
+    np.testing.assert_array_equal(out.image[:, 1:], _bgr(4, 3, 0))
+
+
+def test_bgra_base_alpha_is_dropped() -> None:
+    """An RGBA PNG fed into base must blend correctly without crashing
+    on the 4th channel — the alpha plane is stripped before the math."""
+    node = MaskedBlend()
+    base = np.zeros((4, 4, 4), dtype=np.uint8)
+    base[..., :3] = 100
+    base[..., 3] = 0  # would corrupt the math if not stripped
+    overlay = _bgr(4, 4, 200)
+    mask = _grey(4, 4, 255)
+    _wire(
+        node,
+        IoData.from_image(base),
+        IoData.from_image(overlay),
+        IoData.from_greyscale(mask),
+    )
+    out = node.outputs[0].last_emitted
+    assert out is not None
+    assert out.image.shape == (4, 4, 3)
+    np.testing.assert_array_equal(out.image, _bgr(4, 4, 200))
+
+
+def test_does_not_mutate_inputs() -> None:
+    node = MaskedBlend()
+    base = _bgr(4, 4, 50)
+    overlay = _bgr(4, 4, 200)
+    mask = _grey(4, 4, 128)
+    _wire(
+        node,
+        IoData.from_image(base),
+        IoData.from_image(overlay),
+        IoData.from_greyscale(mask),
+    )
+    np.testing.assert_array_equal(base, _bgr(4, 4, 50))
+    np.testing.assert_array_equal(overlay, _bgr(4, 4, 200))
+    np.testing.assert_array_equal(mask, _grey(4, 4, 128))


### PR DESCRIPTION
## Summary

This PR introduces two new compositing nodes and extends gradient functionality:

1. **GradientSource** — A new procedural source node that generates single-channel greyscale gradient images with configurable direction, symmetry mode, plateau width, and easing.
2. **MaskedBlend** — A new compositing filter that blends two images using a separate greyscale mask as the blend driver.
3. **Linear gradient mode** — Extends GradientSource with a `mode` parameter supporting both symmetric (centred double gradient) and linear (one-sided 0→255 ramp) variants.

## Key Changes

### GradientSource (`src/nodes/sources/gradient_source.py`)
- New `GradientDirection` enum: `VERTICAL`, `HORIZONTAL`, `RADIAL`
- New `GradientMode` enum: `SYMMETRIC` (default, mirrored around centre), `LINEAR` (one-sided)
- Configurable parameters:
  - `width`, `height` — output image dimensions
  - `direction` — axis along which gradient grows
  - `mode` — symmetry mode (SYMMETRIC is default for backward compatibility)
  - `band_width` — normalised plateau width where mask stays at 0 (clamped to [0, 1))
  - `smooth` — cosine-eased ramp (default) vs linear ramp
- Reactive node that updates live as parameters change
- RADIAL mode ignores `mode` parameter (always symmetric)
- Comprehensive test coverage (278 lines) validating all modes, directions, and edge cases

### MaskedBlend (`src/nodes/filters/masked_blend.py`)
- Blends two images per-pixel: `out = base * (1 - m) + overlay * m` where `m = mask / 255`
- Type promotion: greyscale inputs promoted to BGR if either base/overlay is colour
- Auto-resizes mask to base dimensions if shapes differ (enables small procedural gradients to mask full-resolution streams)
- Handles BGRA inputs by stripping alpha channel before blending
- Comprehensive test coverage (209 lines) validating blend math, type handling, and edge cases

### Example Flow
- Added `flow/video_tiltshift.flowjs` demonstrating tilt-shift effect using GradientSource (LINEAR mode with high band_width) to mask a blurred video stream

## Implementation Details

- **GradientSource** uses numpy for efficient vectorized gradient computation with optional cosine easing
- **MaskedBlend** uses float32 intermediate representation to avoid uint8 overflow during blending
- Both nodes follow the existing `NodeBase`/`SourceNodeBase` patterns with proper input/output port management
- Enums backed by `IntEnum` for clean JSON serialization in saved flows
- Setters accept both enum members and integer values for flexibility
- Version bumped to 0.2.18 with changelog entries

https://claude.ai/code/session_012q4JU1CXd2HkfvJiwyJf4p