### PR TITLE
feat(display): show total frame count in debug overlay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,19 @@ once a first tagged release is cut.
 
 ## [Unreleased]
 
+## [0.2.27] — 2026-04-28
+
+### Added
+- **Display node shows total frame count.** The top-left debug overlay
+  now carries a second line — `N <count>` — showing the total number of
+  frames processed since the current run started. The count is visible
+  from the very first tick (unlike FPS which needs a measurable `dt`
+  and only appears from tick 2). A new read-only property
+  `frames_processed` exposes the same counter to tests and the UI
+  without scraping the overlay text. The helper method that paints the
+  overlay is renamed `_draw_overlay` (was `_draw_fps_overlay`) to
+  reflect that it now carries more than FPS. Closes #207.
+
 ## [0.2.26] — 2026-04-28
 
 ### Changed

--- a/doc/welcome.html
+++ b/doc/welcome.html
@@ -180,7 +180,7 @@
   <main class="content-col">
 
     <header class="hero">
-      <h1>Welcome to Stjörnhorn <span class="version">v0.2.26</span></h1>
+      <h1>Welcome to Stjörnhorn <span class="version">v0.2.27</span></h1>
       <div class="tagline">A node-based image- and video-processing playground.</div>
     </header>
 
@@ -210,6 +210,13 @@
           <p>Write frames to image files or encode video (MP4V, XVID) with live preview via the Display node.</p>
         </div>
       </div>
+    </section>
+
+    <section>
+      <h2>What's new in v0.2.27</h2>
+      <ul class="tips">
+        <li><strong>Display node shows total frame count.</strong> The top-left debug overlay now has two lines: FPS (from tick 2 as before) and <em>N</em> — the running count of frames processed since the last run started. The count is visible from the very first frame so you can tell at a glance how far into a stream the node is. The new <code>frames_processed</code> property exposes the same counter to tests and the UI without scraping the overlay text. Issue #207.</li>
+      </ul>
     </section>
 
     <section>

--- a/src/constants.py
+++ b/src/constants.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 APP_NAME:         str = "Image-Inquest"
 APP_DISPLAY_NAME: str = "Stjörnhorn"
-APP_VERSION:      str = "0.2.26"
+APP_VERSION:      str = "0.2.27"
 API_URL:    str = "https://beltoforion.de"
 
 # Path resolution -----------------------------------------------------------

--- a/src/nodes/filters/display.py
+++ b/src/nodes/filters/display.py
@@ -30,12 +30,12 @@ class Display(NodeBase):
     each kind (pixmap for images, formatted text for scalars and
     matrices).
 
-    A small FPS read-out is always rendered into the top-left of the
-    *displayed* frame from the second tick onwards (the first tick has
-    no measurable ``dt`` to derive a rate from). The overlay is
-    preview-only — the output port still forwards the original
-    :class:`IoData` so a downstream VideoSink isn't recording debug
-    overlays into the file.
+    A small debug overlay (FPS + frame count) is rendered into the
+    top-left of each *displayed* image frame. The frame count is shown
+    from the very first tick; the FPS line is added from the second tick
+    once a measurable ``dt`` is available. The overlay is preview-only —
+    the output port still forwards the original :class:`IoData` so a
+    downstream VideoSink isn't recording debug overlays into the file.
 
     The node itself is Qt-free — the preview widget lives on the UI
     side in :mod:`ui.preview_widgets`; the worker-thread → main-thread
@@ -53,6 +53,7 @@ class Display(NodeBase):
         self._frame_callback:  Callable[[IoData], None] | None = None
         self._last_frame_ts:   float | None = None
         self._fps_ema:         float | None = None
+        self._frame_count:     int = 0
 
         self._add_input(InputPort("image", set(_DISPLAY_TYPES)))
         self._add_output(OutputPort("image", set(_DISPLAY_TYPES)))
@@ -63,13 +64,17 @@ class Display(NodeBase):
     def latest_frame(self) -> np.ndarray | None:
         """Most recent payload seen, or ``None`` before any run.
 
-        For image payloads this is the FPS-annotated frame from the
-        second tick onwards (so the preview widget renders the
-        overlay); for SCALAR / MATRIX payloads it is the raw 0-d / 2-d
-        array unchanged. The output port always forwards the original
-        payload either way.
+        For image payloads this is the overlay-annotated frame (so the
+        preview widget renders the debug info); for SCALAR / MATRIX
+        payloads it is the raw 0-d / 2-d array unchanged. The output
+        port always forwards the original payload either way.
         """
         return self._latest_frame
+
+    @property
+    def frames_processed(self) -> int:
+        """Total frames dispatched since the last run started."""
+        return self._frame_count
 
     # ── UI integration ─────────────────────────────────────────────────────────
 
@@ -96,10 +101,13 @@ class Display(NodeBase):
         self._latest_frame  = None
         self._last_frame_ts = None
         self._fps_ema       = None
+        self._frame_count   = 0
 
     @override
     def process_impl(self) -> None:
         in_data = self.inputs[0].data
+
+        self._frame_count += 1
 
         # Track dispatch cadence regardless of payload kind — a SCALAR
         # stream has the same notion of "frames per second" as an
@@ -118,13 +126,13 @@ class Display(NodeBase):
                     )
         self._last_frame_ts = now
 
-        # Image payloads get the FPS overlay drawn on a copy for the
+        # Image payloads get the debug overlay drawn on a copy for the
         # preview; SCALAR / MATRIX payloads bypass the overlay since
         # the text-mode preview has no image to annotate. The view
         # IoData (annotated copy or original) is what the callback
         # receives — the output port always forwards the original.
-        if in_data.is_image() and self._fps_ema is not None:
-            annotated = self._draw_fps_overlay(in_data.payload, self._fps_ema)
+        if in_data.is_image():
+            annotated = self._draw_overlay(in_data.payload, self._fps_ema, self._frame_count)
             view_data = IoData(in_data.type, payload=annotated)
             self._latest_frame = annotated
         else:
@@ -141,36 +149,56 @@ class Display(NodeBase):
     # ── Overlay ────────────────────────────────────────────────────────────────
 
     @staticmethod
-    def _draw_fps_overlay(image: np.ndarray, fps: float) -> np.ndarray:
-        """Return a copy of *image* with a small FPS read-out in the top-left."""
+    def _draw_overlay(
+        image: np.ndarray,
+        fps: float | None,
+        frame_count: int,
+    ) -> np.ndarray:
+        """Return a copy of *image* with a debug overlay in the top-left.
+
+        Shows the frame count on every tick. The FPS line is added from
+        tick 2 onwards once a measurable ``dt`` is available.
+        Greyscale (2-D) and colour (3-D) images are both handled.
+        """
         annotated = image.copy()
-        text   = f"FPS {fps:5.1f}"
-        font   = cv2.FONT_HERSHEY_SIMPLEX
-        scale  = 0.6
-        thick  = 1
-        (tw, th), baseline = cv2.getTextSize(text, font, scale, thick)
-        x, y = 8, 8 + th
-        pad  = 4
+        font  = cv2.FONT_HERSHEY_SIMPLEX
+        scale = 0.6
+        thick = 1
+        pad   = 4
+
+        lines: list[str] = []
+        if fps is not None:
+            lines.append(f"FPS {fps:5.1f}")
+        lines.append(f"N   {frame_count:5d}")
+
+        sizes = [cv2.getTextSize(t, font, scale, thick) for t in lines]
+        line_h   = sizes[0][0][1]
+        baseline = sizes[0][1]
+        total_w  = max(s[0][0] for s in sizes)
+        line_gap = 6  # px between successive baselines
+
+        x     = 8
+        y_top = 8 + line_h  # baseline of the first rendered line
+
+        rect_top    = y_top - line_h - pad
+        rect_bottom = y_top + (len(lines) - 1) * (line_h + line_gap) + baseline + pad
+        rect_right  = x + total_w + pad
 
         # Greyscale (2-D) and colour (3-D) take different scalar shapes for
         # cv2.rectangle / putText — branch once instead of guessing.
-        if annotated.ndim == 2:
-            cv2.rectangle(
-                annotated,
-                (x - pad, y - th - pad),
-                (x + tw + pad, y + baseline),
-                0, -1,
-            )
-            cv2.putText(annotated, text, (x, y), font, scale, 255, thick, cv2.LINE_AA)
-        else:
-            cv2.rectangle(
-                annotated,
-                (x - pad, y - th - pad),
-                (x + tw + pad, y + baseline),
-                (0, 0, 0), -1,
-            )
-            cv2.putText(
-                annotated, text, (x, y), font, scale,
-                (255, 255, 255), thick, cv2.LINE_AA,
-            )
+        is_grey = annotated.ndim == 2
+        bg = 0         if is_grey else (0, 0, 0)
+        fg = 255       if is_grey else (255, 255, 255)
+
+        cv2.rectangle(
+            annotated,
+            (x - pad, rect_top),
+            (rect_right, rect_bottom),
+            bg, -1,
+        )
+
+        for i, text in enumerate(lines):
+            y = y_top + i * (line_h + line_gap)
+            cv2.putText(annotated, text, (x, y), font, scale, fg, thick, cv2.LINE_AA)
+
         return annotated

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -135,11 +135,36 @@ def test_display_forwards_finish() -> None:
 
 
 def test_display_has_no_params() -> None:
-    # FPS overlay is unconditional — no user-facing knobs to expose.
+    # Debug overlay is unconditional — no user-facing knobs to expose.
     assert Display().params == []
 
 
-# ── FPS overlay (image preview only) ──────────────────────────────────────────
+def test_display_frames_processed_counter() -> None:
+    node = Display()
+    up, _ = _wire(node)
+
+    node.before_run()
+    assert node.frames_processed == 0
+
+    for i in range(1, 4):
+        up.send(IoData.from_image(_bgr()))
+        assert node.frames_processed == i
+
+    node.before_run()  # reset on new run
+    assert node.frames_processed == 0
+
+
+def test_display_frames_processed_counts_all_payload_kinds() -> None:
+    node = Display()
+    up_img = OutputPort("img", {IoDataType.IMAGE})
+    up_img.connect(node.inputs[0])
+
+    node.before_run()
+    up_img.send(IoData.from_image(_bgr()))
+    assert node.frames_processed == 1
+
+
+# ── Debug overlay (image preview only) ────────────────────────────────────────
 
 def test_display_fps_overlay_does_not_leak_to_output() -> None:
     # The overlay is for the preview only; the output port must still
@@ -167,10 +192,9 @@ def test_display_fps_overlay_does_not_leak_to_output() -> None:
         assert int(d.payload[-1, -1, 0]) == v
 
 
-def test_display_fps_overlay_writes_visible_pixels_on_preview() -> None:
-    # Sanity-check that the overlay actually paints something. The first
-    # frame has no measurable dt → overlay can't render yet, but every
-    # frame after that should have a black rectangle in the top-left.
+def test_display_overlay_writes_visible_pixels_from_first_frame() -> None:
+    # The frame-count line is shown from tick 1; the FPS line joins from
+    # tick 2. Both produce a black background rect in the top-left.
     node = Display()
     received: list[IoData] = []
     node.set_frame_callback(received.append)
@@ -180,12 +204,11 @@ def test_display_fps_overlay_writes_visible_pixels_on_preview() -> None:
     for _ in range(3):
         up.send(IoData.from_image(_bgr(100, h=64, w=128)))
 
-    # First frame is unmodified (no dt yet to derive an FPS reading).
-    np.testing.assert_array_equal(received[0].payload, _bgr(100, h=64, w=128))
-    # On the second frame the overlay rect lives in the top-left.
-    # Pixel (5, 50) sits in the rect's clear space above the text glyphs
-    # so it should be solid black, distinct from the input fill of 100.
-    assert int(received[1].payload[5, 50, 0]) == 0
+    # All three frames have the overlay. Pixel (5, 50) sits inside the
+    # background rect (well clear of the text glyphs) and should be
+    # solid black, distinct from the uniform fill of 100.
+    for frame in received:
+        assert int(frame.payload[5, 50, 0]) == 0
 
 
 # ── SCALAR / MATRIX support ───────────────────────────────────────────────────
@@ -250,8 +273,8 @@ def test_display_passes_through_matrix() -> None:
     assert node.latest_frame.shape == (2, 2)
 
 
-def test_display_skips_fps_overlay_for_scalar_payload() -> None:
-    """SCALAR / MATRIX preview is text-mode — the FPS overlay (an
+def test_display_skips_overlay_for_scalar_payload() -> None:
+    """SCALAR / MATRIX preview is text-mode — the debug overlay (an
     image-blitting cv2 op) can't and shouldn't run on a 0-d array.
     The callback must receive the original IoData unchanged."""
     node = Display()


### PR DESCRIPTION
The Display node's top-left overlay now shows two lines: FPS (from tick 2 as before) and `N <count>` (total frames processed since the run started, visible from tick 1).

New read-only property `frames_processed` exposes the counter without scraping overlay text. The helper is renamed `_draw_overlay` (was `_draw_fps_overlay`). Tests updated and two new counter tests added.

Closes #207

Generated with [Claude Code](https://claude.ai/code)