### PR TITLE
refactor: centralise param-widget layout boilerplate (H3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,20 @@ once a first tagged release is cut.
 
 ## [Unreleased]
 
+## [0.2.26] — 2026-04-28
+
+### Changed
+- **Param-widget plumbing centralised.** The six param-editor widgets
+  embedded in every node (Int, Float, Bool, String, Enum, FilePath)
+  used to each repeat the same zero-margin ``QHBoxLayout`` setup and
+  the same ``setMinimumWidth`` / ``setFixedHeight`` pair on their
+  value control. That ritual now lives in two helpers on
+  ``ParamWidgetBase`` — ``_make_row_layout()`` and
+  ``_size_value_control()`` — so the layout shape is named in one
+  place and any future param widget defaults to the right visual
+  contract. No behaviour change. Backlog item H3 from
+  ``refacturing.txt``.
+
 ## [0.2.25] — 2026-04-28
 
 ### Added

--- a/doc/welcome.html
+++ b/doc/welcome.html
@@ -180,7 +180,7 @@
   <main class="content-col">
 
     <header class="hero">
-      <h1>Welcome to Stjörnhorn <span class="version">v0.2.25</span></h1>
+      <h1>Welcome to Stjörnhorn <span class="version">v0.2.26</span></h1>
       <div class="tagline">A node-based image- and video-processing playground.</div>
     </header>
 
@@ -210,6 +210,13 @@
           <p>Write frames to image files or encode video (MP4V, XVID) with live preview via the Display node.</p>
         </div>
       </div>
+    </section>
+
+    <section>
+      <h2>What's new in v0.2.26</h2>
+      <ul class="tips">
+        <li><strong>Param-widget plumbing centralised.</strong> The six param-editor widgets embedded in every node (Int, Float, Bool, String, Enum, FilePath) used to each repeat the same zero-margin <code>QHBoxLayout</code> setup and the same min-width / fixed-height pair on their value control. That ritual now lives in two helpers on <code>ParamWidgetBase</code> — <code>_make_row_layout()</code> and <code>_size_value_control()</code> — so the layout shape is named in one place. No behaviour change. Backlog item H3.</li>
+      </ul>
     </section>
 
     <section>

--- a/refacturing.txt
+++ b/refacturing.txt
@@ -37,13 +37,21 @@ High
   Direction: a Param descriptor that owns storage, validation, default,
   metadata, port wiring as one declaration.
 
-[OPEN] H3. Param-widget subclasses duplicate >90% boilerplate.
+[WIP] H3. Param-widget subclasses duplicate >90% boilerplate.
   Duplication / OCP. src/ui/param_widgets.py:138-289 — every widget
   repeats QHBoxLayout(self), setContentsMargins(0,0,0,0), identical
   _on_value_changed → _write_to_node + emit, identical _initial_value,
   identical fixed-size calls.
   Direction: a _SingleControlParamWidget base taking control factory +
   value-coerce funcs; concrete widgets shrink to ~10 lines.
+  Status (2026-04-28): scope reduced after design-review pushback —
+  full template-method base would have been over-engineering. Landed
+  the minimal version on branch claude/refactor-param-widgets: two
+  helpers on ParamWidgetBase (_make_row_layout, _size_value_control)
+  that the six widgets call instead of inlining the layout dance.
+  _on_value_changed and the int()/float()/bool()/str() coercions stay
+  inline per subclass — they're already short and clearer there than
+  behind a hook. Move to Resolved on merge.
 
 [OPEN] H4. Identical port-construction boilerplate in ~35 filter files.
   Duplication / OCP. E.g. src/nodes/filters/rotate.py:28-57,

--- a/src/constants.py
+++ b/src/constants.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 APP_NAME:         str = "Image-Inquest"
 APP_DISPLAY_NAME: str = "Stjörnhorn"
-APP_VERSION:      str = "0.2.25"
+APP_VERSION:      str = "0.2.26"
 API_URL:    str = "https://beltoforion.de"
 
 # Path resolution -----------------------------------------------------------

--- a/src/ui/param_widgets.py
+++ b/src/ui/param_widgets.py
@@ -110,6 +110,33 @@ class ParamWidgetBase(QWidget):
 
     # ── Helpers shared by all subclasses ───────────────────────────────────────
 
+    def _make_row_layout(self, spacing: int = 0) -> QHBoxLayout:
+        """Install a zero-margin :class:`QHBoxLayout` on this widget and
+        return it so the caller can attach value-bearing controls.
+
+        Every concrete param widget hosts its controls in a horizontal
+        row with no contents margins (so the row sits flush against the
+        node body's parameter slot). Centralising the boilerplate keeps
+        all widgets visually consistent and shrinks each subclass.
+        """
+        layout = QHBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(spacing)
+        return layout
+
+    @staticmethod
+    def _size_value_control(control: QWidget) -> None:
+        """Apply the standard min-width / fixed-height to a value control.
+
+        See :data:`PARAM_VALUE_MIN_WIDTH` and :data:`PARAM_VALUE_HEIGHT`
+        for the rationale on the chosen pixel values. Used by every
+        single-control numeric / string / enum widget; FilePath sizes
+        its line edit separately because it shares the row with two
+        buttons.
+        """
+        control.setMinimumWidth(PARAM_VALUE_MIN_WIDTH)
+        control.setFixedHeight(PARAM_VALUE_HEIGHT)
+
     def _initial_value(self, fallback: object) -> object:
         """Return the value the widget should display on first creation.
 
@@ -143,14 +170,10 @@ class IntParamWidget(ParamWidgetBase):
         self._spin = QSpinBox()
         self._spin.setRange(-10_000_000, 10_000_000)
         self._spin.setAlignment(Qt.AlignmentFlag.AlignRight)
-        self._spin.setMinimumWidth(PARAM_VALUE_MIN_WIDTH)
-        self._spin.setFixedHeight(PARAM_VALUE_HEIGHT)
+        self._size_value_control(self._spin)
         self._spin.valueChanged.connect(self._on_value_changed)
         self._spin.setValue(int(self._initial_value(0)))
-
-        layout = QHBoxLayout(self)
-        layout.setContentsMargins(0, 0, 0, 0)
-        layout.addWidget(self._spin)
+        self._make_row_layout().addWidget(self._spin)
 
     def _on_value_changed(self, value: int) -> None:
         self._write_to_node(value)
@@ -184,14 +207,10 @@ class FloatParamWidget(ParamWidgetBase):
         self._spin.setDecimals(int(meta.get("decimals", 3)))
         self._spin.setSingleStep(float(meta.get("step", 0.1)))
         self._spin.setAlignment(Qt.AlignmentFlag.AlignRight)
-        self._spin.setMinimumWidth(PARAM_VALUE_MIN_WIDTH)
-        self._spin.setFixedHeight(PARAM_VALUE_HEIGHT)
+        self._size_value_control(self._spin)
         self._spin.valueChanged.connect(self._on_value_changed)
         self._spin.setValue(float(self._initial_value(0.0)))
-
-        layout = QHBoxLayout(self)
-        layout.setContentsMargins(0, 0, 0, 0)
-        layout.addWidget(self._spin)
+        self._make_row_layout().addWidget(self._spin)
 
     def _on_value_changed(self, value: float) -> None:
         self._write_to_node(value)
@@ -214,10 +233,7 @@ class BoolParamWidget(ParamWidgetBase):
         self._check = QCheckBox()
         self._check.toggled.connect(self._on_value_changed)
         self._check.setChecked(bool(self._initial_value(False)))
-
-        layout = QHBoxLayout(self)
-        layout.setContentsMargins(0, 0, 0, 0)
-        layout.addWidget(self._check)
+        self._make_row_layout().addWidget(self._check)
 
     def _on_value_changed(self, value: bool) -> None:
         self._write_to_node(value)
@@ -249,8 +265,7 @@ class StringParamWidget(ParamWidgetBase):
         meta = port.metadata
 
         self._line = QLineEdit()
-        self._line.setMinimumWidth(PARAM_VALUE_MIN_WIDTH)
-        self._line.setFixedHeight(PARAM_VALUE_HEIGHT)
+        self._size_value_control(self._line)
         placeholder = meta.get("placeholder")
         if placeholder is not None:
             self._line.setPlaceholderText(str(placeholder))
@@ -260,10 +275,7 @@ class StringParamWidget(ParamWidgetBase):
 
         self._line.setText(str(self._initial_value("")))
         self._line.editingFinished.connect(self._on_editing_finished)
-
-        layout = QHBoxLayout(self)
-        layout.setContentsMargins(0, 0, 0, 0)
-        layout.addWidget(self._line)
+        self._make_row_layout().addWidget(self._line)
 
     def _on_editing_finished(self) -> None:
         value = self._line.text()
@@ -313,8 +325,7 @@ class EnumParamWidget(ParamWidgetBase):
         self._enum_cls: type[Enum] = enum_cls
 
         self._combo = SceneAwareComboBox()
-        self._combo.setMinimumWidth(PARAM_VALUE_MIN_WIDTH)
-        self._combo.setFixedHeight(PARAM_VALUE_HEIGHT)
+        self._size_value_control(self._combo)
         for member in self._enum_cls:
             self._combo.addItem(self._label_for(member), member)
 
@@ -326,10 +337,7 @@ class EnumParamWidget(ParamWidgetBase):
         # initial value back to the node via the setter (and fire a
         # spurious param_changed).
         self._combo.currentIndexChanged.connect(self._on_index_changed)
-
-        layout = QHBoxLayout(self)
-        layout.setContentsMargins(0, 0, 0, 0)
-        layout.addWidget(self._combo)
+        self._make_row_layout().addWidget(self._combo)
 
     def _on_index_changed(self, _index: int) -> None:
         member = self._combo.currentData()
@@ -416,12 +424,10 @@ class FilePathParamWidget(ParamWidgetBase):
         self._line.textChanged.connect(self._update_view_enabled)
 
         # initialize self._path and the line edit's text to the node's current value (or the
-        self.set_value(str(self._initial_value(""))) 
+        self.set_value(str(self._initial_value("")))
         self._update_view_enabled()
 
-        layout = QHBoxLayout(self)
-        layout.setContentsMargins(0, 0, 0, 0)
-        layout.setSpacing(4)
+        layout = self._make_row_layout(spacing=4)
         layout.addWidget(self._line, 1)
         layout.addWidget(browse, 0)
         layout.addWidget(self._view, 0)


### PR DESCRIPTION
## Summary

- Pulls the zero-margin `QHBoxLayout` dance and the `setMinimumWidth` / `setFixedHeight` pair out of every param-widget subclass (Int, Float, Bool, String, Enum, FilePath) into two helpers on `ParamWidgetBase`: `_make_row_layout(spacing=0)` and `_size_value_control(control)`.
- The layout shape is now named in one place; any future param widget defaults to the right visual contract.
- No behaviour change.

Addresses backlog item **H3** in `refacturing.txt`.

## Design notes

Scope deliberately kept minimal. An earlier proposal to introduce a full `_SingleControlParamWidget` template-method base with hooks for build/connect/read/write was rejected as over-engineering for six small subclasses. `_on_value_changed` and the `int()` / `float()` / `bool()` / `str()` coercions stay inline per subclass — they're short and clearer there than behind a hook.

`FilePathParamWidget` is genuinely multi-control (line edit + browse + view buttons with non-zero spacing and stretch factors); it now calls `_make_row_layout(spacing=4)` and keeps its three-control body unchanged.

## Test plan

- [ ] Open an existing flow (e.g. `image_rgb_dither`) — every node renders, every param widget edits cleanly.
- [ ] Drop a node of each kind that exercises a different param type — Int (Rotate angle), Float (Gaussian Blur sigma), Bool (any toggle), String (Notify message), Enum (Dither method), FilePath (ImageSource / FileSink).
- [ ] Confirm visual sizing is unchanged: row height ~24 px, value-control min width ~96 px.
- [ ] Type/edit values, run the flow, confirm values round-trip and persist on save/reload.

https://claude.ai/code/session_017Sbygfh52wCk9uJYDUEyLW

---
_Generated by [Claude Code](https://claude.ai/code/session_017Sbygfh52wCk9uJYDUEyLW)_