### PR TITLE
Filter documentation sweep: description + bounds + units on 18 nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,38 @@ once a first tagged release is cut.
 
 ## [Unreleased]
 
+## [0.2.22] — 2026-04-27
+
+### Changed
+- **Filter documentation sweep.** Every parameter on the eighteen
+  filter nodes that were still undocumented after v0.2.20 now ships
+  with a ``"description"`` metadata key, and where it makes sense
+  also a numeric ``min`` / ``max`` bound and a ``unit`` suffix.
+  Affected nodes:
+  ``AdaptiveGaussianThreshold``, ``ApplyColormap``, ``Clamp``,
+  ``Crop``, ``DebugParam``, ``Delay``, ``Dither``, ``Flip``,
+  ``Math``, ``Median``, ``Ncc``, ``Notify``, ``Overlay``,
+  ``Scale``, ``Shift``, ``SubpixelMosaic``, ``TemporalMean``,
+  ``TemporalMedian``.
+
+  Visible effects:
+  - Hovering an inline parameter widget on these nodes now shows
+    the description as a tooltip (introduced in v0.2.20).
+  - The Node Documentation panel (v0.2.21) renders the full
+    descriptions, ranges and units in its Inputs and Parameters
+    sections.
+  - Numeric param widgets that gained a ``min`` / ``max`` now
+    constrain the spin-box range instead of accepting and then
+    rejecting out-of-range values at run time. The bounds match
+    what the existing setters already enforced — e.g.
+    ``Median.size >= 1``, ``Crop.width >= 1`` — so no saved flow
+    stops working; the change is purely a friendlier edit
+    surface.
+
+  Lint progress: ``test_param_ports_have_description`` flips from
+  18 ``XFAIL`` cases to 18 ``XPASS``; the six remaining ``XFAIL``s
+  are all sources / sinks and are scoped for a follow-up sweep PR.
+
 ## [0.2.21] — 2026-04-27
 
 ### Added

--- a/doc/welcome.html
+++ b/doc/welcome.html
@@ -180,7 +180,7 @@
   <main class="content-col">
 
     <header class="hero">
-      <h1>Welcome to Stjörnhorn <span class="version">v0.2.21</span></h1>
+      <h1>Welcome to Stjörnhorn <span class="version">v0.2.22</span></h1>
       <div class="tagline">A node-based image- and video-processing playground.</div>
     </header>
 
@@ -210,6 +210,13 @@
           <p>Write frames to image files or encode video (MP4V, XVID) with live preview via the Display node.</p>
         </div>
       </div>
+    </section>
+
+    <section>
+      <h2>What's new in v0.2.22</h2>
+      <ul class="tips">
+        <li><strong>Filter documentation sweep.</strong> Every parameter on the eighteen filter nodes that were still undocumented after v0.2.20 (Adaptive Gaussian Threshold, Apply Colormap, Clamp, Crop, Debug Params, Delay, Dither, Flip, Math, Median, NCC, Notify, Overlay, Scale, Shift, Subpixel Mosaic, Temporal Mean, Temporal Median) now ships with a hover-tooltip description, and where applicable a min / max bound and a unit suffix (px, deg, %, s, frames). The Node Documentation panel and the per-widget hover tooltips both pick up the new content automatically. Lint progress: 24 → 6 XFAIL remaining (sources / sinks).</li>
+      </ul>
     </section>
 
     <section>

--- a/src/constants.py
+++ b/src/constants.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 APP_NAME:         str = "Image-Inquest"
 APP_DISPLAY_NAME: str = "Stjörnhorn"
-APP_VERSION:      str = "0.2.21"
+APP_VERSION:      str = "0.2.22"
 API_URL:    str = "https://beltoforion.de"
 
 # Path resolution -----------------------------------------------------------

--- a/src/nodes/filters/adaptive_gaussian_threshold.py
+++ b/src/nodes/filters/adaptive_gaussian_threshold.py
@@ -34,14 +34,32 @@ class AdaptiveGaussianThreshold(NodeBase):
             {IoDataType.SCALAR},
             optional=True,
             default_value=101,
-            metadata={"default": 101, "param_type": NodeParamType.INT},
+            metadata={
+                "default": 101,
+                "param_type": NodeParamType.INT,
+                "min": 3,
+                "unit": "px",
+                "description": (
+                    "Side length of the neighbourhood used to compute the "
+                    "local threshold. Must be odd and >= 3; even values "
+                    "are bumped up to the next odd integer."
+                ),
+            },
         ))
         self._add_input(InputPort(
             "c",
             {IoDataType.SCALAR},
             optional=True,
             default_value=-32,
-            metadata={"default": -32, "param_type": NodeParamType.INT},
+            metadata={
+                "default": -32,
+                "param_type": NodeParamType.INT,
+                "description": (
+                    "Constant subtracted from the local weighted mean. "
+                    "Negative values bias toward classifying pixels as "
+                    "white; positive values bias toward black."
+                ),
+            },
         ))
         self._add_output(OutputPort("image", {IoDataType.IMAGE_GREY}))
 

--- a/src/nodes/filters/apply_colormap.py
+++ b/src/nodes/filters/apply_colormap.py
@@ -73,7 +73,15 @@ class ApplyColormap(NodeBase):
             "colormap",
             NodeParamType.ENUM,
             default=Colormap.VIRIDIS,
-            metadata={"enum": Colormap},
+            metadata={
+                "enum": Colormap,
+                "description": (
+                    "Lookup table used to colorize the greyscale input. "
+                    "VIRIDIS / PLASMA / MAGMA / INFERNO are perceptually "
+                    "uniform; JET and TURBO are the classic spectrogram "
+                    "/ FFT-magnitude palettes."
+                ),
+            },
         ))
         self._add_output(OutputPort("image", {IoDataType.IMAGE}))
 

--- a/src/nodes/filters/clamp.py
+++ b/src/nodes/filters/clamp.py
@@ -33,14 +33,28 @@ class Clamp(NodeBase):
             {IoDataType.SCALAR},
             optional=True,
             default_value=0.0,
-            metadata={"default": 0.0, "param_type": NodeParamType.FLOAT},
+            metadata={
+                "default": 0.0,
+                "param_type": NodeParamType.FLOAT,
+                "description": (
+                    "Lower bound. Values below this are clipped up to it."
+                ),
+            },
         ))
         self._add_input(InputPort(
             "max_value",
             {IoDataType.SCALAR},
             optional=True,
             default_value=1.0,
-            metadata={"default": 1.0, "param_type": NodeParamType.FLOAT},
+            metadata={
+                "default": 1.0,
+                "param_type": NodeParamType.FLOAT,
+                "description": (
+                    "Upper bound. Values above this are clipped down to it. "
+                    "If the upper bound ends up below the lower bound the "
+                    "two are swapped so the range is always usable."
+                ),
+            },
         ))
         self._add_output(OutputPort("value", {IoDataType.SCALAR}))
 

--- a/src/nodes/filters/crop.py
+++ b/src/nodes/filters/crop.py
@@ -30,28 +30,55 @@ class Crop(NodeBase):
             {IoDataType.SCALAR},
             optional=True,
             default_value=0,
-            metadata={"default": 0, "param_type": NodeParamType.INT},
+            metadata={
+                "default": 0,
+                "param_type": NodeParamType.INT,
+                "min": 0,
+                "unit": "px",
+                "description": "Left edge of the ROI in input-pixel coordinates.",
+            },
         ))
         self._add_input(InputPort(
             "y",
             {IoDataType.SCALAR},
             optional=True,
             default_value=0,
-            metadata={"default": 0, "param_type": NodeParamType.INT},
+            metadata={
+                "default": 0,
+                "param_type": NodeParamType.INT,
+                "min": 0,
+                "unit": "px",
+                "description": "Top edge of the ROI in input-pixel coordinates.",
+            },
         ))
         self._add_input(InputPort(
             "width",
             {IoDataType.SCALAR},
             optional=True,
             default_value=100,
-            metadata={"default": 100, "param_type": NodeParamType.INT},
+            metadata={
+                "default": 100,
+                "param_type": NodeParamType.INT,
+                "min": 1,
+                "unit": "px",
+                "description": (
+                    "ROI width in pixels. Clamped to the input bounds, so "
+                    "the node always emits a positive-area image."
+                ),
+            },
         ))
         self._add_input(InputPort(
             "height",
             {IoDataType.SCALAR},
             optional=True,
             default_value=100,
-            metadata={"default": 100, "param_type": NodeParamType.INT},
+            metadata={
+                "default": 100,
+                "param_type": NodeParamType.INT,
+                "min": 1,
+                "unit": "px",
+                "description": "ROI height in pixels. Same clamping as width.",
+            },
         ))
         self._add_output(OutputPort("image", set(IMAGE_TYPES)))
 

--- a/src/nodes/filters/debug_param.py
+++ b/src/nodes/filters/debug_param.py
@@ -49,6 +49,7 @@ class DebugParam(NodeBase):
                 "filter": "All files (*)",
                 "base_dir": INPUT_DIR,
                 "param_type": NodeParamType.FILE_PATH,
+                "description": "Demo FILE_PATH parameter — exercises the path widget.",
             },
         ))
         self._add_input(InputPort(
@@ -56,35 +57,57 @@ class DebugParam(NodeBase):
             {IoDataType.SCALAR},
             optional=True,
             default_value=0,
-            metadata={"default": 0, "param_type": NodeParamType.INT},
+            metadata={
+                "default": 0,
+                "param_type": NodeParamType.INT,
+                "description": "Demo INT parameter — exercises the int spinbox widget.",
+            },
         ))
         self._add_input(InputPort(
             "factor",
             {IoDataType.SCALAR},
             optional=True,
             default_value=1.0,
-            metadata={"default": 1.0, "param_type": NodeParamType.FLOAT},
+            metadata={
+                "default": 1.0,
+                "param_type": NodeParamType.FLOAT,
+                "description": "Demo FLOAT parameter — exercises the float spinbox widget.",
+            },
         ))
         self._add_input(InputPort(
             "label",
             {IoDataType.STRING},
             optional=True,
             default_value="",
-            metadata={"default": "", "placeholder": "text…", "param_type": NodeParamType.STRING},
+            metadata={
+                "default": "",
+                "placeholder": "text…",
+                "param_type": NodeParamType.STRING,
+                "description": "Demo STRING parameter — exercises the line-edit widget.",
+            },
         ))
         self._add_input(InputPort(
             "enabled",
             {IoDataType.BOOL},
             optional=True,
             default_value=False,
-            metadata={"default": False, "param_type": NodeParamType.BOOL},
+            metadata={
+                "default": False,
+                "param_type": NodeParamType.BOOL,
+                "description": "Demo BOOL parameter — exercises the checkbox widget.",
+            },
         ))
         self._add_input(InputPort(
             "mode",
             {IoDataType.ENUM},
             optional=True,
             default_value=DebugMode.ALPHA,
-            metadata={"default": DebugMode.ALPHA, "enum": DebugMode, "param_type": NodeParamType.ENUM},
+            metadata={
+                "default": DebugMode.ALPHA,
+                "enum": DebugMode,
+                "param_type": NodeParamType.ENUM,
+                "description": "Demo ENUM parameter — exercises the combo-box widget.",
+            },
         ))
         self._add_output(OutputPort("image", set(IMAGE_TYPES)))
 

--- a/src/nodes/filters/delay.py
+++ b/src/nodes/filters/delay.py
@@ -29,7 +29,16 @@ class Delay(NodeBase):
             {IoDataType.SCALAR},
             optional=True,
             default_value=5.0,
-            metadata={"default": 5.0, "param_type": NodeParamType.FLOAT},
+            metadata={
+                "default": 5.0,
+                "param_type": NodeParamType.FLOAT,
+                "min": 0.0,
+                "unit": "s",
+                "description": (
+                    "How long to sleep between frames, in seconds. "
+                    "Set to 0 to disable the pacing entirely."
+                ),
+            },
         ))
         self._add_output(OutputPort("image", set(IMAGE_TYPES)))
 

--- a/src/nodes/filters/dither.py
+++ b/src/nodes/filters/dither.py
@@ -125,6 +125,14 @@ class Dither(NodeBase):
                 "default": DitherMethod.STUCKI,
                 "enum": DitherMethod,
                 "param_type": NodeParamType.ENUM,
+                "description": (
+                    "Dithering algorithm. BAYER2 / 4 / 8 are ordered-dither "
+                    "matrices (cheap, regular pattern). NOISE is white-noise "
+                    "thresholding. FLOYD_STEINBERG, STUCKI, ATKINSON, BURKES, "
+                    "SIERRA distribute quantisation error to neighbouring "
+                    "pixels for finer detail. DIFFUSION_X / _XY are minimal "
+                    "1- or 2-cell diffusion variants."
+                ),
             },
         ))
         self._add_output(OutputPort("image", set(IMAGE_TYPES)))

--- a/src/nodes/filters/flip.py
+++ b/src/nodes/filters/flip.py
@@ -41,6 +41,10 @@ class Flip(NodeBase):
                 "default": FlipMode.HORIZONTAL,
                 "enum": FlipMode,
                 "param_type": NodeParamType.ENUM,
+                "description": (
+                    "Flip direction. HORIZONTAL mirrors left/right, "
+                    "VERTICAL mirrors top/bottom, BOTH does a 180° rotation."
+                ),
             },
         ))
         self._add_output(OutputPort("image", set(IMAGE_TYPES)))

--- a/src/nodes/filters/math.py
+++ b/src/nodes/filters/math.py
@@ -161,13 +161,31 @@ class Math(NodeBase):
                 {IoDataType.SCALAR},
                 optional=True,
                 default_value=default,
-                metadata={"default": default, "param_type": NodeParamType.FLOAT},
+                metadata={
+                    "default": default,
+                    "param_type": NodeParamType.FLOAT,
+                    "description": (
+                        f"Operand {name!r} in the expression. Unconnected "
+                        "ports use the inline-edited default."
+                    ),
+                },
             ))
 
         self._add_param(NodeParam(
             "expression",
             NodeParamType.STRING,
             default="a",
+            metadata={
+                "description": (
+                    "Arithmetic expression in the variables a, b, c, d "
+                    "plus the helpers sin / cos / tan / asin / acos / "
+                    "atan / atan2 / sinh / cosh / tanh / sqrt / exp / "
+                    "log / log2 / log10 / abs / floor / ceil / round / "
+                    "min / max / deg / rad and the constants pi and e. "
+                    "Examples: 'a + b', 'a * b + c * d', "
+                    "'sin(a * pi/180) * b', 'a if b > 0 else c'."
+                ),
+            },
         ))
 
         self._add_output(OutputPort("result", {IoDataType.SCALAR}))

--- a/src/nodes/filters/median.py
+++ b/src/nodes/filters/median.py
@@ -33,7 +33,18 @@ class Median(NodeBase):
             {IoDataType.SCALAR},
             optional=True,
             default_value=3,
-            metadata={"default": 3, "param_type": NodeParamType.INT},
+            metadata={
+                "default": 3,
+                "param_type": NodeParamType.INT,
+                "min": 1,
+                "unit": "px",
+                "description": (
+                    "Kernel side length in pixels. Must be odd; even "
+                    "values are bumped up to the next odd integer. "
+                    "Larger kernels remove more noise at the cost of "
+                    "fine detail."
+                ),
+            },
         ))
         self._add_output(OutputPort("image", set(IMAGE_TYPES)))
 

--- a/src/nodes/filters/ncc.py
+++ b/src/nodes/filters/ncc.py
@@ -45,14 +45,35 @@ class Ncc(NodeBase):
             {IoDataType.PATH},
             optional=True,
             default_value="pad.jpg",
-            metadata={"default": "pad.jpg", "filter": "Images (*.png *.jpg *.jpeg *.webp *.bmp *.tif *.tiff)", "base_dir": INPUT_DIR, "param_type": NodeParamType.FILE_PATH},
+            metadata={
+                "default": "pad.jpg",
+                "filter": "Images (*.png *.jpg *.jpeg *.webp *.bmp *.tif *.tiff)",
+                "base_dir": INPUT_DIR,
+                "param_type": NodeParamType.FILE_PATH,
+                "description": (
+                    "Path to the template image to search for. Loaded "
+                    "once per run and converted to greyscale at load "
+                    "time, so the per-frame cost is the matchTemplate "
+                    "call only."
+                ),
+            },
         ))
         self._add_input(InputPort(
             "retain_size",
             {IoDataType.BOOL},
             optional=True,
             default_value=True,
-            metadata={"default": True, "param_type": NodeParamType.BOOL},
+            metadata={
+                "default": True,
+                "param_type": NodeParamType.BOOL,
+                "description": (
+                    "When on, the match map is pasted onto a canvas the "
+                    "same size as the input, with each response at the "
+                    "template-centre pixel. When off, the raw response "
+                    "is emitted (smaller than the input by template "
+                    "size minus one on each axis)."
+                ),
+            },
         ))
         self._add_output(OutputPort("image", {IoDataType.IMAGE_GREY}))
 

--- a/src/nodes/filters/notify.py
+++ b/src/nodes/filters/notify.py
@@ -62,13 +62,26 @@ class Notify(NodeBase):
                 "default":     "",
                 "placeholder": "message shown in the banner",
                 "param_type":  NodeParamType.STRING,
+                "description": (
+                    "Text shown in the floating banner (or carried by "
+                    "the raised RuntimeError when severity is ERROR). "
+                    "Wire any STRING source in to drive the message "
+                    "per frame."
+                ),
             },
         ))
         self._add_param(NodeParam(
             "severity",
             NodeParamType.ENUM,
             default=NotifySeverity.INFO,
-            metadata={"enum": NotifySeverity},
+            metadata={
+                "enum": NotifySeverity,
+                "description": (
+                    "INFO (blue) and WARNING (amber) keep the run going; "
+                    "ERROR (red) raises a RuntimeError that aborts at "
+                    "this node."
+                ),
+            },
         ))
         self._add_output(OutputPort("image", set(IMAGE_TYPES)))
 

--- a/src/nodes/filters/overlay.py
+++ b/src/nodes/filters/overlay.py
@@ -74,35 +74,75 @@ class Overlay(NodeBase):
             {IoDataType.SCALAR},
             optional=True,
             default_value=0.0,
-            metadata={"default": 0.0, "param_type": NodeParamType.FLOAT},
+            metadata={
+                "default": 0.0,
+                "param_type": NodeParamType.FLOAT,
+                "unit": "deg",
+                "description": (
+                    "Overlay rotation in degrees, counter-clockwise around "
+                    "its centre. The bounding box is expanded so no pixels "
+                    "are lost."
+                ),
+            },
         ))
         self._add_input(InputPort(
             "scale",
             {IoDataType.SCALAR},
             optional=True,
             default_value=1.0,
-            metadata={"default": 1.0, "param_type": NodeParamType.FLOAT},
+            metadata={
+                "default": 1.0,
+                "param_type": NodeParamType.FLOAT,
+                "min": 0.0,
+                "description": "Overlay scale factor. 1.0 = unchanged.",
+            },
         ))
         self._add_input(InputPort(
             "xpos",
             {IoDataType.SCALAR},
             optional=True,
             default_value=0,
-            metadata={"default": 0, "param_type": NodeParamType.INT},
+            metadata={
+                "default": 0,
+                "param_type": NodeParamType.INT,
+                "unit": "px",
+                "description": (
+                    "X-coordinate (in base-image pixels) of the overlay's "
+                    "centre — not its top-left corner."
+                ),
+            },
         ))
         self._add_input(InputPort(
             "ypos",
             {IoDataType.SCALAR},
             optional=True,
             default_value=0,
-            metadata={"default": 0, "param_type": NodeParamType.INT},
+            metadata={
+                "default": 0,
+                "param_type": NodeParamType.INT,
+                "unit": "px",
+                "description": (
+                    "Y-coordinate (in base-image pixels) of the overlay's "
+                    "centre — not its top-left corner."
+                ),
+            },
         ))
         self._add_input(InputPort(
             "alpha",
             {IoDataType.SCALAR},
             optional=True,
             default_value=1.0,
-            metadata={"default": 1.0, "param_type": NodeParamType.FLOAT},
+            metadata={
+                "default": 1.0,
+                "param_type": NodeParamType.FLOAT,
+                "min": 0.0,
+                "max": 1.0,
+                "description": (
+                    "Global opacity multiplier in [0, 1]. For BGRA "
+                    "overlays this multiplies on top of the per-pixel "
+                    "alpha channel."
+                ),
+            },
         ))
         self._add_output(OutputPort("image", set(IMAGE_TYPES)))
 

--- a/src/nodes/filters/scale.py
+++ b/src/nodes/filters/scale.py
@@ -49,7 +49,16 @@ class Scale(NodeBase):
             {IoDataType.SCALAR},
             optional=True,
             default_value=100,
-            metadata={"default": 100, "param_type": NodeParamType.INT},
+            metadata={
+                "default": 100,
+                "param_type": NodeParamType.INT,
+                "min": 1,
+                "unit": "%",
+                "description": (
+                    "Scale factor in percent. 100 leaves the image "
+                    "unchanged; 50 halves it; 200 doubles it."
+                ),
+            },
         ))
         self._add_input(InputPort(
             "interpolation",
@@ -60,6 +69,12 @@ class Scale(NodeBase):
                 "default": Interpolation.LINEAR,
                 "enum": Interpolation,
                 "param_type": NodeParamType.ENUM,
+                "description": (
+                    "Resampling method. NEAREST is fast and pixelated; "
+                    "LINEAR / CUBIC / LANCZOS4 produce progressively "
+                    "smoother results at higher cost; AREA is OpenCV's "
+                    "preferred choice when downsampling."
+                ),
             },
         ))
         self._add_output(OutputPort("image", set(IMAGE_TYPES)))

--- a/src/nodes/filters/shift.py
+++ b/src/nodes/filters/shift.py
@@ -30,14 +30,32 @@ class Shift(NodeBase):
             {IoDataType.SCALAR},
             optional=True,
             default_value=0,
-            metadata={"default": 0, "param_type": NodeParamType.INT},
+            metadata={
+                "default": 0,
+                "param_type": NodeParamType.INT,
+                "unit": "px",
+                "description": (
+                    "Horizontal shift in pixels. Positive moves right; "
+                    "exposed areas at the left edge are filled with "
+                    "black."
+                ),
+            },
         ))
         self._add_input(InputPort(
             "offset_y",
             {IoDataType.SCALAR},
             optional=True,
             default_value=0,
-            metadata={"default": 0, "param_type": NodeParamType.INT},
+            metadata={
+                "default": 0,
+                "param_type": NodeParamType.INT,
+                "unit": "px",
+                "description": (
+                    "Vertical shift in pixels. Positive moves down; "
+                    "exposed areas at the top edge are filled with "
+                    "black."
+                ),
+            },
         ))
         self._add_output(OutputPort("image", set(IMAGE_TYPES)))
 

--- a/src/nodes/filters/subpixel_mosaic.py
+++ b/src/nodes/filters/subpixel_mosaic.py
@@ -39,14 +39,30 @@ class SubpixelMosaic(NodeBase):
             {IoDataType.BOOL},
             optional=True,
             default_value=False,
-            metadata={"default": False, "param_type": NodeParamType.BOOL},
+            metadata={
+                "default": False,
+                "param_type": NodeParamType.BOOL,
+                "description": (
+                    "When on, the mosaic canvas is resampled to 2w × 2h "
+                    "so the output matches the source aspect ratio. "
+                    "When off, the raw 1.5w × 2h mosaic is emitted "
+                    "(vertical stretch of 4/3)."
+                ),
+            },
         ))
         self._add_input(InputPort(
             "output_grayscale",
             {IoDataType.BOOL},
             optional=True,
             default_value=False,
-            metadata={"default": False, "param_type": NodeParamType.BOOL},
+            metadata={
+                "default": False,
+                "param_type": NodeParamType.BOOL,
+                "description": (
+                    "When on, drops the colour and emits the per-pixel "
+                    "sample intensity as a single-channel image."
+                ),
+            },
         ))
         self._add_output(OutputPort("image", set(IMAGE_TYPES)))
 

--- a/src/nodes/filters/temporal_mean.py
+++ b/src/nodes/filters/temporal_mean.py
@@ -33,7 +33,17 @@ class TemporalMean(NodeBase):
             {IoDataType.SCALAR},
             optional=True,
             default_value=5,
-            metadata={"default": 5, "param_type": NodeParamType.INT},
+            metadata={
+                "default": 5,
+                "param_type": NodeParamType.INT,
+                "min": 1,
+                "unit": "frames",
+                "description": (
+                    "Number of recent frames averaged per output. "
+                    "Larger values denoise more aggressively but blur "
+                    "any motion in the scene."
+                ),
+            },
         ))
         self._add_output(OutputPort("image", set(IMAGE_TYPES)))
 

--- a/src/nodes/filters/temporal_median.py
+++ b/src/nodes/filters/temporal_median.py
@@ -34,7 +34,18 @@ class TemporalMedian(NodeBase):
             {IoDataType.SCALAR},
             optional=True,
             default_value=5,
-            metadata={"default": 5, "param_type": NodeParamType.INT},
+            metadata={
+                "default": 5,
+                "param_type": NodeParamType.INT,
+                "min": 1,
+                "unit": "frames",
+                "description": (
+                    "Number of recent frames whose per-pixel median is "
+                    "emitted. Strong against transient outliers — single-"
+                    "frame spikes, salt-and-pepper noise — without the "
+                    "smearing a mean would produce."
+                ),
+            },
         ))
         self._add_output(OutputPort("image", set(IMAGE_TYPES)))
 


### PR DESCRIPTION
## Summary

Filter half of the documentation sweep tracked under #187. Every
parameter on the eighteen filter nodes that were still undocumented
after v0.2.20 now ships with a `"description"` metadata key, and
where appropriate a numeric `min` / `max` bound and a `unit` suffix.

**Affected nodes (18):**
`AdaptiveGaussianThreshold`, `ApplyColormap`, `Clamp`, `Crop`,
`DebugParam`, `Delay`, `Dither`, `Flip`, `Math`, `Median`, `Ncc`,
`Notify`, `Overlay`, `Scale`, `Shift`, `SubpixelMosaic`,
`TemporalMean`, `TemporalMedian`.

## Why now

PR #189 wired the description metadata to inline tooltips. PR #195
wired it to the Node Documentation dock. Both work today, but the
content they render is sparse — only the five nodes touched in #189
had descriptions. Filling in the rest is the cheapest way to make
the existing infrastructure visibly useful.

## Visible effects

- **Inline tooltips** (v0.2.20) — every numeric / enum / bool / file-
  path widget on the eighteen nodes now shows the description on
  hover.
- **Documentation dock** (v0.2.21) — Inputs section (always visible)
  and Parameters section (under *Details*) both gain prose for these
  nodes.
- **Spin-box ranges** — params that gained `min` / `max` now
  constrain the widget directly instead of letting the user enter
  out-of-range values that the setter would then reject. The bounds
  match what the property setters *already* enforced
  (`Median.size >= 1`, `Crop.width >= 1`,
  `GaussianBlur.ksize >= 1`, etc.), so no saved flow stops working —
  it's strictly a friendlier edit surface.

## Lint test progress

`tests/test_node_documentation.py::test_param_ports_have_description`
flips **18 cases** from `XFAIL` to `XPASS` in one go.

```
before:  542 passed, 24 xfailed, 111 xpassed
after:   542 passed,  6 xfailed, 129 xpassed
```

The six remaining `XFAIL`s are sources / sinks (`ConstantValue`,
`DirectorySource`, `GradientSource`, `ValueSource`, `VideoSource`,
`VideoSink`) and are scoped for a follow-up `claude/doc-sweep-sources-sinks`
PR. The `xfail` markers themselves stay in place until that PR
lands so the lint does not flip to strict halfway through the
corpus.

## Version bump

0.2.21 → **0.2.22**. Strictly speaking this is metadata-only, but
adding `min` / `max` keys *does* affect the spin-box range a user
sees in the editor — a real, if minor, behaviour change. CHANGELOG
and welcome.html updated accordingly.

## What's *not* in this PR

- **No source / sink sweep.** Six XFAILs left, addressed in a
  separate small PR so each can be reviewed independently.
- **No new metadata keys** beyond what was already declared in the
  schema (#188). This PR is pure consumption of the contract.
- **No `xfail` decorator removal.** That happens when the corpus is
  100 % compliant.

## Test plan

- [x] `pytest` passes locally — 542 / 6 xfailed / 129 xpassed.
- [x] Lint test movement verified: 24 → 6 XFAIL.
- [ ] CI green on PR.
- [ ] Manual: drop a `Median` node, hover the `size` spin-box →
      tooltip explains the kernel rule. Try entering `0` → the
      spin-box clamps to the new `min: 1` bound. Open the Node
      Documentation dock, click `Crop` → the four params each
      show their description and `unit: px` extras.

## Refs

- Builds on: #189 (param-widget tooltips), #195 (documentation
  panel), both merged.
- Umbrella: #187.
- Companion follow-up: `claude/doc-sweep-sources-sinks` (the
  remaining 6 XFAILs) before the lint can flip to strict.

---
Refs #187

---
_Generated by [Claude Code](https://claude.ai/code/session_016Hmx5dxasutufp7oXHMr6x)_