### PR TITLE
Add output-path placeholder expansion for FileSink and VideoSink

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,39 @@ once a first tagged release is cut.
 
 ## [Unreleased]
 
+## [0.2.26] — 2026-04-28
+
+### Added
+- **Output-filename placeholders for `FileSink` and `VideoSink`.**
+  The `output_path` parameter now expands ``$token$`` placeholders at
+  write time, so the on-disk filename can be derived from whatever's
+  flowing through the flow rather than typed by hand. Issue #159.
+
+  Tokens:
+  - ``$input_stem$`` — source filename without extension (``ship``)
+  - ``$input_name$`` — source filename with extension (``ship.jpg``)
+  - ``$input_ext$`` — extension without dot (``jpg``)
+  - ``$flow_name$`` — currently-loaded flow name
+  - ``$frame_index$`` — zero-padded 4-digit frame counter (``0001``)
+  - ``$timestamp$`` — run start time (``YYYYMMDD_HHMMSS``)
+
+  Use cases unlocked by this:
+  - **Stream → numbered stills.** Set a `FileSink` ``output_path`` to
+    ``frame_$frame_index$.png`` and a video stream is dumped to
+    ``frame_0000.png``, ``frame_0001.png``, … in one pass instead of
+    overwriting a single file or renaming after the run.
+  - **Per-input batch naming.** ``$input_stem$.$flow_name$.png`` on
+    ``ship.jpg`` in flow ``denoise_v2`` writes ``ship.denoise_v2.png``
+    — the source filename is preserved and the flow name distinguishes
+    one experiment from another.
+
+  Backwards-compatible: paths with no tokens (the default
+  ``out.png`` / ``out.mp4``) still write the literal filename. Source
+  nodes (``ImageSource``, ``VideoSource``, ``DirectorySource``)
+  stamp the originating file path onto each emitted ``IoData``;
+  pass-through filters propagate it via ``IoData.with_image()`` so
+  the source filename reaches the sink intact.
+
 ## [0.2.25] — 2026-04-28
 
 ### Added

--- a/doc/welcome.html
+++ b/doc/welcome.html
@@ -180,7 +180,7 @@
   <main class="content-col">
 
     <header class="hero">
-      <h1>Welcome to Stjörnhorn <span class="version">v0.2.25</span></h1>
+      <h1>Welcome to Stjörnhorn <span class="version">v0.2.26</span></h1>
       <div class="tagline">A node-based image- and video-processing playground.</div>
     </header>
 
@@ -210,6 +210,13 @@
           <p>Write frames to image files or encode video (MP4V, XVID) with live preview via the Display node.</p>
         </div>
       </div>
+    </section>
+
+    <section>
+      <h2>What's new in v0.2.26</h2>
+      <ul class="tips">
+        <li><strong>Output-filename placeholders for File Sink and Video Sink.</strong> The <code>output_path</code> parameter now accepts <code>$token$</code> placeholders that expand at write time — <code>$input_stem$</code>, <code>$input_name$</code>, <code>$input_ext$</code> (source filename and extension), <code>$flow_name$</code>, <code>$frame_index$</code> (zero-padded 4-digit counter) and <code>$timestamp$</code>. Two patterns this unlocks: <em>stream-to-stills</em> (<code>frame_$frame_index$.png</code> dumps a video to <code>frame_0000.png</code>, <code>frame_0001.png</code>, … in one pass) and <em>per-input batch naming</em> (<code>$input_stem$.$flow_name$.png</code> on <code>ship.jpg</code> in flow <code>denoise_v2</code> writes <code>ship.denoise_v2.png</code>). Paths with no tokens behave exactly as before. Issue #159.</li>
+      </ul>
     </section>
 
     <section>

--- a/flow/video_tiltshift.flowjs
+++ b/flow/video_tiltshift.flowjs
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "app_version": "0.2.23",
+  "app_version": "0.2.24",
   "name": "video_tiltshift",
   "nodes": [
     {
@@ -8,8 +8,8 @@
       "module": "nodes.sources.video_source",
       "class": "VideoSource",
       "position": [
-        -1663.6862007952038,
-        -843.8034402957649
+        -1697.9622288212852,
+        -850.9442794678652
       ],
       "port_defaults": {
         "file_path": "video.mp4",
@@ -21,8 +21,8 @@
       "module": "nodes.filters.gaussian_blur",
       "class": "GaussianBlur",
       "position": [
-        -1272.7862461576121,
-        -499.9139451240976
+        -1307.0622741836935,
+        -507.0547842961979
       ],
       "port_defaults": {
         "ksize": 51,
@@ -38,8 +38,8 @@
       "module": "nodes.sources.gradient_source",
       "class": "GradientSource",
       "position": [
-        -1569.7562845586424,
-        -707.6666139544177
+        -1604.0323125847237,
+        -714.807453126518
       ],
       "port_defaults": {
         "width": 512,
@@ -55,8 +55,8 @@
       "module": "nodes.filters.masked_blend",
       "class": "MaskedBlend",
       "position": [
-        -1272.7862461576121,
-        -667.9139451240976
+        -1307.0622741836935,
+        -675.0547842961979
       ],
       "port_defaults": {},
       "size": [
@@ -83,8 +83,8 @@
       "module": "nodes.sinks.video_sink",
       "class": "VideoSink",
       "position": [
-        -591.337788257158,
-        -917.6306599121991
+        -598.4786274292582,
+        -904.7771494024187
       ],
       "port_defaults": {
         "output_path": "out_tiltshift.mp4",
@@ -92,7 +92,7 @@
         "codec": 0
       },
       "size": [
-        422.32697229598693,
+        433.75231497134746,
         148.0
       ]
     },
@@ -172,8 +172,8 @@
   "backdrops": [
     {
       "position": [
-        -1705.7239719739187,
-        -872.8591608278997
+        -1740.0,
+        -880.0
       ],
       "size": [
         720.0,

--- a/src/constants.py
+++ b/src/constants.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 APP_NAME:         str = "Image-Inquest"
 APP_DISPLAY_NAME: str = "Stjörnhorn"
-APP_VERSION:      str = "0.2.25"
+APP_VERSION:      str = "0.2.26"
 API_URL:    str = "https://beltoforion.de"
 
 # Path resolution -----------------------------------------------------------

--- a/src/core/flow.py
+++ b/src/core/flow.py
@@ -4,7 +4,12 @@ import logging
 import re
 from collections.abc import Iterator
 
-from core.node_base import NodeBase, SinkNodeBase, SourceNodeBase
+from core.node_base import (
+    NodeBase,
+    SinkNodeBase,
+    SourceNodeBase,
+    set_current_flow_name,
+)
 from core.port import InputPort, OutputPort
 
 logger = logging.getLogger(__name__)
@@ -201,6 +206,10 @@ class Flow:
         # short-circuit the next Run.
         self._stop_requested = False
 
+        # Publish the flow name so sinks can expand ``$flow_name$``
+        # placeholders in their output paths. Cleared in ``finally``.
+        set_current_flow_name(self._name)
+
         logger.info("initializing nodes")
 
         # initialize all nodes before starting any source
@@ -267,4 +276,6 @@ class Flow:
                     node.after_run(success)
                 except Exception:
                     logger.exception(f"Exception during cleanup of node {node.display_name} ({type(node).__name__})")
+
+            set_current_flow_name(None)
 

--- a/src/core/io_data.py
+++ b/src/core/io_data.py
@@ -53,16 +53,22 @@ class IoData:
     payload value on this channel.
     """
 
-    def __init__(self, type: IoDataType, payload: Any) -> None:
+    def __init__(
+        self,
+        type: IoDataType,
+        payload: Any,
+        source_path: Path | None = None,
+    ) -> None:
         self._type = type
         self._payload = payload
+        self._source_path: Path | None = source_path
 
     # ── Factory methods ────────────────────────────────────────────────────────
 
     @classmethod
-    def from_image(cls, image: np.ndarray) -> IoData:
+    def from_image(cls, image: np.ndarray, source_path: Path | None = None) -> IoData:
         """Wrap a (potentially multi-channel) image as :data:`IoDataType.IMAGE`."""
-        return cls(IoDataType.IMAGE, payload=image)
+        return cls(IoDataType.IMAGE, payload=image, source_path=source_path)
 
     @classmethod
     def from_greyscale(cls, image: np.ndarray) -> IoData:
@@ -149,6 +155,18 @@ class IoData:
         return self._type
 
     @property
+    def source_path(self) -> Path | None:
+        """Originating source filename, when known.
+
+        Stamped by source nodes (e.g. ``ImageSource``, ``VideoSource``,
+        ``DirectorySource``) onto each :class:`IoData` they emit, and
+        propagated through pass-through filters via :meth:`with_image`.
+        Sinks read it to expand ``$input_stem$`` / ``$input_name$`` /
+        ``$input_ext$`` placeholders in their ``output_path``.
+        """
+        return self._source_path
+
+    @property
     def payload(self) -> Any:
         """The underlying value, regardless of payload kind.
 
@@ -178,9 +196,11 @@ class IoData:
 
         Use this in pass-through filters so the output type (IMAGE vs
         IMAGE_GREY) matches the input without the filter having to branch on
-        it explicitly.
+        it explicitly. The originating :attr:`source_path` is preserved
+        so sinks downstream can still derive output filenames from the
+        input.
         """
-        return IoData(self._type, payload=image)
+        return IoData(self._type, payload=image, source_path=self._source_path)
 
     def __repr__(self) -> str:
         # Image / SCALAR / MATRIX payloads expose a numpy ``shape``; the

--- a/src/core/node_base.py
+++ b/src/core/node_base.py
@@ -34,6 +34,25 @@ def set_process_observer(callback: Callable[["NodeBase"], None] | None) -> None:
     _process_observer = callback
 
 
+# Name of the currently-executing flow. Set by :meth:`core.flow.Flow.run`
+# before any node fires, cleared on completion. Read by sinks to expand
+# the ``$flow_name$`` placeholder in their ``output_path``. Module-level
+# rather than threaded through every node call because the push-based
+# dispatcher doesn't otherwise carry a Flow reference across boundaries.
+_current_flow_name: str | None = None
+
+
+def set_current_flow_name(name: str | None) -> None:
+    """Install (or clear) the name of the currently-running flow."""
+    global _current_flow_name
+    _current_flow_name = name
+
+
+def get_current_flow_name() -> str | None:
+    """Return the name of the currently-running flow, if any."""
+    return _current_flow_name
+
+
 class NodeParamType(Enum):
     """Enumeration of parameter types for node parameters."""
     FILE_PATH = 0,

--- a/src/core/path_placeholders.py
+++ b/src/core/path_placeholders.py
@@ -1,0 +1,99 @@
+"""Output-path placeholder expansion for sinks.
+
+Sink nodes (``FileSink``, ``VideoSink``) accept ``$token$`` placeholders
+in their ``output_path`` so the on-disk filename can be derived from the
+input flowing through the flow. See issue #159.
+
+Supported tokens:
+
+==================  =============================================
+``$input_stem$``    Filename (no extension) of the originating
+                    source, e.g. ``ship`` for ``ship.jpg``.
+``$input_name$``    Filename with extension, e.g. ``ship.jpg``.
+``$input_ext$``     Extension without the dot, e.g. ``jpg``.
+``$flow_name$``     Name of the currently-loaded flow.
+``$frame_index$``   Zero-padded running frame index (``0001``).
+``$timestamp$``     Run start time as ``YYYYMMDD_HHMMSS``.
+==================  =============================================
+
+Placeholders that can't be resolved (e.g. ``$input_stem$`` when no
+source has stamped a path) expand to an empty string. Tokens that don't
+match any of the above are passed through unchanged.
+
+A path with no placeholders is returned as-is, byte-for-byte — keeps
+the common case (a literal ``out.png``) backwards-compatible.
+"""
+from __future__ import annotations
+
+import re
+from datetime import datetime
+from pathlib import Path
+
+#: Matches a ``$token$`` token. The inner group is the token name.
+_PLACEHOLDER_RE = re.compile(r"\$([a-zA-Z_][a-zA-Z0-9_]*)\$")
+
+#: Default zero-padding width for ``$frame_index$``.
+FRAME_INDEX_WIDTH: int = 4
+
+
+def has_placeholders(template: str) -> bool:
+    """Return True if ``template`` contains at least one ``$token$``."""
+    return _PLACEHOLDER_RE.search(template) is not None
+
+
+def expand_placeholders(
+    template: str,
+    *,
+    source_path: Path | None = None,
+    flow_name: str | None = None,
+    frame_index: int | None = None,
+    run_started_at: datetime | None = None,
+) -> str:
+    """Expand ``$token$`` placeholders in ``template``.
+
+    Args:
+        template: The user-supplied path string (relative or absolute).
+        source_path: Originating filename of the upstream source, if known.
+        flow_name: Name of the currently-running flow, if known.
+        frame_index: Running per-frame counter for streaming sinks.
+        run_started_at: Run start time, used by ``$timestamp$``.
+
+    Returns:
+        The expanded path string. Unknown tokens are left untouched so
+        the user can spot typos by reading the resulting filename.
+    """
+    if not has_placeholders(template):
+        return template
+
+    values: dict[str, str] = {}
+
+    if source_path is not None:
+        values["input_name"] = source_path.name
+        values["input_stem"] = source_path.stem
+        # Path.suffix includes the leading dot; strip it for the token.
+        values["input_ext"] = source_path.suffix.lstrip(".")
+    else:
+        values["input_name"] = ""
+        values["input_stem"] = ""
+        values["input_ext"] = ""
+
+    values["flow_name"] = flow_name or ""
+
+    if frame_index is not None:
+        values["frame_index"] = f"{frame_index:0{FRAME_INDEX_WIDTH}d}"
+    else:
+        values["frame_index"] = ""
+
+    if run_started_at is not None:
+        values["timestamp"] = run_started_at.strftime("%Y%m%d_%H%M%S")
+    else:
+        values["timestamp"] = ""
+
+    def _sub(match: re.Match[str]) -> str:
+        token = match.group(1)
+        if token in values:
+            return values[token]
+        # Unknown token: pass the literal ``$token$`` through unchanged.
+        return match.group(0)
+
+    return _PLACEHOLDER_RE.sub(_sub, template)

--- a/src/nodes/sinks/file_sink.py
+++ b/src/nodes/sinks/file_sink.py
@@ -34,10 +34,40 @@ class FileSink(SinkNodeBase):
     at run time, which keeps saved flows portable across machines that
     share the same output layout.
 
-    The ``output_path`` accepts ``$token$`` placeholders that expand at
-    write time, e.g. ``frame_$frame_index$.png`` or
-    ``$input_stem$.$flow_name$.png`` — see
-    :mod:`core.path_placeholders` for the supported tokens. Issue: #159.
+    The ``output_path`` accepts ``$token$`` placeholders that expand
+    every frame at write time. Without a frame-varying token the same
+    file is overwritten on every frame, so a stream collapses to its
+    final frame; chain ``$frame_index$`` or ``$input_stem$`` (when the
+    upstream source streams multiple files) to get one output file per
+    frame.
+
+    Supported tokens:
+
+      ``$input_stem$``    Originating source filename without extension
+                          (``ship`` for ``ship.jpg``). Empty when no
+                          upstream source stamped a path on the frame.
+      ``$input_name$``    Originating source filename with extension
+                          (``ship.jpg``). Empty when unknown.
+      ``$input_ext$``     Extension of the originating source, dot
+                          stripped (``jpg``). Empty when unknown.
+      ``$flow_name$``     Name of the currently-running flow.
+      ``$frame_index$``   Zero-padded 4-digit per-run frame counter,
+                          starting at ``0000`` and incrementing for
+                          each frame written by this sink.
+      ``$timestamp$``     Run start time as ``YYYYMMDD_HHMMSS``,
+                          stable for the duration of one Run.
+
+    Unknown tokens are left as-is in the resulting filename so typos
+    surface visibly. Paths with no tokens are written byte-for-byte
+    (the common ``out.png`` case is unchanged). Issue: #159.
+
+    Examples (assuming ``ship.jpg`` is the upstream source and the flow
+    is named ``denoise_v2``)::
+
+        out.png                          → out.png
+        frame_$frame_index$.png          → frame_0000.png, frame_0001.png, ...
+        $input_stem$.$flow_name$.png     → ship.denoise_v2.png
+        runs/$timestamp$/$input_name$    → runs/20260428_182300/ship.jpg
     """
 
     def __init__(self):
@@ -61,12 +91,21 @@ class FileSink(SinkNodeBase):
                 "filter": "Images (*.png *.jpg *.jpeg)",
                 "base_dir": OUTPUT_DIR,
                 "description": (
-                    "Where to write each frame. Accepts $token$ placeholders "
-                    "expanded per frame — e.g. $input_stem$ (source filename), "
-                    "$flow_name$, $frame_index$ (zero-padded), $timestamp$. "
+                    "Where to write each frame. Relative paths are resolved "
+                    "against the output folder.\n"
+                    "\n"
+                    "Accepts $token$ placeholders expanded per frame:\n"
+                    "  $input_stem$   — source filename without extension (ship)\n"
+                    "  $input_name$   — source filename with extension (ship.jpg)\n"
+                    "  $input_ext$    — source extension, no dot (jpg)\n"
+                    "  $flow_name$    — currently-running flow name\n"
+                    "  $frame_index$  — zero-padded 4-digit frame counter (0000)\n"
+                    "  $timestamp$    — run start time (YYYYMMDD_HHMMSS)\n"
+                    "\n"
                     "Without a frame-varying token the file is overwritten on "
-                    "every frame, so chain $frame_index$ or $input_stem$ in "
-                    "the path if you want a sequence rather than one file."
+                    "every frame. Use $frame_index$ for stream → numbered "
+                    "stills, or $input_stem$ when the upstream source streams "
+                    "multiple files (DirectorySource)."
                 ),
             },
         ))

--- a/src/nodes/sinks/file_sink.py
+++ b/src/nodes/sinks/file_sink.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from datetime import datetime
 from enum import Enum
 from pathlib import Path
 
@@ -8,7 +9,13 @@ from typing_extensions import override
 
 from constants import OUTPUT_DIR
 from core.io_data import IMAGE_TYPES
-from core.node_base import NodeParam, NodeParamType, SinkNodeBase
+from core.node_base import (
+    NodeParam,
+    NodeParamType,
+    SinkNodeBase,
+    get_current_flow_name,
+)
+from core.path_placeholders import expand_placeholders, has_placeholders
 from core.path_utils import resolve_against, store_relative_to
 from core.port import InputPort
 
@@ -26,6 +33,11 @@ class FileSink(SinkNodeBase):
     as an absolute path. Relative paths are resolved against ``OUTPUT_DIR``
     at run time, which keeps saved flows portable across machines that
     share the same output layout.
+
+    The ``output_path`` accepts ``$token$`` placeholders that expand at
+    write time, e.g. ``frame_$frame_index$.png`` or
+    ``$input_stem$.$flow_name$.png`` — see
+    :mod:`core.path_placeholders` for the supported tokens. Issue: #159.
     """
 
     def __init__(self):
@@ -33,6 +45,11 @@ class FileSink(SinkNodeBase):
 
         self._output_path: Path = Path("out.png")
         self._output_format: OutputFormat = OutputFormat.SAME_AS_INPUT
+
+        # Per-run state for placeholder expansion. Reset in
+        # ``_before_run_impl`` so a second run starts at frame 0.
+        self._frame_index: int = 0
+        self._run_started_at: datetime | None = None
 
         self._add_input(InputPort("image", set(IMAGE_TYPES)))
         self._add_param(NodeParam(
@@ -44,10 +61,12 @@ class FileSink(SinkNodeBase):
                 "filter": "Images (*.png *.jpg *.jpeg)",
                 "base_dir": OUTPUT_DIR,
                 "description": (
-                    "Where to write each frame. The file is overwritten on "
-                    "every frame, so this sink fits a single still or the "
-                    "last frame of a stream — chain a unique filename per "
-                    "frame upstream if you need a sequence."
+                    "Where to write each frame. Accepts $token$ placeholders "
+                    "expanded per frame — e.g. $input_stem$ (source filename), "
+                    "$flow_name$, $frame_index$ (zero-padded), $timestamp$. "
+                    "Without a frame-varying token the file is overwritten on "
+                    "every frame, so chain $frame_index$ or $input_stem$ in "
+                    "the path if you want a sequence rather than one file."
                 ),
             },
         ))
@@ -76,8 +95,15 @@ class FileSink(SinkNodeBase):
     # ── SinkNodeBase interface ──────────────────────────────────────────────────
 
     @override
+    def _before_run_impl(self) -> None:
+        super()._before_run_impl()
+        self._frame_index = 0
+        self._run_started_at = datetime.now()
+
+    @override
     def process_impl(self) -> None:
-        resolved = self._resolved_path()
+        in_data = self.inputs[0].data
+        resolved = self._resolved_path(source_path=in_data.source_path)
 
         if self._output_format == OutputFormat.SAME_AS_INPUT:
             output = resolved
@@ -86,10 +112,25 @@ class FileSink(SinkNodeBase):
         else:
             raise ValueError(f"Unsupported output format: {self._output_format}")
 
-        cv2.imwrite(str(output), self.inputs[0].data.image)
+        output.parent.mkdir(parents=True, exist_ok=True)
+        cv2.imwrite(str(output), in_data.image)
+        self._frame_index += 1
 
     # ── Internals ──────────────────────────────────────────────────────────────
 
-    def _resolved_path(self) -> Path:
-        """Return an absolute path; relative values are joined with OUTPUT_DIR."""
+    def _resolved_path(self, source_path: Path | None = None) -> Path:
+        """Return an absolute path; relative values are joined with OUTPUT_DIR.
+
+        Expands ``$token$`` placeholders before resolving. Issue: #159.
+        """
+        raw = str(self._output_path)
+        if has_placeholders(raw):
+            expanded = expand_placeholders(
+                raw,
+                source_path=source_path,
+                flow_name=get_current_flow_name(),
+                frame_index=self._frame_index,
+                run_started_at=self._run_started_at,
+            )
+            return resolve_against(Path(expanded), OUTPUT_DIR)
         return resolve_against(self._output_path, OUTPUT_DIR)

--- a/src/nodes/sinks/video_sink.py
+++ b/src/nodes/sinks/video_sink.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from datetime import datetime
 from enum import IntEnum
 from pathlib import Path
 
@@ -9,7 +10,13 @@ from typing_extensions import override
 
 from constants import OUTPUT_DIR
 from core.io_data import IMAGE_TYPES
-from core.node_base import NodeParam, NodeParamType, SinkNodeBase
+from core.node_base import (
+    NodeParam,
+    NodeParamType,
+    SinkNodeBase,
+    get_current_flow_name,
+)
+from core.path_placeholders import expand_placeholders, has_placeholders
 from core.path_utils import resolve_against, store_relative_to
 from core.port import InputPort
 
@@ -58,12 +65,29 @@ class VideoSink(SinkNodeBase):
         self._writer: cv2.VideoWriter | None = None
         self._frame_shape: tuple[int, ...] | None = None
 
+        # Per-run state for placeholder expansion. ``$frame_index$`` on a
+        # video sink locks to ``0000`` (one container, one starting frame)
+        # — the index is per-file, not per-frame inside the file.
+        self._run_started_at: datetime | None = None
+
         self._add_input(InputPort("image", set(IMAGE_TYPES)))
         self._add_param(NodeParam(
             "output_path",
             NodeParamType.FILE_PATH,
             default="out.mp4",
-            metadata={"mode": "save", "filter": "Video (*.mp4)", "base_dir": OUTPUT_DIR},
+            metadata={
+                "mode": "save",
+                "filter": "Video (*.mp4)",
+                "base_dir": OUTPUT_DIR,
+                "description": (
+                    "Where to write the encoded video. Accepts $token$ "
+                    "placeholders resolved on writer open — e.g. "
+                    "$input_stem$ (source filename), $flow_name$, "
+                    "$timestamp$. The path is fixed for the whole stream, "
+                    "so placeholders that change per frame "
+                    "($frame_index$) are not useful here."
+                ),
+            },
         ))
         self._add_param(NodeParam(
             "fps",
@@ -121,10 +145,12 @@ class VideoSink(SinkNodeBase):
         # writer may still be open. Reset state so this run starts clean.
         self._release_writer()
         self._frame_shape = None
+        self._run_started_at = datetime.now()
 
     @override
     def process_impl(self) -> None:
-        frame: np.ndarray = self.inputs[0].data.image
+        in_data = self.inputs[0].data
+        frame: np.ndarray = in_data.image
 
         # Always encode as BGR so a single sink can consume either
         # colour or greyscale upstream pipelines without producing
@@ -133,7 +159,7 @@ class VideoSink(SinkNodeBase):
             frame = cv2.cvtColor(frame, cv2.COLOR_GRAY2BGR)
 
         if self._writer is None:
-            self._open_writer(frame)
+            self._open_writer(frame, source_path=in_data.source_path)
             self._frame_shape = frame.shape
         elif frame.shape != self._frame_shape:
             raise ValueError(
@@ -157,13 +183,26 @@ class VideoSink(SinkNodeBase):
 
     # ── Internals ──────────────────────────────────────────────────────────────
 
-    def _resolved_path(self) -> Path:
+    def _resolved_path(self, source_path: Path | None = None) -> Path:
+        """Return an absolute path; expands ``$token$`` placeholders. Issue: #159."""
+        raw = str(self._output_path)
+        if has_placeholders(raw):
+            expanded = expand_placeholders(
+                raw,
+                source_path=source_path,
+                flow_name=get_current_flow_name(),
+                # VideoSink writes one file per run, so frame_index is
+                # always the start-of-stream value.
+                frame_index=0,
+                run_started_at=self._run_started_at,
+            )
+            return resolve_against(Path(expanded), OUTPUT_DIR)
         return resolve_against(self._output_path, OUTPUT_DIR)
 
-    def _open_writer(self, frame: np.ndarray) -> None:
+    def _open_writer(self, frame: np.ndarray, source_path: Path | None = None) -> None:
         h, w = frame.shape[:2]
         fourcc = cv2.VideoWriter.fourcc(*_CODEC_FOURCC[self._codec])
-        path = self._resolved_path()
+        path = self._resolved_path(source_path=source_path)
         path.parent.mkdir(parents=True, exist_ok=True)
         # frame is BGR by the time this is called, so isColor=True always.
         self._writer = cv2.VideoWriter(

--- a/src/nodes/sinks/video_sink.py
+++ b/src/nodes/sinks/video_sink.py
@@ -53,6 +53,34 @@ class VideoSink(SinkNodeBase):
     interactive preview, monitor-relative resize and blocking
     ``waitKey`` are dropped, and GIF support is omitted because
     ``imageio`` isn't a pipeline dependency.
+
+    The ``output_path`` accepts ``$token$`` placeholders, resolved once
+    when the writer opens on the first frame:
+
+      ``$input_stem$``    Originating source filename without extension
+                          (``ship`` for ``ship.mp4``). Empty when the
+                          upstream source did not stamp a path.
+      ``$input_name$``    Originating source filename with extension.
+      ``$input_ext$``     Extension of the originating source, dot
+                          stripped.
+      ``$flow_name$``     Name of the currently-running flow.
+      ``$timestamp$``     Run start time as ``YYYYMMDD_HHMMSS``.
+      ``$frame_index$``   Locked to ``0000``. The path is fixed for the
+                          whole stream — one container per Run — so a
+                          per-frame counter has no useful interpretation
+                          here. Use :class:`FileSink` if you want a
+                          frame-by-frame numbered output.
+
+    Paths with no tokens are written byte-for-byte (the common
+    ``out.mp4`` case is unchanged). Unknown tokens are left as-is so
+    typos surface visibly. Issue: #159.
+
+    Examples (assuming ``video.mp4`` is the upstream source and the flow
+    is named ``denoise_v2``)::
+
+        out.mp4                          → out.mp4
+        $input_stem$.$flow_name$.mp4     → video.denoise_v2.mp4
+        runs/$timestamp$/$input_name$    → runs/20260428_182300/video.mp4
     """
 
     def __init__(self) -> None:
@@ -80,12 +108,20 @@ class VideoSink(SinkNodeBase):
                 "filter": "Video (*.mp4)",
                 "base_dir": OUTPUT_DIR,
                 "description": (
-                    "Where to write the encoded video. Accepts $token$ "
-                    "placeholders resolved on writer open — e.g. "
-                    "$input_stem$ (source filename), $flow_name$, "
-                    "$timestamp$. The path is fixed for the whole stream, "
-                    "so placeholders that change per frame "
-                    "($frame_index$) are not useful here."
+                    "Where to write the encoded video. Relative paths are "
+                    "resolved against the output folder.\n"
+                    "\n"
+                    "Accepts $token$ placeholders, resolved once when the "
+                    "writer opens on the first frame:\n"
+                    "  $input_stem$   — source filename without extension\n"
+                    "  $input_name$   — source filename with extension\n"
+                    "  $input_ext$    — source extension, no dot\n"
+                    "  $flow_name$    — currently-running flow name\n"
+                    "  $timestamp$    — run start time (YYYYMMDD_HHMMSS)\n"
+                    "\n"
+                    "$frame_index$ is locked to 0000 here — one container "
+                    "per run — so it isn't useful in this sink. Use "
+                    "FileSink if you want frame-numbered stills."
                 ),
             },
         ))

--- a/src/nodes/sources/directory_source.py
+++ b/src/nodes/sources/directory_source.py
@@ -105,7 +105,7 @@ class DirectorySource(SourceNodeBase):
             image = self._load_image(path)
             if image is None:
                 continue
-            self.outputs[0].send(IoData.from_image(image))
+            self.outputs[0].send(IoData.from_image(image, source_path=path))
             yield
 
     @override

--- a/src/nodes/sources/image_source.py
+++ b/src/nodes/sources/image_source.py
@@ -99,7 +99,7 @@ class ImageSource(SourceNodeBase):
             if image.ndim == 2:
                 image = cv2.cvtColor(image, cv2.COLOR_GRAY2BGR)
 
-        self.outputs[0].send(IoData.from_image(image))
+        self.outputs[0].send(IoData.from_image(image, source_path=resolved))
 
     # ── Internals ──────────────────────────────────────────────────────────────
 

--- a/src/nodes/sources/video_source.py
+++ b/src/nodes/sources/video_source.py
@@ -100,7 +100,7 @@ class VideoSource(SourceNodeBase):
                 ok, frame = cap.read()
                 if not ok:
                     break
-                self.outputs[0].send(IoData.from_image(frame))
+                self.outputs[0].send(IoData.from_image(frame, source_path=resolved))
                 frame_count += 1
                 yield
                 if self._max_num_frames >= 0 and frame_count >= self._max_num_frames:

--- a/tests/test_io_data.py
+++ b/tests/test_io_data.py
@@ -201,6 +201,38 @@ def test_repr_for_non_numeric_payloads_uses_value_form() -> None:
     assert "value='hi'" in repr(IoData.from_string("hi"))
 
 
+# ── source_path propagation (issue #159) ─────────────────────────────────────
+
+def test_image_default_source_path_is_none() -> None:
+    """Existing call sites that don't pass ``source_path`` keep the
+    None default — no behaviour change for legacy callers."""
+    data = IoData.from_image(np.zeros((4, 4, 3), dtype=np.uint8))
+    assert data.source_path is None
+
+
+def test_image_can_carry_source_path() -> None:
+    src = Path("/in/ship.jpg")
+    data = IoData.from_image(np.zeros((4, 4, 3), dtype=np.uint8), source_path=src)
+    assert data.source_path == src
+
+
+def test_with_image_propagates_source_path() -> None:
+    """Pass-through filters using ``with_image`` must keep the
+    originating source path so sinks downstream can derive output
+    filenames from the input."""
+    src = Path("/in/ship.jpg")
+    original = IoData.from_image(np.zeros((4, 4, 3), dtype=np.uint8), source_path=src)
+    derived = original.with_image(np.ones((4, 4, 3), dtype=np.uint8))
+    assert derived.source_path == src
+    assert derived.type is IoDataType.IMAGE
+
+
+def test_with_image_propagates_none_source_path() -> None:
+    original = IoData.from_image(np.zeros((4, 4, 3), dtype=np.uint8))
+    derived = original.with_image(np.ones((4, 4, 3), dtype=np.uint8))
+    assert derived.source_path is None
+
+
 def test_image_types_set_unaffected_by_new_kinds() -> None:
     """``IMAGE_TYPES`` must keep being just IMAGE + IMAGE_GREY — adding
     BOOL/STRING/ENUM/PATH must not pollute the set that filters use to

--- a/tests/test_path_placeholders.py
+++ b/tests/test_path_placeholders.py
@@ -1,0 +1,99 @@
+"""Unit tests for ``core.path_placeholders.expand_placeholders``. Issue #159."""
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+
+from core.path_placeholders import (
+    expand_placeholders,
+    has_placeholders,
+)
+
+
+def test_no_placeholders_returns_template_verbatim() -> None:
+    """Common case: a literal path string is returned byte-for-byte."""
+    assert expand_placeholders("out.png") == "out.png"
+    assert expand_placeholders("output/sub/out.mp4") == "output/sub/out.mp4"
+
+
+def test_input_stem_expands_to_source_filename_without_extension() -> None:
+    expanded = expand_placeholders(
+        "$input_stem$.png", source_path=Path("/abs/path/ship.jpg"),
+    )
+    assert expanded == "ship.png"
+
+
+def test_input_name_includes_extension() -> None:
+    expanded = expand_placeholders(
+        "copy_$input_name$", source_path=Path("ship.jpg"),
+    )
+    assert expanded == "copy_ship.jpg"
+
+
+def test_input_ext_strips_leading_dot() -> None:
+    assert expand_placeholders(
+        "out.$input_ext$", source_path=Path("ship.JPG"),
+    ) == "out.JPG"
+
+
+def test_flow_name_expands() -> None:
+    assert expand_placeholders(
+        "$flow_name$.png", flow_name="denoise_v2",
+    ) == "denoise_v2.png"
+
+
+def test_frame_index_zero_padded_to_four_digits() -> None:
+    assert expand_placeholders(
+        "frame_$frame_index$.png", frame_index=0,
+    ) == "frame_0000.png"
+    assert expand_placeholders(
+        "frame_$frame_index$.png", frame_index=42,
+    ) == "frame_0042.png"
+    assert expand_placeholders(
+        "frame_$frame_index$.png", frame_index=12345,
+    ) == "frame_12345.png"
+
+
+def test_timestamp_uses_yyyymmdd_hhmmss() -> None:
+    when = datetime(2026, 4, 28, 13, 45, 9)
+    assert expand_placeholders(
+        "run_$timestamp$.png", run_started_at=when,
+    ) == "run_20260428_134509.png"
+
+
+def test_combined_tokens() -> None:
+    expanded = expand_placeholders(
+        "$input_stem$.$flow_name$.frame_$frame_index$.$input_ext$",
+        source_path=Path("ship.jpg"),
+        flow_name="denoise",
+        frame_index=7,
+    )
+    assert expanded == "ship.denoise.frame_0007.jpg"
+
+
+def test_unknown_token_passes_through_unchanged() -> None:
+    """A typo'd token is left as-is so the user spots it in the file
+    name rather than getting a silent empty string."""
+    assert expand_placeholders(
+        "$nope$.png", source_path=Path("ship.jpg"),
+    ) == "$nope$.png"
+
+
+def test_unresolved_known_token_expands_to_empty_string() -> None:
+    """Known tokens with no value collapse to ``""``. The user opted in
+    to the placeholder; the empty string is at least a debuggable
+    artefact in the resulting filename."""
+    assert expand_placeholders("$input_stem$.png") == ".png"
+    assert expand_placeholders("$flow_name$.png") == ".png"
+
+
+def test_has_placeholders_true_for_token() -> None:
+    assert has_placeholders("$input_stem$.png") is True
+    assert has_placeholders("frame_$frame_index$.png") is True
+
+
+def test_has_placeholders_false_for_literal() -> None:
+    assert has_placeholders("out.png") is False
+    # A lone ``$`` without a closing ``$`` doesn't match the token
+    # pattern — the dollar sign is just a literal.
+    assert has_placeholders("price_$5.png") is False

--- a/tests/test_sink_placeholders.py
+++ b/tests/test_sink_placeholders.py
@@ -1,0 +1,180 @@
+"""Sink-side placeholder expansion tests for ``FileSink`` / ``VideoSink``.
+
+Drives each sink end-to-end (source → sink) so the test exercises both
+``IoData.source_path`` propagation and the per-frame state on the sink.
+Issue #159.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import cv2
+import numpy as np
+from typing_extensions import override
+
+from core.flow import Flow
+from core.io_data import IoData, IoDataType
+from core.node_base import SourceNodeBase
+from core.port import OutputPort
+from nodes.sinks.file_sink import FileSink
+from nodes.sinks.video_sink import VideoSink
+
+
+class _PathStampedSource(SourceNodeBase):
+    """Streams pre-built BGR frames, each tagged with a fixed source_path.
+
+    Mirrors what ``ImageSource`` / ``VideoSource`` do — stamp each
+    outgoing :class:`IoData` so downstream sinks can derive output
+    filenames from the input.
+    """
+
+    def __init__(
+        self,
+        frames: list[np.ndarray],
+        source_path: Path,
+    ) -> None:
+        super().__init__("Stamped Frames", section="Sources")
+        self._frames = frames
+        self._source_path = source_path
+        self._add_output(OutputPort("image", {IoDataType.IMAGE}))
+
+    @override
+    def process_impl(self) -> None:
+        for frame in self._frames:
+            self.outputs[0].send(
+                IoData.from_image(frame, source_path=self._source_path)
+            )
+
+
+def _bgr(value: int = 100, h: int = 16, w: int = 16) -> np.ndarray:
+    return np.full((h, w, 3), value, dtype=np.uint8)
+
+
+# ── FileSink ─────────────────────────────────────────────────────────────────
+
+def test_file_sink_no_placeholders_writes_literal_path(tmp_path: Path) -> None:
+    """Backwards-compat: a literal path with no tokens still writes the
+    one configured file (last-write-wins on streams)."""
+    sink = FileSink()
+    sink.output_path = tmp_path / "out.png"
+
+    src = _PathStampedSource([_bgr(40), _bgr(120)], source_path=Path("ship.jpg"))
+    flow = Flow("literal")
+    flow.add_node(src)
+    flow.add_node(sink)
+    flow.connect(src, 0, sink, 0)
+    flow.run()
+
+    assert (tmp_path / "out.png").exists()
+
+
+def test_file_sink_input_stem_uses_source_filename(tmp_path: Path) -> None:
+    sink = FileSink()
+    sink.output_path = tmp_path / "$input_stem$.png"
+
+    src = _PathStampedSource([_bgr(80)], source_path=Path("/in/ship.jpg"))
+    flow = Flow("stem")
+    flow.add_node(src)
+    flow.add_node(sink)
+    flow.connect(src, 0, sink, 0)
+    flow.run()
+
+    assert (tmp_path / "ship.png").exists()
+
+
+def test_file_sink_frame_index_writes_one_file_per_frame(tmp_path: Path) -> None:
+    """The big payoff of the feature: stream-to-stills without manual
+    renaming. Three frames must land in three distinct files."""
+    sink = FileSink()
+    sink.output_path = tmp_path / "frame_$frame_index$.png"
+
+    src = _PathStampedSource(
+        [_bgr(40), _bgr(120), _bgr(200)], source_path=Path("clip.mp4"),
+    )
+    flow = Flow("frames")
+    flow.add_node(src)
+    flow.add_node(sink)
+    flow.connect(src, 0, sink, 0)
+    flow.run()
+
+    files = sorted(tmp_path.glob("frame_*.png"))
+    assert [f.name for f in files] == [
+        "frame_0000.png", "frame_0001.png", "frame_0002.png",
+    ]
+
+
+def test_file_sink_flow_name_expands(tmp_path: Path) -> None:
+    sink = FileSink()
+    sink.output_path = tmp_path / "$input_stem$.$flow_name$.png"
+
+    src = _PathStampedSource([_bgr(60)], source_path=Path("ship.jpg"))
+    flow = Flow("denoise_v2")
+    flow.add_node(src)
+    flow.add_node(sink)
+    flow.connect(src, 0, sink, 0)
+    flow.run()
+
+    assert (tmp_path / "ship.denoise_v2.png").exists()
+
+
+def test_file_sink_frame_index_resets_between_runs(tmp_path: Path) -> None:
+    """Running a flow twice must restart the frame counter — otherwise
+    the second run would skip past the first run's filenames."""
+    sink = FileSink()
+    sink.output_path = tmp_path / "f_$frame_index$.png"
+
+    src = _PathStampedSource([_bgr(40), _bgr(80)], source_path=Path("a.png"))
+    flow = Flow("twice")
+    flow.add_node(src)
+    flow.add_node(sink)
+    flow.connect(src, 0, sink, 0)
+
+    flow.run()
+    flow.run()
+
+    # Both runs wrote to f_0000 and f_0001 — the second run overwrote
+    # the files (correct: same input → same output) rather than rolling
+    # the counter forward to f_0002 / f_0003.
+    files = sorted(tmp_path.glob("f_*.png"))
+    assert [f.name for f in files] == ["f_0000.png", "f_0001.png"]
+
+
+# ── VideoSink ────────────────────────────────────────────────────────────────
+
+def test_video_sink_input_stem_in_output_path(tmp_path: Path) -> None:
+    sink = VideoSink()
+    sink.output_path = tmp_path / "$input_stem$.mp4"
+    sink.fps = 30.0
+
+    src = _PathStampedSource(
+        [_bgr(40), _bgr(120), _bgr(200)], source_path=Path("/in/clip.mp4"),
+    )
+    flow = Flow("video_stem")
+    flow.add_node(src)
+    flow.add_node(sink)
+    flow.connect(src, 0, sink, 0)
+    flow.run()
+
+    out = tmp_path / "clip.mp4"
+    assert out.exists() and out.stat().st_size > 0
+
+    cap = cv2.VideoCapture(str(out))
+    try:
+        assert int(cap.get(cv2.CAP_PROP_FRAME_COUNT)) >= 1
+    finally:
+        cap.release()
+
+
+def test_video_sink_flow_name_expands(tmp_path: Path) -> None:
+    sink = VideoSink()
+    sink.output_path = tmp_path / "$input_stem$.$flow_name$.mp4"
+    sink.fps = 30.0
+
+    src = _PathStampedSource([_bgr(40), _bgr(120)], source_path=Path("clip.mp4"))
+    flow = Flow("denoise_v2")
+    flow.add_node(src)
+    flow.add_node(sink)
+    flow.connect(src, 0, sink, 0)
+    flow.run()
+
+    assert (tmp_path / "clip.denoise_v2.mp4").exists()


### PR DESCRIPTION
## Summary

Implement output-filename placeholder expansion for sink nodes, allowing dynamic filename generation based on input source paths, flow names, frame indices, and timestamps. This enables common workflows like converting video streams to numbered image sequences or batch-processing files with flow-specific naming.

## Key Changes

- **New module `core.path_placeholders`**: Provides `expand_placeholders()` function that substitutes `$token$` placeholders in path templates with runtime values. Supported tokens:
  - `$input_stem$` — source filename without extension
  - `$input_name$` — source filename with extension
  - `$input_ext$` — file extension without dot
  - `$flow_name$` — currently-running flow name
  - `$frame_index$` — zero-padded 4-digit frame counter
  - `$timestamp$` — run start time in `YYYYMMDD_HHMMSS` format

- **Enhanced `IoData` class**: Added `source_path` property to carry originating filename through the processing pipeline. Source nodes (`ImageSource`, `VideoSource`, `DirectorySource`) now stamp the source path onto emitted `IoData`, and pass-through filters propagate it via `with_image()`.

- **Updated `FileSink`**: 
  - Expands placeholders in `output_path` on each frame write
  - Tracks per-run `_frame_index` (resets on each `run()` call) and `_run_started_at` timestamp
  - Creates parent directories as needed
  - Updated parameter description to document placeholder support

- **Updated `VideoSink`**:
  - Expands placeholders in `output_path` when opening the writer
  - Treats `$frame_index$` as always `0` (one file per run, not per frame)
  - Updated parameter description to document placeholder support

- **Flow integration**: Added `set_current_flow_name()` and `get_current_flow_name()` to `core.node_base` so sinks can access the flow name during execution. `Flow.run()` publishes the flow name before processing and clears it in the finally block.

- **Comprehensive test coverage**:
  - Unit tests for placeholder expansion logic (`test_path_placeholders.py`)
  - End-to-end integration tests for both sinks (`test_sink_placeholders.py`)
  - Tests for `IoData.source_path` propagation (`test_io_data.py`)

## Notable Implementation Details

- **Backwards-compatible**: Paths with no placeholders are returned verbatim, preserving existing behavior for literal filenames like `out.png`.
- **Unknown tokens pass through**: Typos in placeholder names (e.g., `$nope$`) are left unchanged in the output so users can spot mistakes in resulting filenames.
- **Unresolved known tokens expand to empty string**: If a known token has no value (e.g., `$input_stem$` when source_path is None), it expands to `""` rather than raising an error, making the feature graceful for edge cases.
- **Frame index resets per run**: Running a flow twice restarts the frame counter at 0, ensuring consistent output filenames across multiple runs of the same input.
- **VideoSink frame index locked to 0**: Since video sinks write one container per run, `$frame_index$` always expands to `0000` to avoid confusion.

## Version Bump

Updated to v0.2.24 with changelog entry documenting the new feature and use cases.

https://claude.ai/code/session_013vgTr2gbT6GjkhUERpm6ST