### PR TITLE
feat: interactive resize grips on BackdropItem (#192)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,21 @@ once a first tagged release is cut.
 
 ## [Unreleased]
 
+## [0.2.23] — 2026-04-28
+
+### Added
+- **Backdrop resize grips.** Backdrops can now be resized after
+  creation. Hovering or selecting a backdrop reveals eight grips
+  (four corners, four edge midpoints); dragging any grip resizes
+  the rectangle live, with the opposite corner / edge anchored.
+  Width and height clamp at the existing
+  ``MIN_BACKDROP_WIDTH`` / ``MIN_BACKDROP_HEIGHT`` so the frame
+  never collapses into an unclickable sliver. Resizing changes
+  only the frame's geometry — the framed nodes are never swept
+  (that still requires dragging the body). Resized geometry
+  round-trips through save / load like every other backdrop
+  property. Issue #192.
+
 ## [0.2.22] — 2026-04-27
 
 ### Added

--- a/doc/welcome.html
+++ b/doc/welcome.html
@@ -180,7 +180,7 @@
   <main class="content-col">
 
     <header class="hero">
-      <h1>Welcome to Stjörnhorn <span class="version">v0.2.22</span></h1>
+      <h1>Welcome to Stjörnhorn <span class="version">v0.2.23</span></h1>
       <div class="tagline">A node-based image- and video-processing playground.</div>
     </header>
 
@@ -210,6 +210,13 @@
           <p>Write frames to image files or encode video (MP4V, XVID) with live preview via the Display node.</p>
         </div>
       </div>
+    </section>
+
+    <section>
+      <h2>What's new in v0.2.23</h2>
+      <ul class="tips">
+        <li><strong>Backdrop resize grips.</strong> Backdrops are now interactively resizable: hovering or selecting one reveals eight grips (four corners, four edge midpoints). Drag any grip to resize the frame live, with the opposite corner / edge anchored. Width and height clamp at the existing minimum so a backdrop can't collapse into an invisible sliver. Resizing only changes the frame's geometry — the framed nodes still move only when you drag the body. Issue #192.</li>
+      </ul>
     </section>
 
     <section>

--- a/src/constants.py
+++ b/src/constants.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 APP_NAME:         str = "Image-Inquest"
 APP_DISPLAY_NAME: str = "Stjörnhorn"
-APP_VERSION:      str = "0.2.22"
+APP_VERSION:      str = "0.2.23"
 API_URL:    str = "https://beltoforion.de"
 
 # Path resolution -----------------------------------------------------------

--- a/src/ui/backdrop_item.py
+++ b/src/ui/backdrop_item.py
@@ -13,6 +13,28 @@ from PySide6.QtGui import (
 )
 from PySide6.QtWidgets import QGraphicsItem
 
+
+#: Layout of the eight resize grips around a backdrop. ``dx`` / ``dy``
+#: are the direction multipliers for the edge each grip controls:
+#: ``-1`` = left / top edge, ``+1`` = right / bottom edge, ``0`` =
+#: that axis is not affected by this grip. The ``cursor`` is the Qt
+#: shape shown while hovering / dragging the grip.
+_GRIP_LAYOUT: tuple[tuple[str, int, int, Qt.CursorShape], ...] = (
+    ("nw", -1, -1, Qt.CursorShape.SizeFDiagCursor),
+    ("n",   0, -1, Qt.CursorShape.SizeVerCursor),
+    ("ne", +1, -1, Qt.CursorShape.SizeBDiagCursor),
+    ("w",  -1,  0, Qt.CursorShape.SizeHorCursor),
+    ("e",  +1,  0, Qt.CursorShape.SizeHorCursor),
+    ("sw", -1, +1, Qt.CursorShape.SizeBDiagCursor),
+    ("s",   0, +1, Qt.CursorShape.SizeVerCursor),
+    ("se", +1, +1, Qt.CursorShape.SizeFDiagCursor),
+)
+
+#: Edge length of a square resize grip, in scene units. Small enough
+#: that the eight grips don't visually crowd the frame, large enough
+#: to be a comfortable click target.
+_GRIP_SIZE: float = 8.0
+
 from ui.theme import NODE_BORDER_SELECTED, NODE_TITLE_TEXT_COLOR
 
 if TYPE_CHECKING:
@@ -58,10 +80,12 @@ class BackdropItem(QGraphicsItem):
 
     Sits on a lower Z than nodes (:attr:`Z_VALUE`) so mouse events
     on the interior of a framed group still reach the node on top.
-    Drag the title bar to move; the geometry is fixed at creation
-    time (see :meth:`FlowScene.create_group_around_selection`) and
-    is not interactively resizable — the framed group's contents are
-    expected to evolve, not the frame itself.
+    Drag the title bar to move. Eight resize grips (four corners,
+    four edge midpoints) appear when the backdrop is hovered or
+    selected; dragging any grip resizes the rectangle, with the
+    opposite corner / edge anchored. Resizing only changes the
+    frame's geometry — it never moves the framed nodes (those move
+    only when the user drags the body, not a grip).
 
     The header carries an X close button on the right edge, mirroring
     the affordance every regular node has.
@@ -98,6 +122,13 @@ class BackdropItem(QGraphicsItem):
         # exactly what they want to drag together.
         self._captured_snapshot: list = []
         self._drag_anchor_pos: QPointF | None = None
+        # Reveal-state for the resize grips. Qt routes hover to the
+        # topmost item under the cursor, so the body and the grips
+        # never both report ``hovered=True`` at the same time —
+        # tracking each separately keeps the grips visible while
+        # the cursor crosses from body to grip and back.
+        self._body_hovered: bool = False
+        self._grip_hover_count: int = 0
 
         self.setZValue(self.Z_VALUE)
         self.setFlag(QGraphicsItem.GraphicsItemFlag.ItemIsMovable, True)
@@ -105,8 +136,20 @@ class BackdropItem(QGraphicsItem):
         self.setFlag(
             QGraphicsItem.GraphicsItemFlag.ItemSendsScenePositionChanges, True,
         )
+        # Hover events drive the reveal of the resize grips. Without
+        # this flag, hoverEnter/Leave never fire and the grips would
+        # only show on selection.
+        self.setAcceptHoverEvents(True)
 
         self._close_button = _BackdropCloseButton(self)
+        self._grips: list[_BackdropResizeGrip] = [
+            _BackdropResizeGrip(self, name, dx, dy, cursor)
+            for name, dx, dy, cursor in _GRIP_LAYOUT
+        ]
+        # Grips stay invisible until the backdrop is hovered / selected;
+        # they shouldn't compete with the chrome of framed nodes.
+        for grip in self._grips:
+            grip.setVisible(False)
         self._reposition_children()
 
     # ── Public API ─────────────────────────────────────────────────────────────
@@ -136,11 +179,13 @@ class BackdropItem(QGraphicsItem):
         return self._height
 
     def set_size(self, width: float, height: float) -> None:
-        """Update the backdrop rectangle. Used by the loader and
-        :meth:`FlowScene.create_group_around_selection` — the user
-        can't drive this at runtime since the frame has no resize
-        handles. The minimum clamp is kept as defensive sanity for
-        legacy flow files.
+        """Update the backdrop rectangle.
+
+        Called by the loader, :meth:`FlowScene.create_group_around_selection`,
+        and the interactive resize grips. ``width`` / ``height`` are
+        clamped at :data:`MIN_BACKDROP_WIDTH` / :data:`MIN_BACKDROP_HEIGHT`
+        so a grip dragged past the minimum stops the rectangle from
+        collapsing into an unclickable sliver.
         """
         new_w = max(MIN_BACKDROP_WIDTH, float(width))
         new_h = max(MIN_BACKDROP_HEIGHT, float(height))
@@ -205,7 +250,40 @@ class BackdropItem(QGraphicsItem):
             delta = self.scenePos() - self._drag_anchor_pos
             for node_item, start_pos in self._captured_snapshot:
                 node_item.setPos(start_pos + delta)
+        elif change == QGraphicsItem.GraphicsItemChange.ItemSelectedHasChanged:
+            self._refresh_grip_visibility()
         return super().itemChange(change, value)
+
+    # ── Hover-driven grip reveal ───────────────────────────────────────────────
+
+    def hoverEnterEvent(self, event) -> None:  # type: ignore[override]
+        self._body_hovered = True
+        self._refresh_grip_visibility()
+        super().hoverEnterEvent(event)
+
+    def hoverLeaveEvent(self, event) -> None:  # type: ignore[override]
+        self._body_hovered = False
+        self._refresh_grip_visibility()
+        super().hoverLeaveEvent(event)
+
+    def _on_grip_hover_changed(self, entering: bool) -> None:
+        """Bumped by each child grip on hoverEnter / hoverLeave so the
+        grips stay visible while the cursor crosses from the body
+        onto a grip."""
+        if entering:
+            self._grip_hover_count += 1
+        elif self._grip_hover_count > 0:
+            self._grip_hover_count -= 1
+        self._refresh_grip_visibility()
+
+    def _refresh_grip_visibility(self) -> None:
+        visible = (
+            self._body_hovered
+            or self._grip_hover_count > 0
+            or self.isSelected()
+        )
+        for grip in self._grips:
+            grip.setVisible(visible)
 
     # ── Qt overrides ───────────────────────────────────────────────────────────
 
@@ -261,7 +339,8 @@ class BackdropItem(QGraphicsItem):
     # ── Internals ──────────────────────────────────────────────────────────────
 
     def _reposition_children(self) -> None:
-        """Place the close button in its header slot.
+        """Place the close button in its header slot and the eight
+        resize grips at the corners and edge midpoints.
 
         Called from :meth:`set_size` and from ``__init__``.
         """
@@ -271,6 +350,31 @@ class BackdropItem(QGraphicsItem):
             self._width - cb_size - margin,
             (self.HEADER_HEIGHT - cb_size) / 2.0,
         )
+
+        if not getattr(self, "_grips", None):
+            return
+        gs = _GRIP_SIZE
+        half = gs / 2.0
+        w = self._width
+        h = self._height
+        # Top-left corner of each grip in local coords. Grips sit
+        # fully inside the backdrop's body so the cursor crosses the
+        # body first on its way to a grip — that way the backdrop's
+        # hoverEnter fires and the grips become visible *before* the
+        # user reaches them.
+        positions = {
+            "nw": (0,            0),
+            "n":  (w / 2 - half, 0),
+            "ne": (w - gs,       0),
+            "w":  (0,            h / 2 - half),
+            "e":  (w - gs,       h / 2 - half),
+            "sw": (0,            h - gs),
+            "s":  (w / 2 - half, h - gs),
+            "se": (w - gs,       h - gs),
+        }
+        for grip in self._grips:
+            x, y = positions[grip.name]
+            grip.setPos(x, y)
 
 
 class _BackdropCloseButton(QGraphicsItem):
@@ -342,3 +446,148 @@ class _BackdropCloseButton(QGraphicsItem):
             event.accept()
             return
         super().mouseReleaseEvent(event)
+
+
+class _BackdropResizeGrip(QGraphicsItem):
+    """Square resize handle anchored to one edge or corner of a
+    :class:`BackdropItem`.
+
+    The grip lives as a child of the backdrop, drawn in local coords
+    so :meth:`BackdropItem._reposition_children` can place it without
+    any scene-coord arithmetic. ``dx`` and ``dy`` are direction
+    multipliers for the edge this grip controls — ``-1`` means the
+    grip drives the left / top edge (so the right / bottom stays
+    anchored), ``+1`` the opposite, ``0`` means that axis is
+    untouched. The four-corner grips have both axes non-zero, the
+    four edge-midpoint grips have exactly one axis zero.
+
+    Resize math runs in scene coords, snapshotted at press-time, so
+    the grip's own per-frame position update during the drag never
+    feeds back into the cursor delta.
+    """
+
+    Z_VALUE: int = 1
+
+    def __init__(
+        self,
+        backdrop: BackdropItem,
+        name: str,
+        dx: int,
+        dy: int,
+        cursor: Qt.CursorShape,
+    ) -> None:
+        super().__init__(parent=backdrop)
+        self._backdrop = backdrop
+        self.name: str = name
+        self._dx: int = dx
+        self._dy: int = dy
+        self._press_scene_pos: QPointF | None = None
+        self._press_backdrop_pos: QPointF | None = None
+        self._press_width: float = 0.0
+        self._press_height: float = 0.0
+        self._dirty_during_drag: bool = False
+
+        self.setZValue(self.Z_VALUE)
+        self.setAcceptHoverEvents(True)
+        self.setAcceptedMouseButtons(Qt.MouseButton.LeftButton)
+        self.setCursor(cursor)
+
+    def boundingRect(self) -> QRectF:  # type: ignore[override]
+        return QRectF(0, 0, _GRIP_SIZE, _GRIP_SIZE)
+
+    def paint(self, painter: QPainter, option, widget=None) -> None:  # type: ignore[override]
+        painter.setRenderHint(QPainter.RenderHint.Antialiasing, True)
+        painter.setPen(QPen(NODE_BORDER_SELECTED, 1.0))
+        painter.setBrush(QBrush(QColor(40, 40, 40, 220)))
+        painter.drawRect(self.boundingRect().adjusted(0.5, 0.5, -0.5, -0.5))
+
+    def hoverEnterEvent(self, event) -> None:  # type: ignore[override]
+        self._backdrop._on_grip_hover_changed(entering=True)
+        super().hoverEnterEvent(event)
+
+    def hoverLeaveEvent(self, event) -> None:  # type: ignore[override]
+        self._backdrop._on_grip_hover_changed(entering=False)
+        super().hoverLeaveEvent(event)
+
+    def mousePressEvent(self, event) -> None:  # type: ignore[override]
+        if event.button() != Qt.MouseButton.LeftButton:
+            super().mousePressEvent(event)
+            return
+        # Snapshot scene-coord state so per-frame updates compute the
+        # cursor delta against a fixed reference, not against the
+        # grip's own moving position.
+        self._press_scene_pos = event.scenePos()
+        self._press_backdrop_pos = QPointF(self._backdrop.pos())
+        self._press_width = self._backdrop.width
+        self._press_height = self._backdrop.height
+        self._dirty_during_drag = False
+        event.accept()
+
+    def mouseMoveEvent(self, event) -> None:  # type: ignore[override]
+        if self._press_scene_pos is None:
+            super().mouseMoveEvent(event)
+            return
+        delta = event.scenePos() - self._press_scene_pos
+        self._apply_resize(delta.x(), delta.y())
+        event.accept()
+
+    def mouseReleaseEvent(self, event) -> None:  # type: ignore[override]
+        if event.button() != Qt.MouseButton.LeftButton or self._press_scene_pos is None:
+            super().mouseReleaseEvent(event)
+            return
+        if self._dirty_during_drag:
+            scene = self._backdrop.scene()
+            if scene is not None and hasattr(scene, "mark_dirty"):
+                scene.mark_dirty()
+        self._press_scene_pos = None
+        self._press_backdrop_pos = None
+        self._press_width = 0.0
+        self._press_height = 0.0
+        self._dirty_during_drag = False
+        event.accept()
+
+    def _apply_resize(self, scene_dx: float, scene_dy: float) -> None:
+        """Compute the new backdrop geometry from a scene-coord delta
+        and push it through :meth:`BackdropItem.set_size` (plus a
+        ``setPos`` for grips that move the top / left edge).
+
+        Clamping happens before the position adjustment so that
+        dragging past the minimum holds the anchored corner truly
+        fixed instead of letting it drift.
+        """
+        assert self._press_backdrop_pos is not None
+        dx = self._dx
+        dy = self._dy
+
+        if dx == +1:
+            new_w = max(MIN_BACKDROP_WIDTH, self._press_width + scene_dx)
+            pos_dx = 0.0
+        elif dx == -1:
+            new_w = max(MIN_BACKDROP_WIDTH, self._press_width - scene_dx)
+            # Effective left-edge shift: identical to scene_dx until we
+            # hit the minimum, then pinned so the right edge stays put.
+            pos_dx = self._press_width - new_w
+        else:
+            new_w = self._press_width
+            pos_dx = 0.0
+
+        if dy == +1:
+            new_h = max(MIN_BACKDROP_HEIGHT, self._press_height + scene_dy)
+            pos_dy = 0.0
+        elif dy == -1:
+            new_h = max(MIN_BACKDROP_HEIGHT, self._press_height - scene_dy)
+            pos_dy = self._press_height - new_h
+        else:
+            new_h = self._press_height
+            pos_dy = 0.0
+
+        new_pos = QPointF(
+            self._press_backdrop_pos.x() + pos_dx,
+            self._press_backdrop_pos.y() + pos_dy,
+        )
+        if new_pos != self._backdrop.pos():
+            self._backdrop.setPos(new_pos)
+            self._dirty_during_drag = True
+        if (new_w, new_h) != (self._backdrop.width, self._backdrop.height):
+            self._backdrop.set_size(new_w, new_h)
+            self._dirty_during_drag = True

--- a/tests/test_backdrop.py
+++ b/tests/test_backdrop.py
@@ -273,3 +273,158 @@ def test_create_group_marks_scene_dirty(qapp: QApplication) -> None:
     assert scene.is_dirty is False
     scene.create_group_around_selection()
     assert scene.is_dirty is True
+
+
+# ── Interactive resize grips (issue #192) ─────────────────────────────────────
+
+
+def _grip_named(backdrop: BackdropItem, name: str):
+    """Look up a child resize grip by its compass name."""
+    return next(g for g in backdrop._grips if g.name == name)  # noqa: SLF001
+
+
+def _drive_grip(backdrop: BackdropItem, name: str, dx: float, dy: float):
+    """Simulate a grip press + drag without spinning a Qt event loop.
+
+    Mirrors the bookkeeping the real ``mousePressEvent`` /
+    ``mouseMoveEvent`` would set, then invokes ``_apply_resize``
+    with the requested scene-coord delta. Returns the grip so the
+    caller can assert on its press-time snapshot if needed.
+    """
+    grip = _grip_named(backdrop, name)
+    grip._press_scene_pos = QPointF(0, 0)            # noqa: SLF001
+    grip._press_backdrop_pos = QPointF(backdrop.pos())  # noqa: SLF001
+    grip._press_width = backdrop.width                # noqa: SLF001
+    grip._press_height = backdrop.height              # noqa: SLF001
+    grip._dirty_during_drag = False                   # noqa: SLF001
+    grip._apply_resize(dx, dy)                        # noqa: SLF001
+    return grip
+
+
+def test_backdrop_has_eight_resize_grips(qapp: QApplication) -> None:
+    backdrop = BackdropItem()
+    assert len(backdrop._grips) == 8
+    names = {g.name for g in backdrop._grips}
+    assert names == {"nw", "n", "ne", "w", "e", "sw", "s", "se"}
+
+
+def test_grips_are_hidden_by_default(qapp: QApplication) -> None:
+    """Idle backdrops shouldn't show their grips — they'd compete
+    with the chrome of the framed nodes."""
+    backdrop = BackdropItem()
+    assert all(not g.isVisible() for g in backdrop._grips)
+
+
+def test_grips_become_visible_when_selected(qapp: QApplication) -> None:
+    scene = FlowScene()
+    scene.set_flow(Flow(name="grip_select"))
+    backdrop = scene.add_backdrop(QPointF(0, 0))
+    backdrop.setSelected(True)
+    assert all(g.isVisible() for g in backdrop._grips)
+    backdrop.setSelected(False)
+    assert all(not g.isVisible() for g in backdrop._grips)
+
+
+def test_grips_stay_visible_while_cursor_crosses_from_body_to_grip(
+    qapp: QApplication,
+) -> None:
+    """Qt routes hover to the topmost item, so the body sees a
+    hoverLeave the moment the cursor enters a child grip. The grips
+    must stay visible across that transition or the user can never
+    actually grab them."""
+    backdrop = BackdropItem()
+    backdrop._body_hovered = True               # noqa: SLF001 — simulate body hoverEnter
+    backdrop._refresh_grip_visibility()         # noqa: SLF001
+    assert all(g.isVisible() for g in backdrop._grips)
+    # Cursor moves onto a grip: body fires hoverLeave, grip fires hoverEnter.
+    backdrop._body_hovered = False              # noqa: SLF001
+    backdrop._on_grip_hover_changed(entering=True)  # noqa: SLF001
+    backdrop._refresh_grip_visibility()         # noqa: SLF001
+    assert all(g.isVisible() for g in backdrop._grips)
+    # Cursor leaves the grip back into open scene: both flags clear, grips hide.
+    backdrop._on_grip_hover_changed(entering=False)  # noqa: SLF001
+    assert all(not g.isVisible() for g in backdrop._grips)
+
+
+def test_se_grip_grows_width_and_height_keeping_top_left_anchored(
+    qapp: QApplication,
+) -> None:
+    backdrop = BackdropItem(width=200, height=150)
+    backdrop.setPos(QPointF(40, 30))
+    _drive_grip(backdrop, "se", dx=50, dy=20)
+    assert backdrop.width == pytest.approx(250)
+    assert backdrop.height == pytest.approx(170)
+    # SE grip leaves the top-left corner alone.
+    assert backdrop.pos() == QPointF(40, 30)
+
+
+def test_nw_grip_shrinks_size_and_moves_top_left(qapp: QApplication) -> None:
+    backdrop = BackdropItem(width=200, height=150)
+    backdrop.setPos(QPointF(40, 30))
+    _drive_grip(backdrop, "nw", dx=20, dy=10)
+    # Width/height shrink by the drag delta, top-left moves the same.
+    assert backdrop.width == pytest.approx(180)
+    assert backdrop.height == pytest.approx(140)
+    assert backdrop.pos().x() == pytest.approx(60)
+    assert backdrop.pos().y() == pytest.approx(40)
+
+
+def test_n_grip_changes_only_height_and_top_y(qapp: QApplication) -> None:
+    backdrop = BackdropItem(width=200, height=150)
+    backdrop.setPos(QPointF(40, 30))
+    _drive_grip(backdrop, "n", dx=999, dy=15)
+    # The horizontal axis is untouched — dx is irrelevant for N.
+    assert backdrop.width == pytest.approx(200)
+    assert backdrop.height == pytest.approx(135)
+    assert backdrop.pos().x() == pytest.approx(40)
+    assert backdrop.pos().y() == pytest.approx(45)
+
+
+def test_resize_clamps_at_minimum_dimensions(qapp: QApplication) -> None:
+    """Dragging a grip past the minimum holds the anchored corner
+    truly fixed instead of letting it drift past."""
+    backdrop = BackdropItem(width=200, height=150)
+    backdrop.setPos(QPointF(40, 30))
+    # Way over-shrink via NW grip — drag goes far past the minimum.
+    _drive_grip(backdrop, "nw", dx=10_000, dy=10_000)
+    assert backdrop.width == pytest.approx(MIN_BACKDROP_WIDTH)
+    assert backdrop.height == pytest.approx(MIN_BACKDROP_HEIGHT)
+    # Anchored corner (bottom-right) must be where it was at press-time.
+    assert backdrop.pos().x() == pytest.approx(40 + (200 - MIN_BACKDROP_WIDTH))
+    assert backdrop.pos().y() == pytest.approx(30 + (150 - MIN_BACKDROP_HEIGHT))
+
+
+def test_resize_does_not_sweep_framed_nodes(qapp: QApplication) -> None:
+    """The framed nodes must stay put during a resize — only a
+    body-drag is allowed to move them."""
+    from nodes.sources.image_source import ImageSource
+    scene = FlowScene()
+    scene.set_flow(Flow(name="resize_no_sweep"))
+    backdrop = scene.add_backdrop(QPointF(0, 0), width=400, height=300)
+    node = scene.add_node(ImageSource(), QPointF(50, 50))
+    start_pos = node.pos()
+    _drive_grip(backdrop, "se", dx=80, dy=60)
+    assert node.pos() == start_pos
+
+
+def test_resized_geometry_round_trips_through_save_and_load(
+    qapp: QApplication, tmp_path: Path,
+) -> None:
+    scene = FlowScene()
+    flow = Flow(name="resize_roundtrip")
+    scene.set_flow(flow)
+    backdrop = scene.add_backdrop(
+        QPointF(100, 50), title="Mask prep", width=300, height=180,
+    )
+    _drive_grip(backdrop, "se", dx=50, dy=40)
+    assert backdrop.width == 350 and backdrop.height == 220
+
+    path = tmp_path / "bd_resized.flowjs"
+    save_flow_to(path, scene, flow)
+
+    fresh = FlowScene()
+    load_flow_into(path, fresh)
+    [reloaded] = fresh.iter_backdrops()
+    assert reloaded.width == 350
+    assert reloaded.height == 220
+    assert reloaded.pos().x() == 100 and reloaded.pos().y() == 50


### PR DESCRIPTION
Eight grips (four corners + four edge midpoints) appear on hover or selection, drawn as 8 px squares fully inside the backdrop's body so the cursor crosses the body first and reveals them before the user reaches them. Dragging any grip resizes the rectangle live, with the opposite corner / edge anchored:

- corner grips drive both axes,
- edge grips drive a single axis,
- top / left grips also shift the backdrop's scenePos so the bottom / right edge stays put.

Width and height clamp at MIN_BACKDROP_WIDTH / MIN_BACKDROP_HEIGHT; the position adjustment uses the clamped size so the anchored corner stays truly fixed when the user drags past the minimum.

Resizing routes through the grip's own mouse handlers and explicitly does *not* engage the body's captured-group drag, so the framed nodes never move during a resize. Resized geometry round-trips through save / load via the existing flow_io path (no flow_io changes needed).

Bumps APP_VERSION 0.2.22 → 0.2.23 and updates CHANGELOG + doc/welcome.html.

Fixes #192