### PR TITLE
Clean up old nightly release assets before uploading new ones

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -157,6 +157,27 @@ jobs:
           git tag -f nightly
           git push -f origin nightly
 
+      # Filenames embed the date+sha, so old assets would otherwise pile up
+      # on the rolling `nightly` release. Delete every existing asset before
+      # the upload step recreates the current ones.
+      - name: Purge existing nightly assets
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -eu
+          if gh release view nightly --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            names=$(gh release view nightly --repo "$GITHUB_REPOSITORY" \
+              --json assets --jq '.assets[].name')
+            while IFS= read -r name; do
+              [ -z "$name" ] && continue
+              echo "Deleting old asset: $name"
+              gh release delete-asset nightly "$name" \
+                --repo "$GITHUB_REPOSITORY" --yes
+            done <<< "$names"
+          else
+            echo "No existing nightly release – nothing to purge."
+          fi
+
       - uses: softprops/action-gh-release@v2
         with:
           tag_name: nightly


### PR DESCRIPTION
## Summary
This change adds a cleanup step to the nightly release workflow that removes all existing assets from the rolling `nightly` release before uploading new ones. This prevents old build artifacts from accumulating on the release page.

## Key Changes
- Added a new "Purge existing nightly assets" workflow step that runs before the asset upload
- Uses GitHub CLI (`gh`) to check if a nightly release exists
- Iterates through all existing assets and deletes them individually
- Gracefully handles the case where no nightly release exists yet
- Includes informative logging for each deleted asset

## Implementation Details
- The step uses `gh release view` to check for an existing nightly release and fetch asset names
- Asset deletion is performed with `gh release delete-asset` with the `--yes` flag to skip confirmation
- The script properly handles empty lines in the asset list with `[ -z "$name" ] && continue`
- Error handling is enabled with `set -eu` to fail fast on any issues
- This cleanup is necessary because filenames embed date+sha, which would otherwise cause old assets to pile up on the rolling nightly release

https://claude.ai/code/session_01KwGFD2LZn4Y2wVnKB8gGFm