### PR TITLE
feat: generic PageBase state API + node-palette section persistence (#190)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,24 @@ once a first tagged release is cut.
 
 ## [Unreleased]
 
+## [0.2.20] — 2026-04-27
+
+### Added
+- **Node-palette section state persists across sessions.** The
+  expand/collapse state of every section in the node palette (Sources,
+  Sinks, …) is saved to `~/.image-inquest/node_list_state.json` on app
+  close and restored on the next launch. Search-driven expansion is not
+  persisted — only manual toggles and the expand-all / collapse-all
+  buttons are remembered. New sections default to expanded; stale keys
+  for removed sections are silently ignored. Issue #190.
+- **Generic per-page state persistence API in `PageBase`.** `PageBase`
+  gains `save_state()` / `restore_state()` lifecycle hooks (concrete
+  no-ops by default) so any page can opt into persistence without
+  modifying `MainWindow`. `NodeEditorPage` overrides both to cover dock
+  layout (issue #183) and palette section state (issue #190) in one
+  call. `MainWindow.closeEvent` and `__init__` now loop over all pages
+  rather than hardcoding the editor page.
+
 ## [0.2.19] — 2026-04-27
 
 ### Added

--- a/doc/welcome.html
+++ b/doc/welcome.html
@@ -180,7 +180,7 @@
   <main class="content-col">
 
     <header class="hero">
-      <h1>Welcome to Stjörnhorn <span class="version">v0.2.19</span></h1>
+      <h1>Welcome to Stjörnhorn <span class="version">v0.2.20</span></h1>
       <div class="tagline">A node-based image- and video-processing playground.</div>
     </header>
 
@@ -210,6 +210,14 @@
           <p>Write frames to image files or encode video (MP4V, XVID) with live preview via the Display node.</p>
         </div>
       </div>
+    </section>
+
+    <section>
+      <h2>What's new in v0.2.20</h2>
+      <ul class="tips">
+        <li><strong>Node-palette section state persists across sessions.</strong> The expand/collapse state of every section in the node palette (Sources, Sinks, …) is now saved to <code>~/.image-inquest/node_list_state.json</code> when you close the app and restored on the next launch. Search-driven expansion is not persisted — only manual toggles and the expand-all / collapse-all buttons are remembered. New sections default to expanded; removed sections are silently ignored. Issue #190.</li>
+        <li><strong>Generic per-page state persistence API.</strong> <code>PageBase</code> now exposes <code>save_state()</code> / <code>restore_state()</code> lifecycle hooks (no-op by default) so any future page can persist its own UI state without touching <code>MainWindow</code>. <code>NodeEditorPage</code> implements both to cover dock layout (issue #183) and palette section state (issue #190) in one call.</li>
+      </ul>
     </section>
 
     <section>

--- a/src/constants.py
+++ b/src/constants.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 APP_NAME:         str = "Image-Inquest"
 APP_DISPLAY_NAME: str = "Stjörnhorn"
-APP_VERSION:      str = "0.2.19"
+APP_VERSION:      str = "0.2.20"
 API_URL:    str = "https://beltoforion.de"
 
 # Path resolution -----------------------------------------------------------

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -155,11 +155,11 @@ class MainWindow(QMainWindow):
 
         self._activate_page(self._start_page)
 
-        # Re-apply any previously persisted dock arrangement so the
-        # Output Inspector / Node List come up where the user last left
-        # them. Defaults (Node List left, Inspector right) stay in place
-        # if there's no saved layout. Issue: #183
-        self._editor_page.restore_dock_layout()
+        # Re-apply any previously persisted per-page UI state (dock layout,
+        # node-palette section state, …). Each page's restore_state() is a
+        # no-op by default; overriding pages handle their own concerns.
+        for page in self._pages_list:
+            page.restore_state()
 
         # If a flow was supplied on the command line, jump straight into
         # the editor. Failure falls through to the start page (already
@@ -418,9 +418,7 @@ class MainWindow(QMainWindow):
     # ── Lifecycle ──────────────────────────────────────────────────────────────
 
     def closeEvent(self, event) -> None:  # type: ignore[override]
-        """Persist the editor's dock arrangement before the app exits.
-
-        Issue: #183
-        """
-        self._editor_page.save_dock_layout()
+        """Persist per-page UI state before the app exits."""
+        for page in self._pages_list:
+            page.save_state()
         super().closeEvent(event)

--- a/src/ui/node_editor_page.py
+++ b/src/ui/node_editor_page.py
@@ -34,6 +34,7 @@ from typing_extensions import override
 from ui.page import PageBase, ToolbarSection
 from ui.dock_layout import restore_dock_layout, save_dock_layout
 from ui.node_list import NodeList
+from ui.node_list_state import restore_node_list_state, save_node_list_state
 from ui.recent_flows import RecentFlowsManager
 from ui.message_banner import MessageBanner
 from ui.flow_status_widget import FlowStatusWidget
@@ -289,19 +290,27 @@ class NodeEditorPage(PageBase):
         self.title_changed.emit(self.page_title())
         self._viewer.refresh()
 
-    # ── Dock-layout persistence ────────────────────────────────────────────────
+    # ── Page state persistence (PageBase lifecycle) ────────────────────────────
 
-    def restore_dock_layout(self) -> None:
-        """Apply the persisted dock arrangement, if any. Issue: #183
+    @override
+    def restore_state(self) -> None:
+        """Re-apply persisted dock layout and node-palette section state.
 
-        No-op when no layout file exists or the file can't be applied —
-        the constructor already installed the right-hand-default layout.
+        Issue: #183 (dock layout), #190 (section expand/collapse)
         """
         restore_dock_layout(self._inner)
+        states = restore_node_list_state()
+        if states is not None:
+            self._node_list.restore_section_states(states)
 
-    def save_dock_layout(self) -> None:
-        """Persist the current dock arrangement so the next launch restores it."""
+    @override
+    def save_state(self) -> None:
+        """Persist dock layout and node-palette section expand/collapse state.
+
+        Issue: #183 (dock layout), #190 (section expand/collapse)
+        """
         save_dock_layout(self._inner)
+        save_node_list_state(self._node_list.get_section_states())
 
     def _apply_layout_inspector_right(self) -> None:
         """Inspector full-height on the right, Node List full-height on the left.

--- a/src/ui/node_list.py
+++ b/src/ui/node_list.py
@@ -52,10 +52,25 @@ class NodeList(QWidget):
     :data:`NODE_LIST_MIME_TYPE` MIME type carrying a JSON descriptor of
     the node (module, class_name, display_name, category, section). The
     flow canvas reads that payload on drop and instantiates the node.
+
+    Section expand/collapse state is tracked in-memory in
+    :attr:`_section_states` and can be persisted / restored by the
+    owning page via :meth:`get_section_states` /
+    :meth:`restore_section_states`. Search-driven temporary expansion is
+    not written into :attr:`_section_states`; only explicit user toggles
+    (and the expand-all / collapse-all buttons) count. Issue: #190
     """
 
     def __init__(self, registry: NodeRegistry, parent: QWidget | None = None) -> None:
         super().__init__(parent)
+
+        # In-memory truth for per-section expanded state. Updated by
+        # itemExpanded / itemCollapsed signals (but not while a search is
+        # active) and by the expand-all / collapse-all buttons.
+        self._section_states: dict[str, bool] = {}
+        # Guard flag: True while a search is active so signal-driven
+        # expand/collapse changes don't overwrite the user's saved state.
+        self._search_active: bool = False
 
         layout = QVBoxLayout(self)
         layout.setContentsMargins(4, 4, 4, 4)
@@ -94,7 +109,51 @@ class NodeList(QWidget):
         self._populate(registry)
         self._tree.expandAll()
 
+        # Seed _section_states from the just-expanded tree so the in-memory
+        # state is consistent before restore_section_states is called.
+        for i in range(self._tree.topLevelItemCount()):
+            item = self._tree.topLevelItem(i)
+            self._section_states[item.text(0)] = True
+
+        # Wire expand/collapse signals. Connected after populate + expandAll
+        # so the initial bulk-expand doesn't touch _section_states.
+        self._tree.itemExpanded.connect(self._on_item_expanded)
+        self._tree.itemCollapsed.connect(self._on_item_collapsed)
+
+    # ── Public state API (called by the owning page) ───────────────────────────
+
+    def get_section_states(self) -> dict[str, bool]:
+        """Return a shallow copy of the current per-section expanded map."""
+        return dict(self._section_states)
+
+    def restore_section_states(self, states: dict[str, bool]) -> None:
+        """Apply *states* to the tree, defaulting new sections to expanded.
+
+        Stale keys (sections that no longer exist) are ignored. Safe to
+        call on an empty tree.
+        """
+        for i in range(self._tree.topLevelItemCount()):
+            item = self._tree.topLevelItem(i)
+            key = item.text(0)
+            expanded = states.get(key, True)  # default: expanded
+            self._section_states[key] = expanded
+        self._apply_section_states()
+
     # ── Internals ──────────────────────────────────────────────────────────────
+
+    def _apply_section_states(self) -> None:
+        """Expand/collapse each section header to match :attr:`_section_states`."""
+        for i in range(self._tree.topLevelItemCount()):
+            item = self._tree.topLevelItem(i)
+            item.setExpanded(self._section_states.get(item.text(0), True))
+
+    def _on_item_expanded(self, item: QTreeWidgetItem) -> None:
+        if not self._search_active and self._tree.indexOfTopLevelItem(item) != -1:
+            self._section_states[item.text(0)] = True
+
+    def _on_item_collapsed(self, item: QTreeWidgetItem) -> None:
+        if not self._search_active and self._tree.indexOfTopLevelItem(item) != -1:
+            self._section_states[item.text(0)] = False
 
     def _populate(self, registry: NodeRegistry) -> None:
         grouped = registry.nodes_by_section()
@@ -146,6 +205,7 @@ class NodeList(QWidget):
 
     def _on_search(self, text: str) -> None:
         query = text.strip().lower()
+        self._search_active = bool(query)
         for i in range(self._tree.topLevelItemCount()):
             section = self._tree.topLevelItem(i)
             any_visible = False
@@ -162,15 +222,22 @@ class NodeList(QWidget):
                 any_visible = any_visible or matches
             # Section headers stay visible (context matters), but expand
             # automatically while a search is active so matches are not
-            # hidden behind a collapsed group.
+            # hidden behind a collapsed group. When search clears, snap
+            # back to the user's saved state.
             section.setHidden(False)
             if query:
                 section.setExpanded(any_visible)
+        if not query:
+            self._apply_section_states()
 
     def _expand_all(self) -> None:
+        for key in self._section_states:
+            self._section_states[key] = True
         self._tree.expandAll()
 
     def _collapse_all(self) -> None:
+        for key in self._section_states:
+            self._section_states[key] = False
         self._tree.collapseAll()
 
 

--- a/src/ui/node_list_state.py
+++ b/src/ui/node_list_state.py
@@ -1,0 +1,64 @@
+"""Persist and restore the node-palette section expand/collapse state.
+
+Saves a small ``{section_name: expanded}`` map to a JSON file under
+:data:`~constants.USER_CONFIG_DIR`. The file is human-readable for
+debugging and versioned so future shape changes can invalidate stale
+entries cleanly. Corrupt or missing files fall back to the default
+(all sections expanded).
+
+Issue: #190
+"""
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+from constants import USER_CONFIG_DIR
+
+logger = logging.getLogger(__name__)
+
+NODE_LIST_STATE_FILE: Path = USER_CONFIG_DIR / "node_list_state.json"
+
+_STATE_VERSION: int = 1
+
+
+def save_node_list_state(
+    states: dict[str, bool],
+    path: Path = NODE_LIST_STATE_FILE,
+) -> None:
+    """Write the section expand/collapse map *states* to *path*."""
+    payload = {"version": _STATE_VERSION, "sections": states}
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    except OSError:
+        logger.exception("Failed to save node-list state to %s", path)
+
+
+def restore_node_list_state(
+    path: Path = NODE_LIST_STATE_FILE,
+) -> dict[str, bool] | None:
+    """Load the section expand/collapse map from *path*.
+
+    Returns ``None`` on any failure (missing file, version mismatch,
+    corrupt JSON) so the caller can keep its defaults.
+    """
+    if not path.exists():
+        return None
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        logger.exception("Failed to read node-list state from %s", path)
+        return None
+    if not isinstance(data, dict) or data.get("version") != _STATE_VERSION:
+        logger.info(
+            "Ignoring %s: unsupported version %r",
+            path,
+            data.get("version") if isinstance(data, dict) else None,
+        )
+        return None
+    sections = data.get("sections")
+    if not isinstance(sections, dict):
+        return None
+    return {k: bool(v) for k, v in sections.items() if isinstance(k, str)}

--- a/src/ui/page.py
+++ b/src/ui/page.py
@@ -123,3 +123,19 @@ class PageBase(QWidget):
 
     def on_deactivated(self) -> None:
         """Called by MainWindow just before another page becomes visible."""
+
+    def save_state(self) -> None:
+        """Persist any page-specific UI state to disk.
+
+        Called by MainWindow on app close. Default is a no-op; override
+        to persist dock layouts, panel expand/collapse state, scroll
+        positions, or any other per-page UI configuration.
+        """
+
+    def restore_state(self) -> None:
+        """Re-apply previously persisted UI state.
+
+        Called by MainWindow on startup. Default is a no-op; override
+        alongside :meth:`save_state` to restore whatever that method
+        wrote.
+        """


### PR DESCRIPTION
Implements a generic `save_state()` / `restore_state()` API on `PageBase` so any page can persist UI state without touching `MainWindow`.

Also implements node-palette section expand/collapse persistence as the first consumer of the new API.

Closes #190

Generated with [Claude Code](https://claude.ai/code)