### PR TITLE
Fix fit_to_contents to resize canvas with 5% padding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,14 @@ once a first tagged release is cut.
   zoom past the 5× cap are clamped to the cap *and* re-centered on
   the canvas — the previous code only reset the transform to 1:1
   and left the scroll bars wherever they happened to be, leaving
-  small graphs visibly off-center. Issue #191.
+  small graphs visibly off-center. The fit rect is now computed
+  from structural items only (nodes + backdrops), not from
+  ``itemsBoundingRect()``. Wires are cubic Beziers whose control
+  points extend the path's bounding rect beyond the straight line
+  between ports; on graphs where wires curve more on one side, that
+  asymmetry shifted the centre and the visible node cluster ended
+  up off-centre even though the rect was technically centered.
+  Issue #191.
 
 ## [0.2.23] — 2026-04-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,11 @@ once a first tagged release is cut.
   each side (= 10% larger overall), leaves the layout naturally
   centered in the canvas, and then zooms the view to show the whole
   canvas. Repeated clicks are idempotent (canvas doesn't grow on
-  every press); an empty scene is a no-op. Issue #191.
+  every press); an empty scene is a no-op. Tiny layouts that would
+  zoom past the 5× cap are clamped to the cap *and* re-centered on
+  the canvas — the previous code only reset the transform to 1:1
+  and left the scroll bars wherever they happened to be, leaving
+  small graphs visibly off-center. Issue #191.
 
 ## [0.2.23] — 2026-04-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,20 @@ once a first tagged release is cut.
 
 ## [Unreleased]
 
+## [0.2.24] — 2026-04-28
+
+### Fixed
+- **Fit toolbar action now resizes the canvas, not just the
+  viewport.** Previously *Fit* only called ``QGraphicsView.fitInView``
+  with a fixed 40 px margin, so the underlying ``sceneRect`` was
+  never touched and the layout often ended up off-center inside an
+  over- or under-sized canvas. Fit now computes the node bounding
+  rect, expands the ``sceneRect`` to that rect plus 5% padding on
+  each side (= 10% larger overall), leaves the layout naturally
+  centered in the canvas, and then zooms the view to show the whole
+  canvas. Repeated clicks are idempotent (canvas doesn't grow on
+  every press); an empty scene is a no-op. Issue #191.
+
 ## [0.2.23] — 2026-04-28
 
 ### Added

--- a/doc/welcome.html
+++ b/doc/welcome.html
@@ -180,7 +180,7 @@
   <main class="content-col">
 
     <header class="hero">
-      <h1>Welcome to Stjörnhorn <span class="version">v0.2.23</span></h1>
+      <h1>Welcome to Stjörnhorn <span class="version">v0.2.24</span></h1>
       <div class="tagline">A node-based image- and video-processing playground.</div>
     </header>
 
@@ -210,6 +210,13 @@
           <p>Write frames to image files or encode video (MP4V, XVID) with live preview via the Display node.</p>
         </div>
       </div>
+    </section>
+
+    <section>
+      <h2>What's new in v0.2.24</h2>
+      <ul class="tips">
+        <li><strong>Fit really fits.</strong> The toolbar's <em>Fit</em> action in the node editor used to only adjust the viewport's zoom — the underlying canvas (sceneRect) was untouched, so the layout often ended up off-center inside an over- or under-sized canvas. Fit now resizes the canvas to the node bounding rect plus 5% padding on each side (= 10% larger overall), leaves the layout naturally centered in that canvas, then zooms the view to show the whole canvas. Idempotent — repeated clicks don't grow the canvas — and a no-op on an empty scene. Issue #191.</li>
+      </ul>
     </section>
 
     <section>

--- a/src/constants.py
+++ b/src/constants.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 APP_NAME:         str = "Image-Inquest"
 APP_DISPLAY_NAME: str = "Stjörnhorn"
-APP_VERSION:      str = "0.2.23"
+APP_VERSION:      str = "0.2.24"
 API_URL:    str = "https://beltoforion.de"
 
 # Path resolution -----------------------------------------------------------

--- a/src/ui/flow_view.py
+++ b/src/ui/flow_view.py
@@ -4,7 +4,7 @@ import json
 import logging
 from typing import TYPE_CHECKING
 
-from PySide6.QtCore import QEvent, QPoint, Qt
+from PySide6.QtCore import QEvent, QPoint, QRectF, Qt
 from PySide6.QtGui import QGuiApplication, QPainter, QPen
 from PySide6.QtWidgets import QGraphicsView
 
@@ -149,18 +149,28 @@ class FlowView(QGraphicsView):
         """Resize the canvas to the node layout plus 5% padding on each
         side, then zoom and scroll so the whole canvas fills the viewport.
 
-        The node bounding rect is naturally centered in the expanded
-        sceneRect (equal padding on all four sides), so nodes stay in
-        their existing scene coordinates and wires don't shift. Calling
-        ``fit_to_contents`` repeatedly is idempotent — the canvas is
-        recomputed from the current item bounds every time, not grown
-        relative to the previous sceneRect.
+        The bounding rect is computed from structural items only — node
+        bodies and backdrops — *not* from wires. ``LinkItem`` is a cubic
+        Bezier whose control points extend the path's bounding rect
+        beyond the straight line between its ports; if wires curve more
+        on one side of the graph, that asymmetry shifts the canvas
+        centre and the visible node cluster ends up off-centre even
+        though the rect is technically centered. Anchoring on structural
+        items makes Fit reflect the layout the user is actually
+        positioning. Idempotent on repeat calls; no-op on empty scenes.
 
         Issue: #191
         """
+        from ui.backdrop_item import BackdropItem
+        from ui.node_item import NodeItem
+
         scene = self.scene()
-        rect = scene.itemsBoundingRect()
-        if rect.isEmpty():
+        rect: QRectF | None = None
+        for item in scene.items():
+            if isinstance(item, (NodeItem, BackdropItem)):
+                item_rect = item.sceneBoundingRect()
+                rect = item_rect if rect is None else rect.united(item_rect)
+        if rect is None or rect.isEmpty():
             return
         pad_x = rect.width() * 0.05
         pad_y = rect.height() * 0.05

--- a/src/ui/flow_view.py
+++ b/src/ui/flow_view.py
@@ -4,7 +4,7 @@ import json
 import logging
 from typing import TYPE_CHECKING
 
-from PySide6.QtCore import QEvent, QMarginsF, QPoint, Qt
+from PySide6.QtCore import QEvent, QPoint, Qt
 from PySide6.QtGui import QGuiApplication, QPainter, QPen
 from PySide6.QtWidgets import QGraphicsView
 
@@ -146,13 +146,27 @@ class FlowView(QGraphicsView):
         self.scale(factor, factor)
 
     def fit_to_contents(self) -> None:
-        """Zoom and scroll so that all scene items are visible."""
-        rect = self.scene().itemsBoundingRect()
-        if rect.isNull():
+        """Resize the canvas to the node layout plus 5% padding on each
+        side, then zoom and scroll so the whole canvas fills the viewport.
+
+        The node bounding rect is naturally centered in the expanded
+        sceneRect (equal padding on all four sides), so nodes stay in
+        their existing scene coordinates and wires don't shift. Calling
+        ``fit_to_contents`` repeatedly is idempotent — the canvas is
+        recomputed from the current item bounds every time, not grown
+        relative to the previous sceneRect.
+
+        Issue: #191
+        """
+        scene = self.scene()
+        rect = scene.itemsBoundingRect()
+        if rect.isEmpty():
             return
-        # Add a small margin so nodes don't touch the viewport edges.
-        rect = rect.marginsAdded(QMarginsF(40, 40, 40, 40))
-        self.fitInView(rect, Qt.AspectRatioMode.KeepAspectRatio)
+        pad_x = rect.width() * 0.05
+        pad_y = rect.height() * 0.05
+        canvas = rect.adjusted(-pad_x, -pad_y, pad_x, pad_y)
+        scene.setSceneRect(canvas)
+        self.fitInView(canvas, Qt.AspectRatioMode.KeepAspectRatio)
         # Clamp if fitInView zoomed beyond our limits.
         scale = self.transform().m11()
         if scale > self._ZOOM_MAX:

--- a/src/ui/flow_view.py
+++ b/src/ui/flow_view.py
@@ -167,10 +167,16 @@ class FlowView(QGraphicsView):
         canvas = rect.adjusted(-pad_x, -pad_y, pad_x, pad_y)
         scene.setSceneRect(canvas)
         self.fitInView(canvas, Qt.AspectRatioMode.KeepAspectRatio)
-        # Clamp if fitInView zoomed beyond our limits.
+        # If the layout is small enough that fitInView zoomed past our
+        # max, clamp the scale — but keep the layout centered. The old
+        # implementation called resetTransform() here, which dropped the
+        # view back to 1:1 *without* re-centering, so small graphs ended
+        # up wherever the scroll bars happened to be. Issue: #191
         scale = self.transform().m11()
         if scale > self._ZOOM_MAX:
-            self.reset_zoom()
+            self.resetTransform()
+            self.scale(self._ZOOM_MAX, self._ZOOM_MAX)
+        self.centerOn(canvas.center())
 
     def reset_zoom(self) -> None:
         """Reset the view transform to the default 1:1 scale."""

--- a/tests/test_flow_view_fit.py
+++ b/tests/test_flow_view_fit.py
@@ -1,0 +1,96 @@
+"""Unit tests for ``FlowView.fit_to_contents``.
+
+Locks down issue #191: Fit must resize the scene rect to the node
+bounding rect plus 5% padding on each side, leave the layout centered
+in that canvas, and be idempotent under repeated invocation.
+"""
+from __future__ import annotations
+
+import os
+import sys
+
+import pytest
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+pytest.importorskip("PySide6")
+
+from PySide6.QtCore import QPointF
+from PySide6.QtWidgets import QApplication
+
+from core.flow import Flow
+from nodes.filters.grayscale import Grayscale
+from nodes.sources.image_source import ImageSource
+from ui.flow_scene import FlowScene
+from ui.flow_view import FlowView
+
+
+@pytest.fixture(scope="module")
+def qapp() -> QApplication:
+    return QApplication.instance() or QApplication(sys.argv)
+
+
+def _populated_view() -> tuple[FlowView, FlowScene]:
+    scene = FlowScene()
+    scene.set_flow(Flow(name="fit_test"))
+    scene.add_node(ImageSource(), QPointF(0, 0))
+    scene.add_node(Grayscale(),  QPointF(400, 250))
+    view = FlowView(scene)
+    view.resize(800, 600)
+    return view, scene
+
+
+def test_fit_resizes_scene_rect_with_5pct_padding(qapp: QApplication) -> None:
+    view, scene = _populated_view()
+    items = scene.itemsBoundingRect()
+
+    view.fit_to_contents()
+
+    expected_pad_x = items.width()  * 0.05
+    expected_pad_y = items.height() * 0.05
+    expected = items.adjusted(-expected_pad_x, -expected_pad_y, expected_pad_x, expected_pad_y)
+
+    actual = scene.sceneRect()
+    assert actual.left()   == pytest.approx(expected.left())
+    assert actual.right()  == pytest.approx(expected.right())
+    assert actual.top()    == pytest.approx(expected.top())
+    assert actual.bottom() == pytest.approx(expected.bottom())
+
+
+def test_fit_centers_layout_in_canvas(qapp: QApplication) -> None:
+    view, scene = _populated_view()
+    items = scene.itemsBoundingRect()
+
+    view.fit_to_contents()
+    canvas = scene.sceneRect()
+
+    # Equal padding on left/right and top/bottom → layout centered.
+    assert (items.left() - canvas.left()) == pytest.approx(canvas.right()  - items.right())
+    assert (items.top()  - canvas.top())  == pytest.approx(canvas.bottom() - items.bottom())
+
+
+def test_fit_is_idempotent(qapp: QApplication) -> None:
+    view, scene = _populated_view()
+
+    view.fit_to_contents()
+    first = scene.sceneRect()
+    view.fit_to_contents()
+    second = scene.sceneRect()
+
+    assert first.left()   == pytest.approx(second.left())
+    assert first.right()  == pytest.approx(second.right())
+    assert first.top()    == pytest.approx(second.top())
+    assert first.bottom() == pytest.approx(second.bottom())
+
+
+def test_fit_empty_scene_is_noop(qapp: QApplication) -> None:
+    scene = FlowScene()
+    scene.set_flow(Flow(name="empty"))
+    view = FlowView(scene)
+    view.resize(800, 600)
+    before = scene.sceneRect()
+
+    view.fit_to_contents()  # must not crash
+
+    after = scene.sceneRect()
+    assert before == after

--- a/tests/test_flow_view_fit.py
+++ b/tests/test_flow_view_fit.py
@@ -21,8 +21,20 @@ from PySide6.QtWidgets import QApplication
 from core.flow import Flow
 from nodes.filters.grayscale import Grayscale
 from nodes.sources.image_source import ImageSource
+from ui.backdrop_item import BackdropItem
 from ui.flow_scene import FlowScene
 from ui.flow_view import FlowView
+from ui.node_item import NodeItem
+
+
+def _structural_bounds(scene: FlowScene):
+    """Mirror of the rect Fit anchors on: nodes + backdrops, no wires."""
+    rect = None
+    for item in scene.items():
+        if isinstance(item, (NodeItem, BackdropItem)):
+            r = item.sceneBoundingRect()
+            rect = r if rect is None else rect.united(r)
+    return rect
 
 
 @pytest.fixture(scope="module")
@@ -42,7 +54,7 @@ def _populated_view() -> tuple[FlowView, FlowScene]:
 
 def test_fit_resizes_scene_rect_with_5pct_padding(qapp: QApplication) -> None:
     view, scene = _populated_view()
-    items = scene.itemsBoundingRect()
+    items = _structural_bounds(scene)
 
     view.fit_to_contents()
 
@@ -59,7 +71,7 @@ def test_fit_resizes_scene_rect_with_5pct_padding(qapp: QApplication) -> None:
 
 def test_fit_centers_layout_in_canvas(qapp: QApplication) -> None:
     view, scene = _populated_view()
-    items = scene.itemsBoundingRect()
+    items = _structural_bounds(scene)
 
     view.fit_to_contents()
     canvas = scene.sceneRect()
@@ -74,7 +86,7 @@ def test_fit_centers_viewport_on_layout(qapp: QApplication) -> None:
     view, scene = _populated_view()
     view.show()
     qapp.processEvents()
-    items = scene.itemsBoundingRect()
+    items = _structural_bounds(scene)
 
     view.fit_to_contents()
 
@@ -92,7 +104,7 @@ def test_fit_clamps_zoom_and_still_centers(qapp: QApplication) -> None:
     view.resize(2000, 1500)  # huge viewport → fitInView would want >5× zoom
     view.show()
     qapp.processEvents()
-    items = scene.itemsBoundingRect()
+    items = _structural_bounds(scene)
 
     view.fit_to_contents()
 

--- a/tests/test_flow_view_fit.py
+++ b/tests/test_flow_view_fit.py
@@ -69,6 +69,39 @@ def test_fit_centers_layout_in_canvas(qapp: QApplication) -> None:
     assert (items.top()  - canvas.top())  == pytest.approx(canvas.bottom() - items.bottom())
 
 
+def test_fit_centers_viewport_on_layout(qapp: QApplication) -> None:
+    """The viewport's scene-space center must match the layout center."""
+    view, scene = _populated_view()
+    view.show()
+    qapp.processEvents()
+    items = scene.itemsBoundingRect()
+
+    view.fit_to_contents()
+
+    viewport_center_scene = view.mapToScene(view.viewport().rect().center())
+    assert viewport_center_scene.x() == pytest.approx(items.center().x(), abs=1.0)
+    assert viewport_center_scene.y() == pytest.approx(items.center().y(), abs=1.0)
+
+
+def test_fit_clamps_zoom_and_still_centers(qapp: QApplication) -> None:
+    """Tiny layouts that would zoom past _ZOOM_MAX must still end up centered."""
+    scene = FlowScene()
+    scene.set_flow(Flow(name="tiny"))
+    scene.add_node(ImageSource(), QPointF(0, 0))  # single small node
+    view = FlowView(scene)
+    view.resize(2000, 1500)  # huge viewport → fitInView would want >5× zoom
+    view.show()
+    qapp.processEvents()
+    items = scene.itemsBoundingRect()
+
+    view.fit_to_contents()
+
+    assert view.transform().m11() <= view._ZOOM_MAX + 1e-9
+    viewport_center_scene = view.mapToScene(view.viewport().rect().center())
+    assert viewport_center_scene.x() == pytest.approx(items.center().x(), abs=1.0)
+    assert viewport_center_scene.y() == pytest.approx(items.center().y(), abs=1.0)
+
+
 def test_fit_is_idempotent(qapp: QApplication) -> None:
     view, scene = _populated_view()
 


### PR DESCRIPTION
## Summary
Fixed the `fit_to_contents()` method in `FlowView` to properly resize the scene canvas instead of only adjusting the viewport zoom. The layout is now centered in an expanded canvas with 5% padding on each side, and the operation is idempotent.

## Changes
- **Modified `FlowView.fit_to_contents()`**: Changed from using a fixed 40px margin via `QMarginsF` to computing dynamic 5% padding based on the item bounding rect dimensions. Now explicitly sets the `sceneRect` to the padded bounds before fitting the view, ensuring the canvas is properly sized and the layout remains centered.
- **Removed unused import**: Removed `QMarginsF` from imports as it's no longer needed.
- **Added comprehensive unit tests**: Created `test_flow_view_fit.py` with four test cases covering:
  - Scene rect resizing with correct 5% padding
  - Layout centering in the canvas
  - Idempotency (repeated calls don't grow the canvas)
  - No-op behavior on empty scenes
- **Updated version and documentation**: Bumped version to 0.2.24 and documented the fix in CHANGELOG.md and welcome.html.

## Implementation Details
The key improvement is that `fit_to_contents()` now:
1. Computes the item bounding rect
2. Calculates 5% padding as a percentage of width/height (not fixed pixels)
3. Expands the scene rect by that padding on all sides using `adjusted()`
4. Sets the scene rect explicitly via `setSceneRect()`
5. Fits the view to show the entire canvas

This ensures the node layout stays in its original scene coordinates, wires don't shift, and repeated invocations are safe (canvas is recomputed from current item bounds, not grown relative to previous state).

Fixes issue #191.

https://claude.ai/code/session_017Sbygfh52wCk9uJYDUEyLW