### PR TITLE
feat: persist node-palette section expand/collapse state (#0190)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ once a first tagged release is cut.
 
 ## [Unreleased]
 
+## [0.2.20] — 2026-04-27
+
+### Added
+- **Node palette persists section expand/collapse state.** The expand/collapse
+  state of each section in the Node List palette (Sources, Sinks, …) is now
+  saved to `~/.image-inquest/node_list_state.json` on app close and restored
+  on the next launch. New sections default to expanded (matching first-run
+  behaviour); stale entries for removed sections are ignored. Search-driven
+  expansion is never persisted — only manual toggles and the expand-all /
+  collapse-all buttons update the saved state. Issue: #190
+
 ## [0.2.19] — 2026-04-27
 
 ### Added

--- a/doc/welcome.html
+++ b/doc/welcome.html
@@ -180,7 +180,7 @@
   <main class="content-col">
 
     <header class="hero">
-      <h1>Welcome to Stjörnhorn <span class="version">v0.2.19</span></h1>
+      <h1>Welcome to Stjörnhorn <span class="version">v0.2.20</span></h1>
       <div class="tagline">A node-based image- and video-processing playground.</div>
     </header>
 
@@ -210,6 +210,13 @@
           <p>Write frames to image files or encode video (MP4V, XVID) with live preview via the Display node.</p>
         </div>
       </div>
+    </section>
+
+    <section>
+      <h2>What's new in v0.2.20</h2>
+      <ul class="tips">
+        <li><strong>Node palette remembers collapsed sections.</strong> The expand/collapse state of each section in the Node List palette (Sources, Sinks, …) is now saved to <code>~/.image-inquest/node_list_state.json</code> when you close the app and restored on the next launch. New sections (e.g. from plugins) default to expanded. Search-driven expansion is never persisted — only manual toggles and the expand-all / collapse-all buttons update the saved state.</li>
+      </ul>
     </section>
 
     <section>

--- a/src/constants.py
+++ b/src/constants.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 APP_NAME:         str = "Image-Inquest"
 APP_DISPLAY_NAME: str = "Stjörnhorn"
-APP_VERSION:      str = "0.2.19"
+APP_VERSION:      str = "0.2.20"
 API_URL:    str = "https://beltoforion.de"
 
 # Path resolution -----------------------------------------------------------

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -160,6 +160,8 @@ class MainWindow(QMainWindow):
         # them. Defaults (Node List left, Inspector right) stay in place
         # if there's no saved layout. Issue: #183
         self._editor_page.restore_dock_layout()
+        # Re-apply palette section expand/collapse state. Issue: #190
+        self._editor_page.restore_node_list_state()
 
         # If a flow was supplied on the command line, jump straight into
         # the editor. Failure falls through to the start page (already
@@ -418,9 +420,10 @@ class MainWindow(QMainWindow):
     # ── Lifecycle ──────────────────────────────────────────────────────────────
 
     def closeEvent(self, event) -> None:  # type: ignore[override]
-        """Persist the editor's dock arrangement before the app exits.
+        """Persist editor state before the app exits.
 
-        Issue: #183
+        Issue: #183, #190
         """
         self._editor_page.save_dock_layout()
+        self._editor_page.save_node_list_state()
         super().closeEvent(event)

--- a/src/ui/node_editor_page.py
+++ b/src/ui/node_editor_page.py
@@ -33,6 +33,7 @@ from typing_extensions import override
 
 from ui.page import PageBase, ToolbarSection
 from ui.dock_layout import restore_dock_layout, save_dock_layout
+from ui.node_list_state import restore_node_list_state, save_node_list_state
 from ui.node_list import NodeList
 from ui.recent_flows import RecentFlowsManager
 from ui.message_banner import MessageBanner
@@ -302,6 +303,16 @@ class NodeEditorPage(PageBase):
     def save_dock_layout(self) -> None:
         """Persist the current dock arrangement so the next launch restores it."""
         save_dock_layout(self._inner)
+
+    # ── Node-list section-state persistence (Issue: #190) ─────────────────────
+
+    def restore_node_list_state(self) -> None:
+        """Apply the persisted palette section expand/collapse state, if any."""
+        restore_node_list_state(self._node_list)
+
+    def save_node_list_state(self) -> None:
+        """Persist the current palette section expand/collapse state."""
+        save_node_list_state(self._node_list)
 
     def _apply_layout_inspector_right(self) -> None:
         """Inspector full-height on the right, Node List full-height on the left.

--- a/src/ui/node_list.py
+++ b/src/ui/node_list.py
@@ -57,6 +57,12 @@ class NodeList(QWidget):
     def __init__(self, registry: NodeRegistry, parent: QWidget | None = None) -> None:
         super().__init__(parent)
 
+        # In-memory map of section_name → expanded. Updated on every
+        # user-initiated toggle; search-driven expansions are excluded.
+        # Issue: #190
+        self._section_states: dict[str, bool] = {}
+        self._search_active: bool = False
+
         layout = QVBoxLayout(self)
         layout.setContentsMargins(4, 4, 4, 4)
         layout.setSpacing(4)
@@ -92,7 +98,12 @@ class NodeList(QWidget):
         layout.addWidget(self._tree, 1)
 
         self._populate(registry)
+        # Connect expand/collapse tracking AFTER the initial expandAll so
+        # the programmatic expansion doesn't populate _section_states —
+        # restore_section_states() will fill it from disk on the next call.
         self._tree.expandAll()
+        self._tree.itemExpanded.connect(self._on_item_expanded)
+        self._tree.itemCollapsed.connect(self._on_item_collapsed)
 
     # ── Internals ──────────────────────────────────────────────────────────────
 
@@ -122,6 +133,8 @@ class NodeList(QWidget):
             # row (not just the disclosure triangle) to toggle expansion.
             header.setFlags(Qt.ItemFlag.ItemIsEnabled)
             header.setData(0, Qt.ItemDataRole.UserRole, None)
+            # Store the raw section name for state persistence (Issue: #190).
+            header.setData(0, Qt.ItemDataRole.UserRole + 1, section)
             self._tree.addTopLevelItem(header)
 
             if not entries:
@@ -146,6 +159,19 @@ class NodeList(QWidget):
 
     def _on_search(self, text: str) -> None:
         query = text.strip().lower()
+        if not query:
+            # Restore all items to visible and re-apply the user's saved
+            # expand/collapse state (search may have temporarily changed it).
+            for i in range(self._tree.topLevelItemCount()):
+                section = self._tree.topLevelItem(i)
+                section.setHidden(False)
+                for j in range(section.childCount()):
+                    section.child(j).setHidden(False)
+            self._search_active = False
+            self._apply_section_states()
+            return
+
+        self._search_active = True
         for i in range(self._tree.topLevelItemCount()):
             section = self._tree.topLevelItem(i)
             any_visible = False
@@ -153,25 +179,70 @@ class NodeList(QWidget):
                 child = section.child(j)
                 payload = child.data(0, Qt.ItemDataRole.UserRole)
                 if payload is None:
-                    # Placeholder "(none)" row — hide it during a search
-                    # so empty sections don't get a misleading match.
-                    child.setHidden(bool(query))
+                    # Placeholder "(none)" row — hide during a search.
+                    child.setHidden(True)
                     continue
-                matches = (not query) or (query in child.text(0).lower())
+                matches = query in child.text(0).lower()
                 child.setHidden(not matches)
                 any_visible = any_visible or matches
             # Section headers stay visible (context matters), but expand
             # automatically while a search is active so matches are not
             # hidden behind a collapsed group.
             section.setHidden(False)
-            if query:
-                section.setExpanded(any_visible)
+            section.setExpanded(any_visible)
 
     def _expand_all(self) -> None:
+        # Clear the search-active guard so signals record the new state.
+        prev = self._search_active
+        self._search_active = False
         self._tree.expandAll()
+        self._search_active = prev
 
     def _collapse_all(self) -> None:
+        prev = self._search_active
+        self._search_active = False
         self._tree.collapseAll()
+        self._search_active = prev
+
+    # ── Section-state persistence (Issue: #190) ────────────────────────────────
+
+    def _on_item_expanded(self, item: QTreeWidgetItem) -> None:
+        if self._search_active:
+            return
+        name = item.data(0, Qt.ItemDataRole.UserRole + 1)
+        if name is not None:
+            self._section_states[name] = True
+
+    def _on_item_collapsed(self, item: QTreeWidgetItem) -> None:
+        if self._search_active:
+            return
+        name = item.data(0, Qt.ItemDataRole.UserRole + 1)
+        if name is not None:
+            self._section_states[name] = False
+
+    def _apply_section_states(self) -> None:
+        """Expand/collapse each section according to ``_section_states``."""
+        for i in range(self._tree.topLevelItemCount()):
+            item = self._tree.topLevelItem(i)
+            name = item.data(0, Qt.ItemDataRole.UserRole + 1)
+            if name is not None:
+                item.setExpanded(self._section_states.get(name, True))
+
+    def get_section_states(self) -> dict[str, bool]:
+        """Return a snapshot of the current section expand/collapse state."""
+        return dict(self._section_states)
+
+    def restore_section_states(self, state: dict) -> None:
+        """Apply *state* (section_name → expanded?) to the palette.
+
+        Keys not present in the tree are ignored (stale entries from a
+        removed section). Sections absent from *state* default to expanded
+        (first-run behaviour). Safe to call on an empty tree.
+        """
+        for key, val in state.items():
+            if isinstance(key, str) and isinstance(val, bool):
+                self._section_states[key] = val
+        self._apply_section_states()
 
 
 class _DraggableTree(QTreeWidget):

--- a/src/ui/node_list_state.py
+++ b/src/ui/node_list_state.py
@@ -1,0 +1,58 @@
+"""Persist and restore the node-palette section expand/collapse state.
+
+Stores a small ``{section_name: expanded}`` map as a human-readable JSON
+file under :data:`USER_CONFIG_DIR`, mirroring the ``recent_flows.json``
+pattern already in use.  Each call to :func:`restore_node_list_state` is
+a no-op when the file is absent or unreadable so first-run behaviour
+(all sections expanded) is preserved automatically.
+
+Issue: #190
+"""
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from constants import USER_CONFIG_DIR
+
+if TYPE_CHECKING:
+    from ui.node_list import NodeList
+
+logger = logging.getLogger(__name__)
+
+#: JSON file holding the persisted palette section state.  Sits next to
+#: ``dock_layout.json`` so all editor-window persistence shares one directory.
+NODE_LIST_STATE_FILE: Path = USER_CONFIG_DIR / "node_list_state.json"
+
+
+def save_node_list_state(node_list: NodeList, path: Path = NODE_LIST_STATE_FILE) -> None:
+    """Write the section expand/collapse state of *node_list* to *path*."""
+    state = node_list.get_section_states()
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(state, indent=2), encoding="utf-8")
+    except OSError:
+        logger.exception("Failed to save node list state to %s", path)
+
+
+def restore_node_list_state(node_list: NodeList, path: Path = NODE_LIST_STATE_FILE) -> bool:
+    """Apply a previously saved section state to *node_list*.
+
+    Returns ``True`` on success.  Missing, corrupt, or wrongly-typed files
+    are silently ignored and the current expand/collapse state is left
+    unchanged (defaults: all sections expanded).
+    """
+    if not path.exists():
+        return False
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        logger.exception("Failed to read node list state from %s", path)
+        return False
+    if not isinstance(raw, dict):
+        logger.info("Ignoring %s: unexpected format", path)
+        return False
+    node_list.restore_section_states(raw)
+    return True


### PR DESCRIPTION
Implements node palette section state persistence across sessions as described in issue #190.

Adds a small `{section_name: bool}` map saved to `~/.image-inquest/node_list_state.json` on app close and restored on the next launch.

Closes #190

Generated with [Claude Code](https://claude.ai/code)