### PR TITLE
H2 PR-2a: migrate 8 numeric-only filters to param descriptors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,33 @@ once a first tagged release is cut.
 
 ## [Unreleased]
 
+## [0.2.28] — 2026-04-28
+
+### Changed
+- **Param descriptor sweep — batch 1 (H2 PR-2a).** Migrated eight
+  more filters to the class-level descriptor pattern landed in
+  PR-1: Median, Delay, Clamp, Shift, Temporal Mean, Temporal Median,
+  Adaptive Gaussian Threshold and Crop. Each loses the
+  ``self._<name>`` init line, the hand-rolled
+  ``_add_input(InputPort(...))``, and the ``@property``/``@setter``
+  pair in favour of a single descriptor declaration. Files are
+  30–50% smaller; metadata, validation and port construction now
+  live in one place per parameter.
+- **Descriptor protocol: validation runs before shaping.**
+  ``_ParamBase.__set__`` is now ``coerce → validate → shape`` rather
+  than ``coerce → validate``. Domain subclasses override the new
+  ``_shape`` hook (e.g. ``OddIntParam``'s even→odd rounding) so a
+  literal value below ``min`` raises rather than being silently
+  shaped up into range. Preserves the semantics of the hand-rolled
+  setters this descriptor replaces — e.g. ``Median.size = 0`` still
+  raises ``ValueError``.
+
+### Deferred
+- ``Overlay`` and the remaining nodes that need new descriptor
+  types (Bool/String/Enum/FilePath, plus a clamping float for
+  ``Overlay.alpha`` and an exclusive-bound float for
+  ``Overlay.scale``) move in subsequent PRs.
+
 ## [0.2.27] — 2026-04-28
 
 ### Changed

--- a/doc/welcome.html
+++ b/doc/welcome.html
@@ -180,7 +180,7 @@
   <main class="content-col">
 
     <header class="hero">
-      <h1>Welcome to Stjörnhorn <span class="version">v0.2.27</span></h1>
+      <h1>Welcome to Stjörnhorn <span class="version">v0.2.28</span></h1>
       <div class="tagline">A node-based image- and video-processing playground.</div>
     </header>
 
@@ -210,6 +210,13 @@
           <p>Write frames to image files or encode video (MP4V, XVID) with live preview via the Display node.</p>
         </div>
       </div>
+    </section>
+
+    <section>
+      <h2>What's new in v0.2.28</h2>
+      <ul class="tips">
+        <li><strong>Param descriptor sweep — first batch (PR-2a of H2).</strong> Eight more filters (Median, Delay, Clamp, Shift, Temporal Mean, Temporal Median, Adaptive Gaussian Threshold, Crop) ported from the hand-rolled <code>InputPort</code> + <code>@property</code>/<code>@setter</code> triple-declaration to the new class-level descriptors. Each migrated file is 30–50% smaller and its parameters now live in one declaration with single-source-of-truth metadata, validation and port construction. Median picks up <code>OddIntParam</code> just like Gaussian Blur — same odd-only invariant, named once. The descriptor protocol gained a <code>_shape</code> hook that runs <em>after</em> validation, so a literal value below <code>min</code> raises rather than being shaped up into range; this matches the hand-rolled setters this descriptor replaces (e.g. <code>Median.size = 0</code> still raises, even though the odd-shape would otherwise round it to 1). The <code>Overlay</code> node and the remaining nodes that need new descriptor types (Bool/String/Enum/FilePath, plus a clamping float and an exclusive-bound float) follow in subsequent PRs.</li>
+      </ul>
     </section>
 
     <section>

--- a/refacturing.txt
+++ b/refacturing.txt
@@ -96,19 +96,40 @@ High
        Every saved flow under flow/ instantiates and indexed
        connection access still works.
 
-  Status (2026-04-28, PR-1 in flight on branch claude/h2-param-descriptor):
-    Landed core/params.py with _ParamBase + IntParam + OddIntParam +
-    FloatParam (Bool/String/Enum/FilePath descriptors deferred to PR-2
-    when a node that uses each kind shows up). NodeBase collects
-    descriptors via __init_subclass__; defaults written via
-    object.__setattr__ in __init__ before any subclass code runs;
-    descriptor-driven ports auto-created in _apply_default_params after
-    the explicit subclass ports so image-first ordering is preserved.
-    GaussianBlur migrated as proof: 95 → 57 lines (~40% smaller),
-    every existing test_new_filters.py GaussianBlur test still passes.
-    New tests/test_param_descriptors.py (17 tests) locks down descriptor
-    mechanics; new tests/test_flow_back_compat.py (15 tests) round-trips
-    every saved flow.
+  Status:
+    PR-1 (merged, 2026-04-28): core/params.py with _ParamBase +
+      IntParam + OddIntParam + FloatParam. NodeBase collects
+      descriptors via __init_subclass__; defaults written via
+      object.__setattr__ in __init__ before any subclass code runs;
+      descriptor-driven ports auto-created in _apply_default_params
+      after the explicit subclass ports so image-first ordering is
+      preserved. GaussianBlur migrated as proof: 95 → 57 lines.
+      tests/test_param_descriptors.py + tests/test_flow_back_compat.py.
+
+    PR-2a (in flight on branch claude/h2-pr2a-numeric-filters):
+      Sweep batch 1 — eight filters using only IntParam / FloatParam
+      / OddIntParam: Median, Delay, Clamp, Shift, Temporal Mean,
+      Temporal Median, Adaptive Gaussian Threshold, Crop. Each loses
+      30–50% LoC. Descriptor protocol gained a _shape hook running
+      after _validate so 0 still raises on Median.size (matching the
+      old setter), even though OddIntParam's shape would round it to
+      1. Test test_filters.py::test_median_rejects_non_positive_size
+      preserved unchanged.
+
+    PR-2b (planned): add ClampedFloatParam (Overlay.alpha) and
+      min_exclusive flag on FloatParam (Overlay.scale > 0). Migrate
+      Overlay. This PR also lands BoolParam + StringParam + EnumParam
+      + FilePathParam descriptors and migrates the next batch of
+      filters that need them: Apply Colormap, Dither, Flip, Notify,
+      Resize, Rotate, Scale, Subpixel Mosaic, Math, NCC.
+
+    PR-2c (planned): sources + sinks. Decides the NodeParam merger
+      question (open question 3). file_path setters with side
+      effects (open question 1) drive the on_change= hook design.
+
+    PR-2d (planned): retire the legacy _add_input(InputPort(...)) +
+      @property path from NodeBase once empty. Move H2, H4, M9 to
+      Resolved.
 
 [WIP] H3. Param-widget subclasses duplicate >90% boilerplate.
   Duplication / OCP. src/ui/param_widgets.py:138-289 — every widget

--- a/src/constants.py
+++ b/src/constants.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 APP_NAME:         str = "Image-Inquest"
 APP_DISPLAY_NAME: str = "Stjörnhorn"
-APP_VERSION:      str = "0.2.27"
+APP_VERSION:      str = "0.2.28"
 API_URL:    str = "https://beltoforion.de"
 
 # Path resolution -----------------------------------------------------------

--- a/src/core/params.py
+++ b/src/core/params.py
@@ -88,7 +88,8 @@ class _ParamBase:
     def __set__(self, instance: object, value: object) -> None:
         coerced = self._coerce(value)
         self._validate(coerced)
-        object.__setattr__(instance, self._private, coerced)
+        shaped = self._shape(coerced)
+        object.__setattr__(instance, self._private, shaped)
 
     # ── Hooks for subclasses ───────────────────────────────────────────────────
 
@@ -96,8 +97,10 @@ class _ParamBase:
         """Convert *value* to the descriptor's storage type.
 
         Default: identity. Numeric subclasses override to ``int(value)``
-        / ``float(value)``; domain subclasses (e.g. :class:`OddIntParam`)
-        chain into ``super()._coerce`` and apply additional shaping.
+        / ``float(value)``. The result of ``_coerce`` is what
+        :meth:`_validate` sees, so range checks reject literal user
+        input *before* any domain-specific shaping rounds it into a
+        valid form.
         """
         return value
 
@@ -106,8 +109,23 @@ class _ParamBase:
 
         Subclasses with declared bounds (``min`` / ``max``) raise
         :class:`ValueError` here so a mis-set value fails loudly at the
-        property assignment, not at downstream-consumer time.
+        property assignment, not at downstream-consumer time. Runs on
+        the type-coerced (but not yet shaped) value so the user can't
+        bypass the bound by feeding a value the shape hook would round
+        into range.
         """
+
+    def _shape(self, value: Any) -> Any:
+        """Apply domain-specific shaping after validation passes.
+
+        Default: identity. Domain subclasses (e.g. :class:`OddIntParam`)
+        override to round the validated value into its canonical form
+        — odd integer, probability ∈ [0, 1], wrapped angle, etc.
+        Running after :meth:`_validate` means a user-supplied value
+        that's out of range fails at assignment time even when the
+        shape hook *could* have rounded it into range.
+        """
+        return value
 
     # ── InputPort factory ──────────────────────────────────────────────────────
 
@@ -198,7 +216,7 @@ class IntParam(_ParamBase):
 
 
 class OddIntParam(IntParam):
-    """Integer parameter coerced to the nearest odd value (rounding up).
+    """Integer parameter shaped to the nearest odd value (rounding up).
 
     Shared invariant for OpenCV-style kernel-size params: Gaussian /
     Median / Bilateral / box filters all require an odd kernel side
@@ -206,11 +224,16 @@ class OddIntParam(IntParam):
     ``v + 1 if v % 2 == 0 else v`` in its own setter; collecting it
     here means the rule is named once and any future filter that needs
     odd-only ints picks it up by changing one declaration.
+
+    Shaping runs *after* :meth:`_validate`, so a literal value below
+    ``min`` raises rather than being shaped up into range — matches
+    the behaviour of the hand-rolled setters this descriptor replaces
+    (e.g. the legacy ``Median.size`` rejected ``0`` outright instead
+    of silently bumping it to ``1``).
     """
 
-    def _coerce(self, value: object) -> int:
-        v = super()._coerce(value)
-        return v + 1 if v % 2 == 0 else v
+    def _shape(self, value: int) -> int:
+        return value + 1 if value % 2 == 0 else value
 
 
 class FloatParam(_ParamBase):

--- a/src/nodes/filters/adaptive_gaussian_threshold.py
+++ b/src/nodes/filters/adaptive_gaussian_threshold.py
@@ -5,7 +5,8 @@ import numpy as np
 from typing_extensions import override
 
 from core.io_data import IMAGE_TYPES, IoData, IoDataType
-from core.node_base import NodeBase, NodeParamType
+from core.node_base import NodeBase
+from core.params import IntParam, OddIntParam
 from core.port import InputPort, OutputPort
 
 
@@ -14,82 +15,39 @@ class AdaptiveGaussianThreshold(NodeBase):
 
     Wraps ``cv2.adaptiveThreshold`` with
     ``ADAPTIVE_THRESH_GAUSSIAN_C`` and ``THRESH_BINARY``. ``block_size``
-    must be odd and > 1; ``c`` is the constant subtracted from the
-    weighted mean. Ported from the original OCVL
-    ``AdaptiveGuaussianThresholdProcessor`` [sic].
+    must be odd and >= 3 — :class:`~core.params.OddIntParam` enforces
+    the odd-only invariant; the ``min=3`` check catches the lower bound
+    after the even→odd bump (so 2 → 3 is accepted).
 
     Accepts colour or greyscale inputs; 3-channel inputs are internally
     converted to greyscale first. The output is always a single-channel
     binary :data:`IoDataType.IMAGE_GREY` payload.
     """
 
+    block_size = OddIntParam(
+        101,
+        min=3,
+        unit="px",
+        description=(
+            "Side length of the neighbourhood used to compute the "
+            "local threshold. Must be odd and >= 3; even values "
+            "are bumped up to the next odd integer."
+        ),
+    )
+    c = IntParam(
+        -32,
+        description=(
+            "Constant subtracted from the local weighted mean. "
+            "Negative values bias toward classifying pixels as "
+            "white; positive values bias toward black."
+        ),
+    )
+
     def __init__(self) -> None:
         super().__init__("Adaptive Gaussian Threshold", section="Processing")
-        self._block_size: int = 101
-        self._c: int = -32
-
         self._add_input(InputPort("image", set(IMAGE_TYPES)))
-        self._add_input(InputPort(
-            "block_size",
-            {IoDataType.SCALAR},
-            optional=True,
-            default_value=101,
-            metadata={
-                "default": 101,
-                "param_type": NodeParamType.INT,
-                "min": 3,
-                "unit": "px",
-                "description": (
-                    "Side length of the neighbourhood used to compute the "
-                    "local threshold. Must be odd and >= 3; even values "
-                    "are bumped up to the next odd integer."
-                ),
-            },
-        ))
-        self._add_input(InputPort(
-            "c",
-            {IoDataType.SCALAR},
-            optional=True,
-            default_value=-32,
-            metadata={
-                "default": -32,
-                "param_type": NodeParamType.INT,
-                "description": (
-                    "Constant subtracted from the local weighted mean. "
-                    "Negative values bias toward classifying pixels as "
-                    "white; positive values bias toward black."
-                ),
-            },
-        ))
         self._add_output(OutputPort("image", {IoDataType.IMAGE_GREY}))
-
         self._apply_default_params()
-
-    # ── Properties ─────────────────────────────────────────────────────────────
-
-    @property
-    def block_size(self) -> int:
-        return self._block_size
-
-    @block_size.setter
-    def block_size(self, value: int) -> None:
-        v = int(value)
-        if v < 3:
-            raise ValueError(f"block_size must be >= 3 (got {v})")
-        if v % 2 == 0:
-            # cv2.adaptiveThreshold requires odd — coerce like Median does.
-            v += 1
-        self._block_size = v
-
-    @property
-    def c(self) -> int:
-        return self._c
-
-    @c.setter
-    def c(self, value: int) -> None:
-        self._c = int(value)
-
-    # ── NodeBase interface ─────────────────────────────────────────────────────
 
     @override
     def process_impl(self) -> None:

--- a/src/nodes/filters/clamp.py
+++ b/src/nodes/filters/clamp.py
@@ -4,7 +4,8 @@ import numpy as np
 from typing_extensions import override
 
 from core.io_data import IoData, IoDataType
-from core.node_base import NodeBase, NodeParamType
+from core.node_base import NodeBase
+from core.params import FloatParam
 from core.port import InputPort, OutputPort
 
 
@@ -22,63 +23,24 @@ class Clamp(NodeBase):
     invert the range.
     """
 
+    min_value = FloatParam(
+        0.0,
+        description="Lower bound. Values below this are clipped up to it.",
+    )
+    max_value = FloatParam(
+        1.0,
+        description=(
+            "Upper bound. Values above this are clipped down to it. "
+            "If the upper bound ends up below the lower bound the "
+            "two are swapped so the range is always usable."
+        ),
+    )
+
     def __init__(self) -> None:
         super().__init__("Clamp", section="Math")
-        self._min_value: float = 0.0
-        self._max_value: float = 1.0
-
         self._add_input(InputPort("value", {IoDataType.SCALAR}))
-        self._add_input(InputPort(
-            "min_value",
-            {IoDataType.SCALAR},
-            optional=True,
-            default_value=0.0,
-            metadata={
-                "default": 0.0,
-                "param_type": NodeParamType.FLOAT,
-                "description": (
-                    "Lower bound. Values below this are clipped up to it."
-                ),
-            },
-        ))
-        self._add_input(InputPort(
-            "max_value",
-            {IoDataType.SCALAR},
-            optional=True,
-            default_value=1.0,
-            metadata={
-                "default": 1.0,
-                "param_type": NodeParamType.FLOAT,
-                "description": (
-                    "Upper bound. Values above this are clipped down to it. "
-                    "If the upper bound ends up below the lower bound the "
-                    "two are swapped so the range is always usable."
-                ),
-            },
-        ))
         self._add_output(OutputPort("value", {IoDataType.SCALAR}))
-
         self._apply_default_params()
-
-    # ── Properties ─────────────────────────────────────────────────────────────
-
-    @property
-    def min_value(self) -> float:
-        return self._min_value
-
-    @min_value.setter
-    def min_value(self, value: float) -> None:
-        self._min_value = float(value)
-
-    @property
-    def max_value(self) -> float:
-        return self._max_value
-
-    @max_value.setter
-    def max_value(self, value: float) -> None:
-        self._max_value = float(value)
-
-    # ── NodeBase interface ─────────────────────────────────────────────────────
 
     @override
     def process_impl(self) -> None:

--- a/src/nodes/filters/crop.py
+++ b/src/nodes/filters/crop.py
@@ -3,8 +3,9 @@ from __future__ import annotations
 import numpy as np
 from typing_extensions import override
 
-from core.io_data import IMAGE_TYPES, IoDataType
-from core.node_base import NodeBase, NodeParamType
+from core.io_data import IMAGE_TYPES
+from core.node_base import NodeBase
+from core.params import IntParam
 from core.port import InputPort, OutputPort
 
 
@@ -17,110 +18,39 @@ class Crop(NodeBase):
     even if the user-specified rectangle reaches outside the input.
     """
 
+    x = IntParam(
+        0,
+        min=0,
+        unit="px",
+        description="Left edge of the ROI in input-pixel coordinates.",
+    )
+    y = IntParam(
+        0,
+        min=0,
+        unit="px",
+        description="Top edge of the ROI in input-pixel coordinates.",
+    )
+    width = IntParam(
+        100,
+        min=1,
+        unit="px",
+        description=(
+            "ROI width in pixels. Clamped to the input bounds, so "
+            "the node always emits a positive-area image."
+        ),
+    )
+    height = IntParam(
+        100,
+        min=1,
+        unit="px",
+        description="ROI height in pixels. Same clamping as width.",
+    )
+
     def __init__(self) -> None:
         super().__init__("Crop", section="Transform")
-        self._x:      int = 0
-        self._y:      int = 0
-        self._width:  int = 100
-        self._height: int = 100
-
         self._add_input(InputPort("image", set(IMAGE_TYPES)))
-        self._add_input(InputPort(
-            "x",
-            {IoDataType.SCALAR},
-            optional=True,
-            default_value=0,
-            metadata={
-                "default": 0,
-                "param_type": NodeParamType.INT,
-                "min": 0,
-                "unit": "px",
-                "description": "Left edge of the ROI in input-pixel coordinates.",
-            },
-        ))
-        self._add_input(InputPort(
-            "y",
-            {IoDataType.SCALAR},
-            optional=True,
-            default_value=0,
-            metadata={
-                "default": 0,
-                "param_type": NodeParamType.INT,
-                "min": 0,
-                "unit": "px",
-                "description": "Top edge of the ROI in input-pixel coordinates.",
-            },
-        ))
-        self._add_input(InputPort(
-            "width",
-            {IoDataType.SCALAR},
-            optional=True,
-            default_value=100,
-            metadata={
-                "default": 100,
-                "param_type": NodeParamType.INT,
-                "min": 1,
-                "unit": "px",
-                "description": (
-                    "ROI width in pixels. Clamped to the input bounds, so "
-                    "the node always emits a positive-area image."
-                ),
-            },
-        ))
-        self._add_input(InputPort(
-            "height",
-            {IoDataType.SCALAR},
-            optional=True,
-            default_value=100,
-            metadata={
-                "default": 100,
-                "param_type": NodeParamType.INT,
-                "min": 1,
-                "unit": "px",
-                "description": "ROI height in pixels. Same clamping as width.",
-            },
-        ))
         self._add_output(OutputPort("image", set(IMAGE_TYPES)))
-
         self._apply_default_params()
-
-    @property
-    def x(self) -> int:
-        return self._x
-
-    @x.setter
-    def x(self, value: int) -> None:
-        self._x = int(value)
-
-    @property
-    def y(self) -> int:
-        return self._y
-
-    @y.setter
-    def y(self, value: int) -> None:
-        self._y = int(value)
-
-    @property
-    def width(self) -> int:
-        return self._width
-
-    @width.setter
-    def width(self, value: int) -> None:
-        v = int(value)
-        if v < 1:
-            raise ValueError(f"width must be >= 1 (got {v})")
-        self._width = v
-
-    @property
-    def height(self) -> int:
-        return self._height
-
-    @height.setter
-    def height(self, value: int) -> None:
-        v = int(value)
-        if v < 1:
-            raise ValueError(f"height must be >= 1 (got {v})")
-        self._height = v
 
     @override
     def process_impl(self) -> None:

--- a/src/nodes/filters/delay.py
+++ b/src/nodes/filters/delay.py
@@ -4,8 +4,9 @@ import time
 
 from typing_extensions import override
 
-from core.io_data import IMAGE_TYPES, IoDataType
-from core.node_base import NodeBase, NodeParamType
+from core.io_data import IMAGE_TYPES
+from core.node_base import NodeBase
+from core.params import FloatParam
 from core.port import InputPort, OutputPort
 
 
@@ -19,41 +20,21 @@ class Delay(NodeBase):
     payload is passed straight through unchanged.
     """
 
+    delay_seconds = FloatParam(
+        5.0,
+        min=0.0,
+        unit="s",
+        description=(
+            "How long to sleep between frames, in seconds. "
+            "Set to 0 to disable the pacing entirely."
+        ),
+    )
+
     def __init__(self) -> None:
         super().__init__("Delay", section="UI")
-        self._delay_seconds: float = 5.0
-
         self._add_input(InputPort("image", set(IMAGE_TYPES)))
-        self._add_input(InputPort(
-            "delay_seconds",
-            {IoDataType.SCALAR},
-            optional=True,
-            default_value=5.0,
-            metadata={
-                "default": 5.0,
-                "param_type": NodeParamType.FLOAT,
-                "min": 0.0,
-                "unit": "s",
-                "description": (
-                    "How long to sleep between frames, in seconds. "
-                    "Set to 0 to disable the pacing entirely."
-                ),
-            },
-        ))
         self._add_output(OutputPort("image", set(IMAGE_TYPES)))
-
         self._apply_default_params()
-
-    @property
-    def delay_seconds(self) -> float:
-        return self._delay_seconds
-
-    @delay_seconds.setter
-    def delay_seconds(self, value: float) -> None:
-        v = float(value)
-        if v < 0:
-            raise ValueError(f"delay_seconds must be >= 0 (got {v})")
-        self._delay_seconds = v
 
     @override
     def process_impl(self) -> None:

--- a/src/nodes/filters/median.py
+++ b/src/nodes/filters/median.py
@@ -4,71 +4,38 @@ import cv2
 import numpy as np
 from typing_extensions import override
 
-from core.io_data import IMAGE_TYPES, IoDataType
-from core.node_base import NodeBase, NodeParamType
+from core.io_data import IMAGE_TYPES
+from core.node_base import NodeBase
+from core.params import OddIntParam
 from core.port import InputPort, OutputPort
 
 
 class Median(NodeBase):
     """Apply a median blur with a square kernel.
 
-    Wraps ``cv2.medianBlur``; the kernel ``size`` must be odd and ≥ 1.
-    Accepts both colour (``IMAGE``) and greyscale (``IMAGE_GREY``) inputs
-    and emits the same type on the output. Ported from the original OCVL
-    ``MedianProcessor``.
-
-    The ``size`` editable property is declared directly as an
-    ``InputPort`` with ``param_type`` in its metadata; no separate
-    params-list override is needed. ``NodeBase.params`` filters the
-    input ports down to the param-style subset that the UI iterates.
+    Wraps ``cv2.medianBlur``; the kernel ``size`` must be odd and ≥ 1
+    — :class:`~core.params.OddIntParam` enforces both invariants so the
+    UI spin-box can step in odd numbers and accept (then bump) even
+    typed input. Accepts both colour (``IMAGE``) and greyscale
+    (``IMAGE_GREY``) inputs and emits the same type on the output.
     """
+
+    size = OddIntParam(
+        3,
+        min=1,
+        unit="px",
+        description=(
+            "Kernel side length in pixels. Must be odd; even values "
+            "are bumped up to the next odd integer. Larger kernels "
+            "remove more noise at the cost of fine detail."
+        ),
+    )
 
     def __init__(self) -> None:
         super().__init__("Median", section="Processing")
-        self._size: int = 3
-
         self._add_input(InputPort("image", set(IMAGE_TYPES)))
-        self._add_input(InputPort(
-            "size",
-            {IoDataType.SCALAR},
-            optional=True,
-            default_value=3,
-            metadata={
-                "default": 3,
-                "param_type": NodeParamType.INT,
-                "min": 1,
-                "unit": "px",
-                "description": (
-                    "Kernel side length in pixels. Must be odd; even "
-                    "values are bumped up to the next odd integer. "
-                    "Larger kernels remove more noise at the cost of "
-                    "fine detail."
-                ),
-            },
-        ))
         self._add_output(OutputPort("image", set(IMAGE_TYPES)))
-
         self._apply_default_params()
-
-    # ── Properties ─────────────────────────────────────────────────────────────
-
-    @property
-    def size(self) -> int:
-        return self._size
-
-    @size.setter
-    def size(self, value: int) -> None:
-        v = int(value)
-        if v < 1:
-            raise ValueError(f"size must be >= 1 (got {v})")
-        if v % 2 == 0:
-            # cv2.medianBlur requires an odd kernel — round up rather than
-            # reject so the UI spinbox feels natural when the user types
-            # an even number mid-edit.
-            v += 1
-        self._size = v
-
-    # ── NodeBase interface ─────────────────────────────────────────────────────
 
     @override
     def process_impl(self) -> None:

--- a/src/nodes/filters/shift.py
+++ b/src/nodes/filters/shift.py
@@ -4,8 +4,9 @@ import cv2
 import numpy as np
 from typing_extensions import override
 
-from core.io_data import IMAGE_TYPES, IoDataType
-from core.node_base import NodeBase, NodeParamType
+from core.io_data import IMAGE_TYPES
+from core.node_base import NodeBase
+from core.params import IntParam
 from core.port import InputPort, OutputPort
 
 
@@ -15,71 +16,31 @@ class Shift(NodeBase):
     Uses ``cv2.warpAffine`` with a pure translation matrix so that the
     output canvas keeps the input's width and height — pixels shifted
     outside the frame are dropped and exposed areas are filled with
-    black (OpenCV's default border). Ported from the original OCVL
-    ``ShiftProcessor``.
+    black (OpenCV's default border).
     """
+
+    offset_x = IntParam(
+        0,
+        unit="px",
+        description=(
+            "Horizontal shift in pixels. Positive moves right; "
+            "exposed areas at the left edge are filled with black."
+        ),
+    )
+    offset_y = IntParam(
+        0,
+        unit="px",
+        description=(
+            "Vertical shift in pixels. Positive moves down; "
+            "exposed areas at the top edge are filled with black."
+        ),
+    )
 
     def __init__(self) -> None:
         super().__init__("Shift", section="Transform")
-        self._offset_x: int = 0
-        self._offset_y: int = 0
-
         self._add_input(InputPort("image", set(IMAGE_TYPES)))
-        self._add_input(InputPort(
-            "offset_x",
-            {IoDataType.SCALAR},
-            optional=True,
-            default_value=0,
-            metadata={
-                "default": 0,
-                "param_type": NodeParamType.INT,
-                "unit": "px",
-                "description": (
-                    "Horizontal shift in pixels. Positive moves right; "
-                    "exposed areas at the left edge are filled with "
-                    "black."
-                ),
-            },
-        ))
-        self._add_input(InputPort(
-            "offset_y",
-            {IoDataType.SCALAR},
-            optional=True,
-            default_value=0,
-            metadata={
-                "default": 0,
-                "param_type": NodeParamType.INT,
-                "unit": "px",
-                "description": (
-                    "Vertical shift in pixels. Positive moves down; "
-                    "exposed areas at the top edge are filled with "
-                    "black."
-                ),
-            },
-        ))
         self._add_output(OutputPort("image", set(IMAGE_TYPES)))
-
         self._apply_default_params()
-
-    # ── Properties ─────────────────────────────────────────────────────────────
-
-    @property
-    def offset_x(self) -> int:
-        return self._offset_x
-
-    @offset_x.setter
-    def offset_x(self, value: int) -> None:
-        self._offset_x = int(value)
-
-    @property
-    def offset_y(self) -> int:
-        return self._offset_y
-
-    @offset_y.setter
-    def offset_y(self, value: int) -> None:
-        self._offset_y = int(value)
-
-    # ── NodeBase interface ─────────────────────────────────────────────────────
 
     @override
     def process_impl(self) -> None:

--- a/src/nodes/filters/temporal_mean.py
+++ b/src/nodes/filters/temporal_mean.py
@@ -3,8 +3,9 @@ from __future__ import annotations
 import numpy as np
 from typing_extensions import override
 
-from core.io_data import IMAGE_TYPES, IoDataType
-from core.node_base import NodeBase, NodeParamType
+from core.io_data import IMAGE_TYPES
+from core.node_base import NodeBase
+from core.params import IntParam
 from core.port import InputPort, OutputPort
 
 
@@ -22,43 +23,23 @@ class TemporalMean(NodeBase):
     just the new input.
     """
 
+    window = IntParam(
+        5,
+        min=1,
+        unit="frames",
+        description=(
+            "Number of recent frames averaged per output. "
+            "Larger values denoise more aggressively but blur "
+            "any motion in the scene."
+        ),
+    )
+
     def __init__(self) -> None:
         super().__init__("Temporal Mean", section="Temporal")
-        self._window: int = 5
         self._buffer: list[np.ndarray] = []
-
         self._add_input(InputPort("image", set(IMAGE_TYPES)))
-        self._add_input(InputPort(
-            "window",
-            {IoDataType.SCALAR},
-            optional=True,
-            default_value=5,
-            metadata={
-                "default": 5,
-                "param_type": NodeParamType.INT,
-                "min": 1,
-                "unit": "frames",
-                "description": (
-                    "Number of recent frames averaged per output. "
-                    "Larger values denoise more aggressively but blur "
-                    "any motion in the scene."
-                ),
-            },
-        ))
         self._add_output(OutputPort("image", set(IMAGE_TYPES)))
-
         self._apply_default_params()
-
-    @property
-    def window(self) -> int:
-        return self._window
-
-    @window.setter
-    def window(self, value: int) -> None:
-        v = int(value)
-        if v < 1:
-            raise ValueError(f"window must be >= 1 (got {v})")
-        self._window = v
 
     @override
     def _before_run_impl(self) -> None:

--- a/src/nodes/filters/temporal_median.py
+++ b/src/nodes/filters/temporal_median.py
@@ -3,8 +3,9 @@ from __future__ import annotations
 import numpy as np
 from typing_extensions import override
 
-from core.io_data import IMAGE_TYPES, IoDataType
-from core.node_base import NodeBase, NodeParamType
+from core.io_data import IMAGE_TYPES
+from core.node_base import NodeBase
+from core.params import IntParam
 from core.port import InputPort, OutputPort
 
 
@@ -23,44 +24,24 @@ class TemporalMedian(NodeBase):
     flush the buffer rather than raising.
     """
 
+    window = IntParam(
+        5,
+        min=1,
+        unit="frames",
+        description=(
+            "Number of recent frames whose per-pixel median is "
+            "emitted. Strong against transient outliers — single-"
+            "frame spikes, salt-and-pepper noise — without the "
+            "smearing a mean would produce."
+        ),
+    )
+
     def __init__(self) -> None:
         super().__init__("Temporal Median", section="Temporal")
-        self._window: int = 5
         self._buffer: list[np.ndarray] = []
-
         self._add_input(InputPort("image", set(IMAGE_TYPES)))
-        self._add_input(InputPort(
-            "window",
-            {IoDataType.SCALAR},
-            optional=True,
-            default_value=5,
-            metadata={
-                "default": 5,
-                "param_type": NodeParamType.INT,
-                "min": 1,
-                "unit": "frames",
-                "description": (
-                    "Number of recent frames whose per-pixel median is "
-                    "emitted. Strong against transient outliers — single-"
-                    "frame spikes, salt-and-pepper noise — without the "
-                    "smearing a mean would produce."
-                ),
-            },
-        ))
         self._add_output(OutputPort("image", set(IMAGE_TYPES)))
-
         self._apply_default_params()
-
-    @property
-    def window(self) -> int:
-        return self._window
-
-    @window.setter
-    def window(self, value: int) -> None:
-        v = int(value)
-        if v < 1:
-            raise ValueError(f"window must be >= 1 (got {v})")
-        self._window = v
 
     @override
     def _before_run_impl(self) -> None:

--- a/tests/test_param_descriptors.py
+++ b/tests/test_param_descriptors.py
@@ -85,19 +85,15 @@ def test_odd_int_param_leaves_odd_unchanged() -> None:
     assert node.kernel == 9
 
 
-def test_odd_int_param_zero_coerces_to_one_within_min() -> None:
-    """0 is even → coerced to 1 → satisfies min=1, no raise. The min
-    check intentionally applies to the *coerced* value, so the
-    odd-only invariant takes priority over a strict literal min.
+def test_odd_int_param_below_min_raises_before_shaping() -> None:
+    """The min gate applies to the type-coerced value, *before* the
+    odd-only shape runs — so 0 raises rather than being silently
+    bumped up to 1. Matches the behaviour of the hand-rolled setters
+    this descriptor replaces.
     """
     node = _DescriptorNode()
-    node.kernel = 0
-    assert node.kernel == 1
-
-
-def test_odd_int_param_negative_below_min_after_coerce_raises() -> None:
-    """Negatives still trip min after coerce: -2 → -1 (odd) < min=1."""
-    node = _DescriptorNode()
+    with pytest.raises(ValueError, match=r"kernel must be >= 1"):
+        node.kernel = 0
     with pytest.raises(ValueError, match=r"kernel must be >= 1"):
         node.kernel = -2
 


### PR DESCRIPTION
## Summary

Sweep **batch 1** of the H2 PR-2 plan. Migrates the 8 filters that use only the descriptor types landed in PR-1 (`IntParam`, `FloatParam`, `OddIntParam`) onto the class-level declarative pattern. Each filter loses its `self._<name>` init line, hand-rolled `_add_input(InputPort(...))` construction, and `@property`/`@setter` pair in favour of one descriptor declaration per parameter. Behaviour is preserved end-to-end.

| Filter | Params | Lines |
|---|---|---|
| Median | `size: OddIntParam` | 77 → 47 |
| Delay | `delay_seconds: FloatParam` | 62 → 41 |
| Clamp | `min_value, max_value: FloatParam` | 90 → 50 |
| Shift | `offset_x, offset_y: IntParam` | 92 → 53 |
| Temporal Mean | `window: IntParam` | 84 → 56 |
| Temporal Median | `window: IntParam` | 86 → 64 |
| Adaptive Gaussian Threshold | `block_size: OddIntParam`, `c: IntParam` | 111 → 64 |
| Crop | `x, y, width, height: IntParam` | 141 → 65 |

**Net –205 LoC** across the changed files. Drift between e.g. `metadata["min"]` and the setter's `>=` check is no longer possible — both flow from the descriptor.

## Descriptor protocol fix

`_ParamBase.__set__` is now `coerce → validate → shape` rather than `coerce → validate`. Domain subclasses override the new `_shape` hook (e.g. `OddIntParam`'s even→odd rounding) so a literal value below `min` raises rather than being silently shaped up into range. This preserves the semantics of the hand-rolled setters the descriptor replaces — `Median.size = 0` still raises `ValueError`, even though `OddIntParam`'s shape would otherwise round it to `1`. Without this change, the existing `test_filters.py::test_median_rejects_non_positive_size` would regress.

## Deferred to follow-ups

- **Overlay** — `alpha` needs a clamping float (out-of-range values stay clamped to `[0, 1]` rather than raising; existing `test_overlay_alpha_is_clamped_to_unit_interval` depends on this) and `scale` needs an exclusive `> 0` bound (existing `test_overlay_rejects_non_positive_scale` asserts `scale = 0.0` raises). Both want small additions to `core.params` — a `ClampedFloatParam` subclass and a `min_exclusive` flag — that PR-2b lands together.
- **Bool/String/Enum/FilePath** descriptors land in PR-2b alongside the next batch of filters that need them (Apply Colormap, Dither, Flip, Math, NCC, Notify, Resize, Rotate, Scale, Subpixel Mosaic).
- **Sources/sinks** + the `NodeParam` merger question land in PR-2c.
- **Retire the legacy path** in PR-2d once the sweep is complete.

`refacturing.txt` carries the full PR-2a–PR-2d plan under H2.

## Test plan

- [x] `tests/test_param_descriptors.py` updated for the new `coerce → validate → shape` ordering: `test_odd_int_param_below_min_raises_before_shaping` replaces the old test that documented the inverse semantics. 16/16 passing locally.
- [x] All existing per-filter tests pass unchanged — `test_filters.py`, `test_clamp.py`, `test_new_filters.py`. 104 tests passing locally.
- [x] Full non-Qt suite: **490 passed, 6 xfailed, 129 xpassed**, 0 regressions.
- [x] `tests/test_flow_back_compat.py` round-trips every saved flow under `flow/` (15 files) — `.flowjs` format is still compatible.
- [ ] CI green on Python 3.13.
- [ ] Open a flow that exercises Median or Crop (`flow/folder_resize.flowjs`, `flow/sample_transform.flowjs`) and confirm the inline param widgets edit / save / reload cleanly.

https://claude.ai/code/session_017Sbygfh52wCk9uJYDUEyLW

---
_Generated by [Claude Code](https://claude.ai/code/session_017Sbygfh52wCk9uJYDUEyLW)_