### PR TITLE
Add Settings page with persistent debug logging toggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ once a first tagged release is cut.
 
 ## [Unreleased]
 
+## [0.2.25] — 2026-04-28
+
+### Added
+- **Settings page.** A new top-level page (toolbar selector next to
+  *Log*) hosts persistent application settings. The first entry is
+  *Enable debug logging*: when off (default) the rotating log file
+  captures INFO and above, when on it captures the full DEBUG stream.
+  The toggle is saved to ``~/.image-inquest/settings.json`` and is
+  applied both at next startup and live to the currently-running file
+  handler.
+
 ## [0.2.24] — 2026-04-28
 
 ### Fixed

--- a/doc/welcome.html
+++ b/doc/welcome.html
@@ -180,7 +180,7 @@
   <main class="content-col">
 
     <header class="hero">
-      <h1>Welcome to Stjörnhorn <span class="version">v0.2.24</span></h1>
+      <h1>Welcome to Stjörnhorn <span class="version">v0.2.25</span></h1>
       <div class="tagline">A node-based image- and video-processing playground.</div>
     </header>
 
@@ -210,6 +210,13 @@
           <p>Write frames to image files or encode video (MP4V, XVID) with live preview via the Display node.</p>
         </div>
       </div>
+    </section>
+
+    <section>
+      <h2>What's new in v0.2.25</h2>
+      <ul class="tips">
+        <li><strong>Settings page.</strong> A new top-level page (toolbar selector at the right of the Log button) hosts the application's persistent options. The first — and currently only — entry is <em>Enable debug logging</em>: when off (the default) the rotating log file at <code>~/.local/share/Stjornhorn/logs/image-inquest.log</code> captures only INFO and above; flip it on to capture the full DEBUG stream when reproducing a bug. The choice is saved to <code>~/.image-inquest/settings.json</code> and applied at next startup as well as live to the running file handler.</li>
+      </ul>
     </section>
 
     <section>

--- a/src/constants.py
+++ b/src/constants.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 APP_NAME:         str = "Image-Inquest"
 APP_DISPLAY_NAME: str = "Stjörnhorn"
-APP_VERSION:      str = "0.2.24"
+APP_VERSION:      str = "0.2.25"
 API_URL:    str = "https://beltoforion.de"
 
 # Path resolution -----------------------------------------------------------

--- a/src/log.py
+++ b/src/log.py
@@ -57,6 +57,12 @@ class _FixedWidthFormatter(logging.Formatter):
         return super().format(rec)
 
 
+#: Module-level handles to the configured handlers, kept around so
+#: :func:`set_debug_logging` can flip their level after startup without
+#: rebuilding the logging stack.
+_file_handler: logging.handlers.RotatingFileHandler | None = None
+
+
 def setup_logging(log_dir: Path, level: int = logging.DEBUG) -> None:
     """Configure the root logger.
 
@@ -64,6 +70,8 @@ def setup_logging(log_dir: Path, level: int = logging.DEBUG) -> None:
         log_dir: Directory where the log file is written (created if absent).
         level:   Minimum level captured by the file handler (default DEBUG).
     """
+    global _file_handler
+
     log_dir.mkdir(parents=True, exist_ok=True)
     log_file = log_dir / "image-inquest.log"
 
@@ -80,6 +88,7 @@ def setup_logging(log_dir: Path, level: int = logging.DEBUG) -> None:
     )
     file_handler.setLevel(level)
     file_handler.setFormatter(fmt)
+    _file_handler = file_handler
 
     # Console handler — only warnings and above to avoid noise
     console_handler = logging.StreamHandler()
@@ -87,7 +96,10 @@ def setup_logging(log_dir: Path, level: int = logging.DEBUG) -> None:
     console_handler.setFormatter(fmt)
 
     root = logging.getLogger()
-    root.setLevel(level)
+    # Root must stay at the lowest level we ever want to forward to a
+    # handler, otherwise records get filtered before reaching the file
+    # handler whose level we may flip up later.
+    root.setLevel(logging.DEBUG)
     root.addHandler(file_handler)
     root.addHandler(console_handler)
 
@@ -107,6 +119,23 @@ def setup_logging(log_dir: Path, level: int = logging.DEBUG) -> None:
     logger.info("Logging initialised → %s", log_file)
     if _faulthandler_file is not None:
         logger.info("faulthandler dump → %s", _faulthandler_file.name)
+
+
+def set_debug_logging(enabled: bool) -> None:
+    """Flip the file log handler between DEBUG and INFO at runtime.
+
+    Called from the settings page when the user toggles "Enable debug
+    logging". No-op if :func:`setup_logging` has not been called yet.
+    """
+    if _file_handler is None:
+        return
+    new_level = logging.DEBUG if enabled else logging.INFO
+    if _file_handler.level == new_level:
+        return
+    _file_handler.setLevel(new_level)
+    logging.getLogger(__name__).info(
+        "File log level → %s", logging.getLevelName(new_level),
+    )
 
 
 def _enable_faulthandler(log_dir: Path) -> None:

--- a/src/main.py
+++ b/src/main.py
@@ -58,6 +58,7 @@ from constants import (
 )
 from log import setup_logging
 from ui.main_window import MainWindow
+from ui.settings import read_debug_logging
 from ui.theme import apply_dark_theme
 
 logger = logging.getLogger(__name__)
@@ -329,7 +330,7 @@ def main(argv: list[str]) -> int:
     )
     args, qt_args = parser.parse_known_args(argv)
 
-    setup_logging(LOG_DIR)
+    setup_logging(LOG_DIR, level=logging.DEBUG if read_debug_logging() else logging.INFO)
     _seed_user_data()
     logger.info("Starting %s v%s", APP_NAME, APP_VERSION)
     # Record the interpreter the app is bound to — handy when triaging

--- a/src/ui/icons.py
+++ b/src/ui/icons.py
@@ -55,6 +55,7 @@ _CODEPOINTS: Final[dict[str, str]] = {
     "unfold_less":  "e5d6",
     "vertical_split":   "e949",
     "horizontal_split": "e947",
+    "settings":         "e8b8",
 }
 
 

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -21,9 +21,12 @@ from PySide6.QtWidgets import (
 from constants import APP_DISPLAY_NAME, BUILTIN_NODES_DIR, USER_NODES_DIR
 from core.flow import Flow
 from core.node_registry import NodeRegistry
+from log import set_debug_logging
 from ui.node_editor_page import NodeEditorPage
 from ui.page import PageBase
 from ui.recent_flows import RecentFlowsManager
+from ui.settings import get_settings
+from ui.settings_page import SettingsPage
 from ui.start_page import StartPage
 from ui.log_page import LogPage
 
@@ -74,9 +77,10 @@ class MainWindow(QMainWindow):
         self._pages = QStackedWidget()
         self.setCentralWidget(self._pages)
 
-        self._start_page  = StartPage(self._recent_flows)
-        self._editor_page = NodeEditorPage(self._registry, self._recent_flows)
-        self._log_page    = LogPage()
+        self._start_page    = StartPage(self._recent_flows)
+        self._editor_page   = NodeEditorPage(self._registry, self._recent_flows)
+        self._log_page      = LogPage()
+        self._settings_page = SettingsPage()
 
         # Single source of truth for the set of pages. Adding a new page
         # means: construct it, append it here, and every loop below —
@@ -86,7 +90,14 @@ class MainWindow(QMainWindow):
             self._start_page,
             self._editor_page,
             self._log_page,
+            self._settings_page,
         ]
+
+        # Apply persisted debug-logging flag to the live file handler and
+        # keep it in sync as the user toggles it from the Settings page.
+        settings = get_settings()
+        set_debug_logging(settings.debug_logging)
+        settings.debug_logging_changed.connect(set_debug_logging)
 
         for page in self._pages_list:
             self._pages.addWidget(page)

--- a/src/ui/settings.py
+++ b/src/ui/settings.py
@@ -1,0 +1,107 @@
+"""Persistent application settings.
+
+The :class:`AppSettings` singleton loads and saves a small JSON file at
+``~/.image-inquest/settings.json`` (or its frozen-build equivalent).
+Mutating a setting writes the file immediately and emits a Qt signal so
+interested parties (logging, UI) can react.
+
+Today the only setting is :attr:`debug_logging`, which controls whether
+the file log handler captures DEBUG records or only INFO and above.
+"""
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+from PySide6.QtCore import QObject, Signal
+
+from constants import USER_CONFIG_DIR
+
+logger = logging.getLogger(__name__)
+
+SETTINGS_FILE: Path = USER_CONFIG_DIR / "settings.json"
+
+_SETTINGS_VERSION: int = 1
+
+_DEFAULT_DEBUG_LOGGING: bool = False
+
+
+def _read_settings_file(path: Path) -> dict:
+    """Return the raw settings dict from *path*, or ``{}`` if unusable.
+
+    Used both by :class:`AppSettings` and by early-startup code that
+    needs a value before a :class:`QApplication` exists (e.g. the
+    logging configuration).
+    """
+    if not path.exists():
+        return {}
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        logger.exception("Failed to read %s; using defaults", path)
+        return {}
+    if not isinstance(data, dict) or data.get("version") != _SETTINGS_VERSION:
+        return {}
+    return data
+
+
+def read_debug_logging(path: Path = SETTINGS_FILE) -> bool:
+    """Return the persisted ``debug_logging`` flag without instantiating Qt."""
+    return bool(_read_settings_file(path).get("debug_logging", _DEFAULT_DEBUG_LOGGING))
+
+
+class AppSettings(QObject):
+    """Process-wide user settings, persisted to a JSON file.
+
+    Use :func:`get_settings` to obtain the shared instance.
+    """
+
+    debug_logging_changed = Signal(bool)
+
+    def __init__(self, path: Path = SETTINGS_FILE) -> None:
+        super().__init__()
+        self._path = path
+        data = _read_settings_file(path)
+        self._debug_logging: bool = bool(
+            data.get("debug_logging", _DEFAULT_DEBUG_LOGGING)
+        )
+
+    # ── Access ────────────────────────────────────────────────────────────────
+
+    @property
+    def debug_logging(self) -> bool:
+        return self._debug_logging
+
+    @debug_logging.setter
+    def debug_logging(self, value: bool) -> None:
+        value = bool(value)
+        if value == self._debug_logging:
+            return
+        self._debug_logging = value
+        self._save()
+        self.debug_logging_changed.emit(value)
+
+    # ── Persistence ───────────────────────────────────────────────────────────
+
+    def _save(self) -> None:
+        payload = {
+            "version": _SETTINGS_VERSION,
+            "debug_logging": self._debug_logging,
+        }
+        try:
+            self._path.parent.mkdir(parents=True, exist_ok=True)
+            self._path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+        except OSError:
+            logger.exception("Failed to save %s", self._path)
+
+
+_INSTANCE: AppSettings | None = None
+
+
+def get_settings() -> AppSettings:
+    """Return the process-wide :class:`AppSettings` singleton."""
+    global _INSTANCE
+    if _INSTANCE is None:
+        _INSTANCE = AppSettings()
+    return _INSTANCE

--- a/src/ui/settings_page.py
+++ b/src/ui/settings_page.py
@@ -1,0 +1,70 @@
+"""Settings page — single-screen view of persistent application options."""
+from __future__ import annotations
+
+from PySide6.QtCore import Qt
+from PySide6.QtGui import QIcon
+from PySide6.QtWidgets import QCheckBox, QLabel, QVBoxLayout, QWidget
+from typing_extensions import override
+
+from ui.icons import material_icon
+from ui.page import PageBase, ToolbarSection
+from ui.settings import get_settings
+
+
+class SettingsPage(PageBase):
+    """Page exposing the user-facing application settings.
+
+    The only setting today is "Enable debug logging", which controls
+    whether the file log handler captures DEBUG records. Toggling the
+    checkbox writes the new value to ``~/.image-inquest/settings.json``
+    and applies it to the running logger immediately.
+    """
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+
+        self._settings = get_settings()
+
+        root = QVBoxLayout(self)
+        root.setContentsMargins(40, 40, 40, 40)
+        root.setSpacing(16)
+        root.setAlignment(Qt.AlignmentFlag.AlignTop)
+
+        heading = QLabel("Settings")
+        font = heading.font()
+        font.setPointSize(18)
+        font.setBold(True)
+        heading.setFont(font)
+        root.addWidget(heading)
+
+        self._debug_logging_check = QCheckBox("Enable debug logging")
+        self._debug_logging_check.setToolTip(
+            "Capture DEBUG-level records in the application log file. "
+            "Useful when reproducing a bug; leave off for normal use."
+        )
+        self._debug_logging_check.setChecked(self._settings.debug_logging)
+        self._debug_logging_check.toggled.connect(self._on_debug_logging_toggled)
+        root.addWidget(self._debug_logging_check)
+
+    # ── Page hooks ─────────────────────────────────────────────────────────────
+
+    @override
+    def page_title(self) -> str:
+        return "Settings"
+
+    @override
+    def page_selector_label(self) -> str:
+        return "Settings"
+
+    @override
+    def page_selector_icon(self) -> QIcon:
+        return material_icon("settings")
+
+    @override
+    def page_toolbar_sections(self) -> list[ToolbarSection]:
+        return []
+
+    # ── Callbacks ──────────────────────────────────────────────────────────────
+
+    def _on_debug_logging_toggled(self, checked: bool) -> None:
+        self._settings.debug_logging = checked


### PR DESCRIPTION
## Summary
Introduces a new Settings page to the application that allows users to persistently control debug logging behavior. Settings are stored in a JSON file and can be toggled both at startup and at runtime.

## Key Changes

- **New `AppSettings` singleton** (`src/ui/settings.py`): Manages persistent application settings stored in `~/.image-inquest/settings.json`. Currently supports the `debug_logging` flag with immediate file persistence and Qt signal emission on changes.

- **Settings page UI** (`src/ui/settings_page.py`): New top-level page accessible from the toolbar with a checkbox to enable/disable debug logging. Integrates with the settings system to persist user choices.

- **Runtime logging control** (`src/log.py`): Added `set_debug_logging()` function to flip the file handler's log level between DEBUG and INFO at runtime without rebuilding the logging stack. The root logger now stays at DEBUG level to allow dynamic handler-level adjustments.

- **Early-stage settings reading** (`src/ui/settings.py`): Exposed `read_debug_logging()` function to read the persisted setting before Qt initialization, allowing the initial file handler level to be set correctly at startup.

- **Main window integration** (`src/ui/main_window.py`): Instantiates the Settings page, applies the persisted debug logging flag on startup, and connects the settings signal to live-update the file handler.

- **Version and documentation updates**: Bumped version to 0.2.25, updated CHANGELOG and welcome page with feature description.

## Notable Implementation Details

- Settings file format includes a version field for future migration support
- Graceful error handling: malformed or missing settings files default to safe values
- The file handler reference is kept at module level in `log.py` to enable runtime level changes without rebuilding handlers
- Settings changes emit Qt signals, allowing UI and logging systems to react independently

https://claude.ai/code/session_01BRw5pVqRyGSzKJLyJSmn8P