### PR TITLE
Add code metrics workflow to track size and complexity

### DIFF
--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -1,0 +1,101 @@
+name: code-metrics
+
+# Tracks size and complexity metrics for the Python sources under `src/` so
+# regressions (file/function bloat, runaway cyclomatic complexity, dropping
+# maintainability index) become visible in PRs and on `main`.
+#
+# Output is rendered into the workflow run's step summary and also uploaded
+# as a JSON/text artifact for downstream tooling.
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'src/**'
+      - 'requirements-dev.txt'
+      - '.github/workflows/metrics.yml'
+  pull_request:
+    paths:
+      - 'src/**'
+      - 'requirements-dev.txt'
+      - '.github/workflows/metrics.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  metrics:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
+      - name: Install radon
+        run: |
+          python -m pip install --upgrade pip
+          pip install radon
+
+      - name: Compute metrics
+        run: |
+          set -eu
+          mkdir -p metrics-out
+
+          # Raw size metrics (LOC, LLOC, SLOC, comments).
+          radon raw -s src > metrics-out/raw.txt
+          radon raw -s --json src > metrics-out/raw.json
+
+          # Cyclomatic complexity per function/method, ranked A–F.
+          # `-n C` flags everything rated C or worse for the summary.
+          radon cc -s -a src > metrics-out/cc.txt
+          radon cc -s -a --json src > metrics-out/cc.json
+          radon cc -s -n C src > metrics-out/cc-hotspots.txt || true
+
+          # Maintainability index per file (0–100, higher is better).
+          # `-n B` flags files rated B or worse.
+          radon mi -s src > metrics-out/mi.txt
+          radon mi -s --json src > metrics-out/mi.json
+          radon mi -s -n B src > metrics-out/mi-hotspots.txt || true
+
+      - name: Render step summary
+        run: |
+          {
+            echo "## Code metrics (radon)"
+            echo
+            echo "### Raw size"
+            echo '```'
+            tail -n 20 metrics-out/raw.txt
+            echo '```'
+            echo
+            echo "### Cyclomatic complexity (average + hotspots ≥ C)"
+            echo '```'
+            tail -n 5 metrics-out/cc.txt
+            echo '```'
+            if [ -s metrics-out/cc-hotspots.txt ]; then
+              echo '<details><summary>Functions rated C or worse</summary>'
+              echo
+              echo '```'
+              cat metrics-out/cc-hotspots.txt
+              echo '```'
+              echo '</details>'
+            else
+              echo "_No functions rated C or worse._"
+            fi
+            echo
+            echo "### Maintainability index (hotspots ≤ B)"
+            if [ -s metrics-out/mi-hotspots.txt ]; then
+              echo '```'
+              cat metrics-out/mi-hotspots.txt
+              echo '```'
+            else
+              echo "_All files rated A._"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: code-metrics
+          path: metrics-out/
+          retention-days: 30

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,3 @@
 -r requirements.txt
 pytest
+radon


### PR DESCRIPTION
## Summary
This PR introduces a GitHub Actions workflow that automatically tracks code quality metrics for the Python sources, making regressions in size and complexity visible in PRs and on the main branch.

## Key Changes
- **New workflow**: `.github/workflows/metrics.yml` that runs on push to main, all PRs, and manual dispatch
  - Computes raw size metrics (LOC, LLOC, SLOC, comments) using radon
  - Analyzes cyclomatic complexity per function/method, flagging anything rated C or worse
  - Calculates maintainability index per file, flagging files rated B or worse
  - Renders results in workflow step summary for easy visibility
  - Uploads metrics as JSON and text artifacts for downstream tooling and historical tracking
- **Updated dependencies**: Added `radon` to `requirements-dev.txt`

## Implementation Details
- Workflow triggers on changes to `src/`, `requirements-dev.txt`, or the workflow itself
- Uses radon's `-s` (summary) and `-a` (all) flags for comprehensive analysis
- Hotspot detection uses `|| true` to prevent workflow failure when no issues are found
- Step summary includes collapsible details for complexity hotspots and highlights maintainability concerns
- Artifacts retained for 30 days to support trend analysis and historical comparison

https://claude.ai/code/session_01TL5AtcKD6vi5fzSKDJGfS6