### PR TITLE
H2 PR-2b: Bool/Enum/Clamped descriptors + migrate 6 more filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,34 @@ once a first tagged release is cut.
 
 ## [Unreleased]
 
+## [0.2.29] — 2026-04-28
+
+### Added
+- **``BoolParam``, ``EnumParam``, ``ClampedFloatParam`` descriptors;
+  ``min_exclusive`` / ``max_exclusive`` flag on ``FloatParam``.**
+  Four new pieces in ``core.params`` covering the descriptor types
+  the next batch of filters needed:
+  - ``BoolParam`` — toggle backed by ``IoDataType.BOOL``.
+  - ``EnumParam`` — combo-box backed by ``IoDataType.ENUM``; coerce
+    accepts the enum member, its ``.value``, or its ``.name``.
+  - ``ClampedFloatParam`` — float whose ``min`` / ``max`` clamp via
+    ``_shape`` rather than raise via ``_validate``. Used when
+    out-of-range input is a UX choice (``Overlay.alpha`` —
+    ``2.5`` becomes ``1.0``, no exception).
+  - ``FloatParam(min_exclusive=True)`` / ``max_exclusive=True`` —
+    strict bounds (``> min`` rather than ``>= min``). Used by
+    ``Overlay.scale`` which must be strictly positive.
+
+### Changed
+- **Param descriptor sweep — batch 2 (H2 PR-2b).** Migrated six more
+  filters: Overlay, Subpixel Mosaic, Flip, Dither, Rotate, Scale.
+  Each loses its ``self._<name>`` init lines, hand-rolled
+  ``_add_input(InputPort(...))`` constructions, and per-param
+  ``@property``/``@setter`` pairs in favour of single descriptor
+  declarations. ``Overlay`` is the headline migration since it
+  exercises all five descriptor types in one node — including the
+  new clamping float and exclusive-bound float.
+
 ## [0.2.28] — 2026-04-28
 
 ### Changed

--- a/doc/welcome.html
+++ b/doc/welcome.html
@@ -180,7 +180,7 @@
   <main class="content-col">
 
     <header class="hero">
-      <h1>Welcome to Stjörnhorn <span class="version">v0.2.28</span></h1>
+      <h1>Welcome to Stjörnhorn <span class="version">v0.2.29</span></h1>
       <div class="tagline">A node-based image- and video-processing playground.</div>
     </header>
 
@@ -210,6 +210,13 @@
           <p>Write frames to image files or encode video (MP4V, XVID) with live preview via the Display node.</p>
         </div>
       </div>
+    </section>
+
+    <section>
+      <h2>What's new in v0.2.29</h2>
+      <ul class="tips">
+        <li><strong>Param descriptor sweep — second batch (PR-2b of H2).</strong> Six more filters (Overlay, Subpixel Mosaic, Flip, Dither, Rotate, Scale) ported from hand-rolled <code>InputPort</code> + <code>@property</code>/<code>@setter</code> declarations to class-level descriptors. The descriptor module gained four new types: <code>BoolParam</code> for toggles, <code>EnumParam</code> for combo-box selections (auto-coerces ints, names, and members), <code>ClampedFloatParam</code> for soft-bounded sliders that saturate instead of raising (used by <code>Overlay.alpha</code> — out-of-range stays clamped to <code>[0, 1]</code>), and a <code>min_exclusive</code> / <code>max_exclusive</code> flag on <code>FloatParam</code> for strict bounds (used by <code>Overlay.scale</code> which requires <code>&gt; 0</code>). All pre-existing per-filter tests pass unchanged. Backlog item H2.</li>
+      </ul>
     </section>
 
     <section>

--- a/refacturing.txt
+++ b/refacturing.txt
@@ -106,26 +106,28 @@ High
       preserved. GaussianBlur migrated as proof: 95 → 57 lines.
       tests/test_param_descriptors.py + tests/test_flow_back_compat.py.
 
-    PR-2a (in flight on branch claude/h2-pr2a-numeric-filters):
-      Sweep batch 1 — eight filters using only IntParam / FloatParam
-      / OddIntParam: Median, Delay, Clamp, Shift, Temporal Mean,
-      Temporal Median, Adaptive Gaussian Threshold, Crop. Each loses
-      30–50% LoC. Descriptor protocol gained a _shape hook running
-      after _validate so 0 still raises on Median.size (matching the
-      old setter), even though OddIntParam's shape would round it to
-      1. Test test_filters.py::test_median_rejects_non_positive_size
-      preserved unchanged.
+    PR-2a (merged): Sweep batch 1 — eight filters using only
+      IntParam / FloatParam / OddIntParam: Median, Delay, Clamp,
+      Shift, Temporal Mean, Temporal Median, Adaptive Gaussian
+      Threshold, Crop. Each lost 30–50% LoC. Descriptor protocol
+      gained a _shape hook running after _validate so 0 still
+      raises on Median.size (matching the old setter), even though
+      OddIntParam's shape would round it to 1.
 
-    PR-2b (planned): add ClampedFloatParam (Overlay.alpha) and
-      min_exclusive flag on FloatParam (Overlay.scale > 0). Migrate
-      Overlay. This PR also lands BoolParam + StringParam + EnumParam
-      + FilePathParam descriptors and migrates the next batch of
-      filters that need them: Apply Colormap, Dither, Flip, Notify,
-      Resize, Rotate, Scale, Subpixel Mosaic, Math, NCC.
+    PR-2b (in flight on branch claude/h2-pr2b-bool-enum-overlay):
+      Added BoolParam, EnumParam, ClampedFloatParam and a
+      min_exclusive / max_exclusive flag on FloatParam. Migrated:
+      Overlay, Subpixel Mosaic, Flip, Dither, Rotate, Scale.
+      Overlay is the headline since it exercises every new type in
+      one node. StringParam + FilePathParam still TODO; they land
+      with the filters that use them in PR-2c (Notify, NCC).
 
-    PR-2c (planned): sources + sinks. Decides the NodeParam merger
-      question (open question 3). file_path setters with side
-      effects (open question 1) drive the on_change= hook design.
+    PR-2c (planned): add StringParam + FilePathParam. Migrate the
+      remaining port-style filters: Notify (STRING + ENUM), NCC
+      (BOOL + FILE_PATH), Math (FLOAT + STRING). Then tackle
+      sources + sinks, deciding the NodeParam merger question
+      (open question 3). file_path setters with side effects
+      (open question 1) drive the on_change= hook design.
 
     PR-2d (planned): retire the legacy _add_input(InputPort(...)) +
       @property path from NodeBase once empty. Move H2, H4, M9 to

--- a/src/constants.py
+++ b/src/constants.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 APP_NAME:         str = "Image-Inquest"
 APP_DISPLAY_NAME: str = "Stjörnhorn"
-APP_VERSION:      str = "0.2.28"
+APP_VERSION:      str = "0.2.29"
 API_URL:    str = "https://beltoforion.de"
 
 # Path resolution -----------------------------------------------------------

--- a/src/core/params.py
+++ b/src/core/params.py
@@ -27,6 +27,7 @@ Backlog item H2 (see ``refacturing.txt``).
 """
 from __future__ import annotations
 
+from enum import Enum
 from typing import TYPE_CHECKING, Any
 
 from core.io_data import IoDataType
@@ -241,6 +242,9 @@ class FloatParam(_ParamBase):
 
     Coerces incoming values via ``float(value)``. Optional ``min`` /
     ``max`` bounds raise :class:`ValueError` on out-of-range writes.
+    Set ``min_exclusive=True`` / ``max_exclusive=True`` to make the
+    bound strict (``> min`` rather than ``>= min``) — used e.g. by
+    ``Overlay.scale`` which must be strictly positive.
     ``step`` and ``decimals`` flow into the spin-box widget metadata.
     """
 
@@ -253,6 +257,8 @@ class FloatParam(_ParamBase):
         *,
         min: float | None = None,
         max: float | None = None,
+        min_exclusive: bool = False,
+        max_exclusive: bool = False,
         step: float | None = None,
         decimals: int | None = None,
         unit: str | None = None,
@@ -267,6 +273,8 @@ class FloatParam(_ParamBase):
         )
         self.min: float | None = min
         self.max: float | None = max
+        self.min_exclusive: bool = min_exclusive
+        self.max_exclusive: bool = max_exclusive
         self.step: float | None = step
         self.decimals: int | None = decimals
 
@@ -274,14 +282,20 @@ class FloatParam(_ParamBase):
         return float(value)
 
     def _validate(self, value: float) -> None:
-        if self.min is not None and value < self.min:
-            raise ValueError(
-                f"{self.name} must be >= {self.min} (got {value})"
-            )
-        if self.max is not None and value > self.max:
-            raise ValueError(
-                f"{self.name} must be <= {self.max} (got {value})"
-            )
+        if self.min is not None:
+            below = value <= self.min if self.min_exclusive else value < self.min
+            if below:
+                op = ">" if self.min_exclusive else ">="
+                raise ValueError(
+                    f"{self.name} must be {op} {self.min} (got {value})"
+                )
+        if self.max is not None:
+            above = value >= self.max if self.max_exclusive else value > self.max
+            if above:
+                op = "<" if self.max_exclusive else "<="
+                raise ValueError(
+                    f"{self.name} must be {op} {self.max} (got {value})"
+                )
 
     def _build_metadata(self) -> dict[str, object]:
         meta = super()._build_metadata()
@@ -294,3 +308,123 @@ class FloatParam(_ParamBase):
         if self.decimals is not None:
             meta["decimals"] = self.decimals
         return meta
+
+
+class ClampedFloatParam(FloatParam):
+    """Float parameter whose ``min`` / ``max`` clamp rather than raise.
+
+    Use when out-of-range input is a UX choice, not a user error — e.g.
+    an opacity slider where 1.5 is conceptually just 1.0 ("fully
+    opaque") and a negative value is just 0.0 ("fully transparent").
+    Validation is suppressed and the bounds are enforced by
+    :meth:`_shape` instead, so the widget still gets ``min`` / ``max``
+    in its metadata (the spin-box stays bounded) but a port-driven or
+    programmatic write that lands outside the range is silently clamped
+    rather than rejected.
+
+    Both bounds are inclusive — the exclusive variants
+    (``min_exclusive`` / ``max_exclusive``) on :class:`FloatParam` do
+    not apply here because clamping a value to an open bound is
+    ill-defined.
+    """
+
+    def _validate(self, value: float) -> None:
+        # Bounds enforced via _shape (clamp), not _validate (raise).
+        pass
+
+    def _shape(self, value: float) -> float:
+        if self.min is not None and value < self.min:
+            return self.min
+        if self.max is not None and value > self.max:
+            return self.max
+        return value
+
+
+class BoolParam(_ParamBase):
+    """Boolean node parameter.
+
+    Coerces incoming values via ``bool(value)``. No validation hook
+    needed — every value Python accepts as truthy/falsy is valid.
+    """
+
+    _NODE_PARAM_TYPE = NodeParamType.BOOL
+    _PORT_TYPE = IoDataType.BOOL
+
+    def __init__(
+        self,
+        default: bool,
+        *,
+        description: str | None = None,
+        optional: bool = True,
+    ) -> None:
+        super().__init__(
+            default,
+            description=description,
+            optional=optional,
+        )
+
+    def _coerce(self, value: object) -> bool:
+        return bool(value)
+
+
+class EnumParam(_ParamBase):
+    """Enum-valued node parameter.
+
+    The enum class is required; the descriptor stores the chosen
+    member, the :class:`InputPort` carries the class itself in its
+    metadata under ``"enum"`` so the param-widget builder can populate
+    the combo box.
+
+    Coercion accepts the enum member, its ``.value``, or its ``.name``
+    (string), to make ``__set__`` forgiving for port-driven streams
+    that may carry either form. Raises :class:`ValueError` if the
+    incoming value can't be mapped to a member of the enum.
+    """
+
+    _NODE_PARAM_TYPE = NodeParamType.ENUM
+    _PORT_TYPE = IoDataType.ENUM
+
+    def __init__(
+        self,
+        enum_cls: type[Enum],
+        default: Enum,
+        *,
+        description: str | None = None,
+        optional: bool = True,
+    ) -> None:
+        if not (isinstance(enum_cls, type) and issubclass(enum_cls, Enum)):
+            raise TypeError(
+                f"EnumParam requires an Enum subclass, got {enum_cls!r}"
+            )
+        if not isinstance(default, enum_cls):
+            raise TypeError(
+                f"EnumParam default {default!r} is not a member of {enum_cls.__name__}"
+            )
+        super().__init__(
+            default,
+            description=description,
+            optional=optional,
+        )
+        self.enum_cls: type[Enum] = enum_cls
+
+    def _coerce(self, value: object) -> Enum:
+        if isinstance(value, self.enum_cls):
+            return value
+        try:
+            return self.enum_cls(value)
+        except (ValueError, KeyError):
+            pass
+        if isinstance(value, str):
+            try:
+                return self.enum_cls[value]
+            except KeyError:
+                pass
+        raise ValueError(
+            f"{self.name}: cannot map {value!r} to a {self.enum_cls.__name__} member"
+        )
+
+    def _build_metadata(self) -> dict[str, object]:
+        meta = super()._build_metadata()
+        meta["enum"] = self.enum_cls
+        return meta
+

--- a/src/nodes/filters/dither.py
+++ b/src/nodes/filters/dither.py
@@ -8,8 +8,9 @@ import numba
 import numpy as np
 from typing_extensions import override
 
-from core.io_data import IMAGE_TYPES, IoDataType
-from core.node_base import NodeBase, NodeParamType
+from core.io_data import IMAGE_TYPES
+from core.node_base import NodeBase
+from core.params import EnumParam
 from core.port import InputPort, OutputPort
 
 
@@ -111,52 +112,24 @@ class Dither(NodeBase):
     original OCVL implementation.
     """
 
+    method = EnumParam(
+        DitherMethod,
+        DitherMethod.STUCKI,
+        description=(
+            "Dithering algorithm. BAYER2 / 4 / 8 are ordered-dither "
+            "matrices (cheap, regular pattern). NOISE is white-noise "
+            "thresholding. FLOYD_STEINBERG, STUCKI, ATKINSON, BURKES, "
+            "SIERRA distribute quantisation error to neighbouring "
+            "pixels for finer detail. DIFFUSION_X / _XY are minimal "
+            "1- or 2-cell diffusion variants."
+        ),
+    )
+
     def __init__(self) -> None:
         super().__init__("Dither", section="Processing")
-        self._method: DitherMethod = DitherMethod.STUCKI
-
         self._add_input(InputPort("image", set(IMAGE_TYPES)))
-        self._add_input(InputPort(
-            "method",
-            {IoDataType.ENUM},
-            optional=True,
-            default_value=DitherMethod.STUCKI,
-            metadata={
-                "default": DitherMethod.STUCKI,
-                "enum": DitherMethod,
-                "param_type": NodeParamType.ENUM,
-                "description": (
-                    "Dithering algorithm. BAYER2 / 4 / 8 are ordered-dither "
-                    "matrices (cheap, regular pattern). NOISE is white-noise "
-                    "thresholding. FLOYD_STEINBERG, STUCKI, ATKINSON, BURKES, "
-                    "SIERRA distribute quantisation error to neighbouring "
-                    "pixels for finer detail. DIFFUSION_X / _XY are minimal "
-                    "1- or 2-cell diffusion variants."
-                ),
-            },
-        ))
         self._add_output(OutputPort("image", set(IMAGE_TYPES)))
-
         self._apply_default_params()
-
-    # ── Properties ─────────────────────────────────────────────────────────────
-
-    @property
-    def method(self) -> DitherMethod:
-        return self._method
-
-    @method.setter
-    def method(self, value: int | DitherMethod) -> None:
-        try:
-            # DitherMethod(int) validates the integer and raises on unknown
-            # values; passing a DitherMethod member just returns itself.
-            self._method = DitherMethod(value)
-        except ValueError as e:
-            raise ValueError(
-                f"method must be one of {[m.value for m in DitherMethod]} (got {value!r})"
-            ) from e
-
-    # ── NodeBase interface ─────────────────────────────────────────────────────
 
     @override
     def process_impl(self) -> None:

--- a/src/nodes/filters/flip.py
+++ b/src/nodes/filters/flip.py
@@ -5,8 +5,9 @@ from enum import IntEnum
 import cv2
 from typing_extensions import override
 
-from core.io_data import IMAGE_TYPES, IoDataType
-from core.node_base import NodeBase, NodeParamType
+from core.io_data import IMAGE_TYPES
+from core.node_base import NodeBase
+from core.params import EnumParam
 from core.port import InputPort, OutputPort
 
 
@@ -27,43 +28,20 @@ class FlipMode(IntEnum):
 class Flip(NodeBase):
     """Mirror an image horizontally, vertically, or both."""
 
+    mode = EnumParam(
+        FlipMode,
+        FlipMode.HORIZONTAL,
+        description=(
+            "Flip direction. HORIZONTAL mirrors left/right, "
+            "VERTICAL mirrors top/bottom, BOTH does a 180° rotation."
+        ),
+    )
+
     def __init__(self) -> None:
         super().__init__("Flip", section="Transform")
-        self._mode: FlipMode = FlipMode.HORIZONTAL
-
         self._add_input(InputPort("image", set(IMAGE_TYPES)))
-        self._add_input(InputPort(
-            "mode",
-            {IoDataType.ENUM},
-            optional=True,
-            default_value=FlipMode.HORIZONTAL,
-            metadata={
-                "default": FlipMode.HORIZONTAL,
-                "enum": FlipMode,
-                "param_type": NodeParamType.ENUM,
-                "description": (
-                    "Flip direction. HORIZONTAL mirrors left/right, "
-                    "VERTICAL mirrors top/bottom, BOTH does a 180° rotation."
-                ),
-            },
-        ))
         self._add_output(OutputPort("image", set(IMAGE_TYPES)))
-
         self._apply_default_params()
-
-    @property
-    def mode(self) -> FlipMode:
-        return self._mode
-
-    @mode.setter
-    def mode(self, value: int | FlipMode) -> None:
-        try:
-            self._mode = FlipMode(value)
-        except ValueError as e:
-            raise ValueError(
-                f"mode must be one of {[m.value for m in FlipMode]} "
-                f"(got {value!r})"
-            ) from e
 
     @override
     def process_impl(self) -> None:

--- a/src/nodes/filters/overlay.py
+++ b/src/nodes/filters/overlay.py
@@ -5,7 +5,8 @@ import numpy as np
 from typing_extensions import override
 
 from core.io_data import IMAGE_TYPES, IoData, IoDataType
-from core.node_base import NodeBase, NodeParamType
+from core.node_base import NodeBase
+from core.params import ClampedFloatParam, FloatParam, IntParam
 from core.port import InputPort, OutputPort
 
 
@@ -36,166 +37,61 @@ class Overlay(NodeBase):
       image is always reduced to BGR before compositing — any alpha
       channel on the base is dropped.
 
-    Port-driven params:
-      Every numeric parameter (``scale``, ``angle``, ``xpos``,
-      ``ypos``, ``alpha``) has a matching optional SCALAR input port,
-      auto-created from the param declaration by
-      :meth:`NodeBase._apply_default_params`. When the port is
-      connected — typically to a
-      :class:`~nodes.sources.value_source.ValueSource` — each
-      streamed value overrides the literal param for that frame,
-      restored to the user-set fallback after the frame. So wiring
-      a 0..359 ramp into ``angle`` produces a full rotation per Run,
-      a 0.5..2.0 ramp into ``scale`` an animated zoom, etc. The
-      ``angle`` port is declared explicitly here at index 2 so saved
-      flows that connected to it pre-auto-port keep loading
-      unchanged; the rest of the param ports come after it via
-      auto-creation.
+    Param ordering note:
+      ``angle`` is declared first so the auto-created ports land in
+      the order ``angle, scale, xpos, ypos, alpha`` — index 2..6 on
+      ``self.inputs``, matching the layout saved flows reference.
     """
+
+    angle = FloatParam(
+        0.0,
+        unit="deg",
+        description=(
+            "Overlay rotation in degrees, counter-clockwise around "
+            "its centre. The bounding box is expanded so no pixels "
+            "are lost."
+        ),
+    )
+    scale = FloatParam(
+        1.0,
+        min=0.0,
+        min_exclusive=True,
+        description="Overlay scale factor. 1.0 = unchanged.",
+    )
+    xpos = IntParam(
+        0,
+        unit="px",
+        description=(
+            "X-coordinate (in base-image pixels) of the overlay's "
+            "centre — not its top-left corner."
+        ),
+    )
+    ypos = IntParam(
+        0,
+        unit="px",
+        description=(
+            "Y-coordinate (in base-image pixels) of the overlay's "
+            "centre — not its top-left corner."
+        ),
+    )
+    alpha = ClampedFloatParam(
+        1.0,
+        min=0.0,
+        max=1.0,
+        description=(
+            "Global opacity multiplier in [0, 1]. Out-of-range values "
+            "clamp rather than raise so a sweep into negative or >1 "
+            "territory just saturates. For BGRA overlays this "
+            "multiplies on top of the per-pixel alpha channel."
+        ),
+    )
 
     def __init__(self) -> None:
         super().__init__("Overlay", section="Composit")
-
-        self._scale: float = 1.0
-        self._angle: float = 0.0
-        self._xpos:  int   = 0
-        self._ypos:  int   = 0
-        self._alpha: float = 1.0
-
         self._add_input(InputPort("image", set(IMAGE_TYPES)))
         self._add_input(InputPort("overlay", set(IMAGE_TYPES)))
-        # Param-style inputs declared inline. ``angle`` lands at index 2
-        # for backwards compat with saved flows that referenced this
-        # port before the auto-port mechanism existed; scale / xpos /
-        # ypos / alpha follow at indices 3..6 in the same order the
-        # old auto-port pass produced them.
-        self._add_input(InputPort(
-            "angle",
-            {IoDataType.SCALAR},
-            optional=True,
-            default_value=0.0,
-            metadata={
-                "default": 0.0,
-                "param_type": NodeParamType.FLOAT,
-                "unit": "deg",
-                "description": (
-                    "Overlay rotation in degrees, counter-clockwise around "
-                    "its centre. The bounding box is expanded so no pixels "
-                    "are lost."
-                ),
-            },
-        ))
-        self._add_input(InputPort(
-            "scale",
-            {IoDataType.SCALAR},
-            optional=True,
-            default_value=1.0,
-            metadata={
-                "default": 1.0,
-                "param_type": NodeParamType.FLOAT,
-                "min": 0.0,
-                "description": "Overlay scale factor. 1.0 = unchanged.",
-            },
-        ))
-        self._add_input(InputPort(
-            "xpos",
-            {IoDataType.SCALAR},
-            optional=True,
-            default_value=0,
-            metadata={
-                "default": 0,
-                "param_type": NodeParamType.INT,
-                "unit": "px",
-                "description": (
-                    "X-coordinate (in base-image pixels) of the overlay's "
-                    "centre — not its top-left corner."
-                ),
-            },
-        ))
-        self._add_input(InputPort(
-            "ypos",
-            {IoDataType.SCALAR},
-            optional=True,
-            default_value=0,
-            metadata={
-                "default": 0,
-                "param_type": NodeParamType.INT,
-                "unit": "px",
-                "description": (
-                    "Y-coordinate (in base-image pixels) of the overlay's "
-                    "centre — not its top-left corner."
-                ),
-            },
-        ))
-        self._add_input(InputPort(
-            "alpha",
-            {IoDataType.SCALAR},
-            optional=True,
-            default_value=1.0,
-            metadata={
-                "default": 1.0,
-                "param_type": NodeParamType.FLOAT,
-                "min": 0.0,
-                "max": 1.0,
-                "description": (
-                    "Global opacity multiplier in [0, 1]. For BGRA "
-                    "overlays this multiplies on top of the per-pixel "
-                    "alpha channel."
-                ),
-            },
-        ))
         self._add_output(OutputPort("image", set(IMAGE_TYPES)))
-
         self._apply_default_params()
-
-    # ── Properties ─────────────────────────────────────────────────────────────
-
-    @property
-    def scale(self) -> float:
-        return self._scale
-
-    @scale.setter
-    def scale(self, value: float) -> None:
-        v = float(value)
-        if v <= 0.0:
-            raise ValueError(f"scale must be > 0 (got {v})")
-        self._scale = v
-
-    @property
-    def angle(self) -> float:
-        return self._angle
-
-    @angle.setter
-    def angle(self, value: float) -> None:
-        self._angle = float(value)
-
-    @property
-    def xpos(self) -> int:
-        return self._xpos
-
-    @xpos.setter
-    def xpos(self, value: int) -> None:
-        self._xpos = int(value)
-
-    @property
-    def ypos(self) -> int:
-        return self._ypos
-
-    @ypos.setter
-    def ypos(self, value: int) -> None:
-        self._ypos = int(value)
-
-    @property
-    def alpha(self) -> float:
-        return self._alpha
-
-    @alpha.setter
-    def alpha(self, value: float) -> None:
-        v = float(value)
-        # Clamp to [0, 1] so cv2.addWeighted stays well-defined.
-        self._alpha = max(0.0, min(1.0, v))
-
-    # ── NodeBase interface ─────────────────────────────────────────────────────
 
     @override
     def process_impl(self) -> None:

--- a/src/nodes/filters/rotate.py
+++ b/src/nodes/filters/rotate.py
@@ -4,8 +4,9 @@ import cv2
 import numpy as np
 from typing_extensions import override
 
-from core.io_data import IMAGE_TYPES, IoDataType
-from core.node_base import NodeBase, NodeParamType
+from core.io_data import IMAGE_TYPES
+from core.node_base import NodeBase
+from core.params import BoolParam, FloatParam
 from core.port import InputPort, OutputPort
 
 
@@ -19,61 +20,28 @@ class Rotate(NodeBase):
     keeps the input dimensions and corners may fall outside.
     """
 
+    angle = FloatParam(
+        0.0,
+        unit="deg",
+        description=(
+            "Rotation angle in degrees, counter-clockwise around "
+            "the image centre."
+        ),
+    )
+    expand = BoolParam(
+        True,
+        description=(
+            "When on, the output canvas grows so no pixel is "
+            "clipped. When off, the output keeps the input "
+            "dimensions and corners may fall outside."
+        ),
+    )
+
     def __init__(self) -> None:
         super().__init__("Rotate", section="Transform")
-        self._angle:  float = 0.0
-        self._expand: bool  = True
-
         self._add_input(InputPort("image", set(IMAGE_TYPES)))
-        self._add_input(InputPort(
-            "angle",
-            {IoDataType.SCALAR},
-            optional=True,
-            default_value=0.0,
-            metadata={
-                "default": 0.0,
-                "param_type": NodeParamType.FLOAT,
-                "unit": "deg",
-                "description": (
-                    "Rotation angle in degrees, counter-clockwise around "
-                    "the image centre."
-                ),
-            },
-        ))
-        self._add_input(InputPort(
-            "expand",
-            {IoDataType.BOOL},
-            optional=True,
-            default_value=True,
-            metadata={
-                "default": True,
-                "param_type": NodeParamType.BOOL,
-                "description": (
-                    "When on, the output canvas grows so no pixel is "
-                    "clipped. When off, the output keeps the input "
-                    "dimensions and corners may fall outside."
-                ),
-            },
-        ))
         self._add_output(OutputPort("image", set(IMAGE_TYPES)))
-
         self._apply_default_params()
-
-    @property
-    def angle(self) -> float:
-        return self._angle
-
-    @angle.setter
-    def angle(self, value: float) -> None:
-        self._angle = float(value)
-
-    @property
-    def expand(self) -> bool:
-        return self._expand
-
-    @expand.setter
-    def expand(self, value: bool) -> None:
-        self._expand = bool(value)
 
     @override
     def process_impl(self) -> None:

--- a/src/nodes/filters/scale.py
+++ b/src/nodes/filters/scale.py
@@ -6,8 +6,9 @@ import cv2
 import numpy as np
 from typing_extensions import override
 
-from core.io_data import IMAGE_TYPES, IoDataType
-from core.node_base import NodeBase, NodeParamType
+from core.io_data import IMAGE_TYPES
+from core.node_base import NodeBase
+from core.params import EnumParam, IntParam
 from core.port import InputPort, OutputPort
 
 
@@ -16,11 +17,7 @@ class Interpolation(IntEnum):
 
     Values mirror the corresponding ``cv2.INTER_*`` flags exactly so the
     enum member can be passed straight into :func:`cv2.resize` without a
-    lookup table. Backed by :class:`IntEnum` so the integer
-    representation (persisted in saved flows) round-trips cleanly: JSON
-    stores the int, the setter accepts both ints and enum members, and
-    the ``ENUM`` param widget renders a combo box of ``name``-based
-    labels.
+    lookup table.
     """
     NEAREST   = cv2.INTER_NEAREST
     LINEAR    = cv2.INTER_LINEAR
@@ -38,78 +35,31 @@ class Scale(NodeBase):
     size is needed, compute the matching scale factor.
     """
 
+    scale_percent = IntParam(
+        100,
+        min=1,
+        unit="%",
+        description=(
+            "Scale factor in percent. 100 leaves the image "
+            "unchanged; 50 halves it; 200 doubles it."
+        ),
+    )
+    interpolation = EnumParam(
+        Interpolation,
+        Interpolation.LINEAR,
+        description=(
+            "Resampling method. NEAREST is fast and pixelated; "
+            "LINEAR / CUBIC / LANCZOS4 produce progressively "
+            "smoother results at higher cost; AREA is OpenCV's "
+            "preferred choice when downsampling."
+        ),
+    )
+
     def __init__(self) -> None:
         super().__init__("Scale", section="Transform")
-        self._scale_percent: int = 100
-        self._interpolation: Interpolation = Interpolation.LINEAR
-
         self._add_input(InputPort("image", set(IMAGE_TYPES)))
-        self._add_input(InputPort(
-            "scale_percent",
-            {IoDataType.SCALAR},
-            optional=True,
-            default_value=100,
-            metadata={
-                "default": 100,
-                "param_type": NodeParamType.INT,
-                "min": 1,
-                "unit": "%",
-                "description": (
-                    "Scale factor in percent. 100 leaves the image "
-                    "unchanged; 50 halves it; 200 doubles it."
-                ),
-            },
-        ))
-        self._add_input(InputPort(
-            "interpolation",
-            {IoDataType.ENUM},
-            optional=True,
-            default_value=Interpolation.LINEAR,
-            metadata={
-                "default": Interpolation.LINEAR,
-                "enum": Interpolation,
-                "param_type": NodeParamType.ENUM,
-                "description": (
-                    "Resampling method. NEAREST is fast and pixelated; "
-                    "LINEAR / CUBIC / LANCZOS4 produce progressively "
-                    "smoother results at higher cost; AREA is OpenCV's "
-                    "preferred choice when downsampling."
-                ),
-            },
-        ))
         self._add_output(OutputPort("image", set(IMAGE_TYPES)))
-
         self._apply_default_params()
-
-    # ── Properties ─────────────────────────────────────────────────────────────
-
-    @property
-    def scale_percent(self) -> int:
-        return self._scale_percent
-
-    @scale_percent.setter
-    def scale_percent(self, value: int) -> None:
-        v = int(value)
-        if v <= 0:
-            raise ValueError(f"scale_percent must be > 0 (got {v})")
-        self._scale_percent = v
-
-    @property
-    def interpolation(self) -> Interpolation:
-        return self._interpolation
-
-    @interpolation.setter
-    def interpolation(self, value: int | Interpolation) -> None:
-        try:
-            # Interpolation(int) validates the integer and raises on unknown
-            # values; passing an Interpolation member just returns itself.
-            self._interpolation = Interpolation(value)
-        except ValueError as e:
-            raise ValueError(
-                f"interpolation must be one of {[m.value for m in Interpolation]} (got {value!r})"
-            ) from e
-
-    # ── NodeBase interface ─────────────────────────────────────────────────────
 
     @override
     def process_impl(self) -> None:

--- a/src/nodes/filters/subpixel_mosaic.py
+++ b/src/nodes/filters/subpixel_mosaic.py
@@ -6,7 +6,8 @@ import numpy as np
 from typing_extensions import override
 
 from core.io_data import IMAGE_TYPES, IoData, IoDataType
-from core.node_base import NodeBase, NodeParamType
+from core.node_base import NodeBase
+from core.params import BoolParam
 from core.port import InputPort, OutputPort
 
 
@@ -28,65 +29,28 @@ class SubpixelMosaic(NodeBase):
     scatter kernel is JIT-compiled by numba (``@njit(cache=True)``).
     """
 
+    keep_aspect = BoolParam(
+        False,
+        description=(
+            "When on, the mosaic canvas is resampled to 2w × 2h "
+            "so the output matches the source aspect ratio. "
+            "When off, the raw 1.5w × 2h mosaic is emitted "
+            "(vertical stretch of 4/3)."
+        ),
+    )
+    output_grayscale = BoolParam(
+        False,
+        description=(
+            "When on, drops the colour and emits the per-pixel "
+            "sample intensity as a single-channel image."
+        ),
+    )
+
     def __init__(self) -> None:
         super().__init__("Subpixel Mosaic", section="Experimental")
-        self._keep_aspect: bool = False
-        self._output_grayscale: bool = False
-
         self._add_input(InputPort("image", {IoDataType.IMAGE}))
-        self._add_input(InputPort(
-            "keep_aspect",
-            {IoDataType.BOOL},
-            optional=True,
-            default_value=False,
-            metadata={
-                "default": False,
-                "param_type": NodeParamType.BOOL,
-                "description": (
-                    "When on, the mosaic canvas is resampled to 2w × 2h "
-                    "so the output matches the source aspect ratio. "
-                    "When off, the raw 1.5w × 2h mosaic is emitted "
-                    "(vertical stretch of 4/3)."
-                ),
-            },
-        ))
-        self._add_input(InputPort(
-            "output_grayscale",
-            {IoDataType.BOOL},
-            optional=True,
-            default_value=False,
-            metadata={
-                "default": False,
-                "param_type": NodeParamType.BOOL,
-                "description": (
-                    "When on, drops the colour and emits the per-pixel "
-                    "sample intensity as a single-channel image."
-                ),
-            },
-        ))
         self._add_output(OutputPort("image", set(IMAGE_TYPES)))
-
         self._apply_default_params()
-
-    # ── Properties ─────────────────────────────────────────────────────────────
-
-    @property
-    def keep_aspect(self) -> bool:
-        return self._keep_aspect
-
-    @keep_aspect.setter
-    def keep_aspect(self, value: bool) -> None:
-        self._keep_aspect = bool(value)
-
-    @property
-    def output_grayscale(self) -> bool:
-        return self._output_grayscale
-
-    @output_grayscale.setter
-    def output_grayscale(self, value: bool) -> None:
-        self._output_grayscale = bool(value)
-
-    # ── NodeBase interface ─────────────────────────────────────────────────────
 
     @override
     def process_impl(self) -> None:

--- a/tests/test_param_descriptors.py
+++ b/tests/test_param_descriptors.py
@@ -16,9 +16,18 @@ from __future__ import annotations
 
 import pytest
 
+from enum import IntEnum
+
 from core.io_data import IMAGE_TYPES, IoDataType
 from core.node_base import NodeBase
-from core.params import FloatParam, IntParam, OddIntParam
+from core.params import (
+    BoolParam,
+    ClampedFloatParam,
+    EnumParam,
+    FloatParam,
+    IntParam,
+    OddIntParam,
+)
 from core.port import InputPort, OutputPort
 
 
@@ -190,3 +199,117 @@ def test_existing_input_with_same_name_blocks_auto_creation() -> None:
     count_ports = [p for p in node.inputs if p.name == "count"]
     assert len(count_ports) == 1
     assert count_ports[0].metadata.get("explicit") is True
+
+
+# ── Bool / Enum / Clamped / exclusive bound ──────────────────────────────────
+
+class _Mood(IntEnum):
+    HAPPY = 1
+    SAD   = 2
+    BORED = 3
+
+
+class _ExtraParamsNode(NodeBase):
+    """Test node exercising BoolParam / EnumParam / ClampedFloatParam /
+    FloatParam(min_exclusive=...)."""
+
+    enabled = BoolParam(False, description="Toggle")
+    mood = EnumParam(_Mood, _Mood.HAPPY, description="Vibe")
+    opacity = ClampedFloatParam(0.5, min=0.0, max=1.0)
+    factor = FloatParam(1.0, min=0.0, min_exclusive=True)
+
+    def __init__(self) -> None:
+        super().__init__("Extra", section="Tests")
+        self._add_output(OutputPort("image", set(IMAGE_TYPES)))
+        self._apply_default_params()
+
+    def process_impl(self) -> None: pass
+
+
+def test_bool_param_coerces_truthy_and_falsy() -> None:
+    node = _ExtraParamsNode()
+    node.enabled = 1
+    assert node.enabled is True
+    node.enabled = ""
+    assert node.enabled is False
+
+
+def test_bool_param_port_uses_bool_io_type() -> None:
+    node = _ExtraParamsNode()
+    port = next(p for p in node.inputs if p.name == "enabled")
+    assert IoDataType.BOOL in port.accepted_types
+
+
+def test_enum_param_accepts_member() -> None:
+    node = _ExtraParamsNode()
+    node.mood = _Mood.SAD
+    assert node.mood is _Mood.SAD
+
+
+def test_enum_param_accepts_int_value() -> None:
+    node = _ExtraParamsNode()
+    node.mood = 3
+    assert node.mood is _Mood.BORED
+
+
+def test_enum_param_accepts_name_string() -> None:
+    node = _ExtraParamsNode()
+    node.mood = "SAD"
+    assert node.mood is _Mood.SAD
+
+
+def test_enum_param_rejects_unknown_value() -> None:
+    node = _ExtraParamsNode()
+    with pytest.raises(ValueError):
+        node.mood = 999
+
+
+def test_enum_param_default_must_be_member() -> None:
+    with pytest.raises(TypeError):
+        EnumParam(_Mood, 1)  # int, not _Mood
+
+
+def test_enum_param_metadata_carries_class() -> None:
+    node = _ExtraParamsNode()
+    port = next(p for p in node.inputs if p.name == "mood")
+    assert port.metadata["enum"] is _Mood
+
+
+def test_clamped_float_param_clamps_above_max() -> None:
+    node = _ExtraParamsNode()
+    node.opacity = 2.5
+    assert node.opacity == 1.0
+
+
+def test_clamped_float_param_clamps_below_min() -> None:
+    node = _ExtraParamsNode()
+    node.opacity = -0.3
+    assert node.opacity == 0.0
+
+
+def test_clamped_float_param_in_range_passes_through() -> None:
+    node = _ExtraParamsNode()
+    node.opacity = 0.7
+    assert node.opacity == 0.7
+
+
+def test_clamped_float_metadata_still_carries_bounds() -> None:
+    """Widget needs min/max for the slider even though the descriptor
+    enforces them via clamping rather than raising."""
+    node = _ExtraParamsNode()
+    port = next(p for p in node.inputs if p.name == "opacity")
+    assert port.metadata["min"] == 0.0
+    assert port.metadata["max"] == 1.0
+
+
+def test_float_min_exclusive_rejects_boundary() -> None:
+    """``min_exclusive=True`` makes the bound strict — value == min raises."""
+    node = _ExtraParamsNode()
+    with pytest.raises(ValueError, match=r"factor must be > 0"):
+        node.factor = 0.0
+
+
+def test_float_min_exclusive_accepts_just_above_boundary() -> None:
+    node = _ExtraParamsNode()
+    node.factor = 0.001
+    assert node.factor == 0.001


### PR DESCRIPTION
## Summary

Sweep **batch 2** of H2 PR-2. Adds four new pieces to `core.params` and migrates six more filters to the descriptor pattern. **Overlay** is the headline since it exercises every new type in one node.

## New descriptor primitives

| Piece | Purpose | First user |
|---|---|---|
| `BoolParam` | Toggle backed by `IoDataType.BOOL` | Subpixel Mosaic, Rotate |
| `EnumParam` | Combo-box backed by `IoDataType.ENUM`. `_coerce` accepts the enum member, its `.value`, or its `.name`; metadata carries the enum class for the widget builder | Flip, Dither, Scale, Overlay |
| `ClampedFloatParam` | Float whose `min`/`max` clamp via `_shape` rather than raise via `_validate`. Used when out-of-range is a UX choice, not a user error | `Overlay.alpha` (`2.5 → 1.0`) |
| `FloatParam(min_exclusive=True)` / `max_exclusive=True` | Strict bounds (`> min` rather than `>= min`) | `Overlay.scale > 0` |

## Filters migrated

| Filter | Descriptors | Lines |
|---|---|---|
| Overlay | FloatParam, ClampedFloatParam, IntParam, FloatParam(min_exclusive) | 326 → ~225 |
| Subpixel Mosaic | BoolParam × 2 | 144 → ~95 |
| Flip | EnumParam | 73 → ~50 |
| Dither | EnumParam | 230 → ~204 |
| Rotate | FloatParam, BoolParam | 100 → ~67 |
| Scale | IntParam, EnumParam | 128 → ~80 |

## Behaviour preservation

The two `Overlay` tests that gated this PR continue to pass:
- `test_overlay_alpha_is_clamped_to_unit_interval` — needed `ClampedFloatParam`.
- `test_overlay_rejects_non_positive_scale` — needed `min_exclusive=True`.

`Scale.scale_percent` previously raised on `<= 0` via a hand-rolled `if v <= 0: raise`. With `IntParam(min=1)` the contract is identical (`v < 1` raises) — `0` is rejected on both sides.

## Tests

- **`tests/test_param_descriptors.py`** extended with 14 new tests covering every new descriptor and flag (member/value/name coercion, default-must-be-member type check, metadata propagation, clamp above/below/in-range, exclusive boundary behaviour both sides).
- All **30 existing Overlay tests** pass unchanged.
- Full non-Qt suite: **490 passed, 0 regressions**.
- `tests/test_flow_back_compat.py` round-trips all 15 `.flowjs` files unchanged.

## Deferred to PR-2c

- `StringParam` + `FilePathParam` descriptors.
- The remaining port-style filters that need them: **Notify** (STRING + ENUM), **NCC** (BOOL + FILE_PATH), **Math** (FLOAT + STRING).
- The `NodeParam`-using filters (**Apply Colormap**, **Resize**, **Notify**, **Math**) and **all sources/sinks** — these decide the open `NodeParam` merger and `on_change=` hook design questions documented in `refacturing.txt` H2.

## Test plan

- [x] 30/30 descriptor tests passing locally.
- [x] All 30 Overlay tests passing.
- [x] Full non-Qt suite: 490 passed, 0 regressions.
- [x] `.flowjs` back-compat round-trips clean.
- [ ] CI green on Python 3.13.
- [ ] Open `flow/image_dither.flowjs` and `flow/image_rgb_dither.flowjs` (use Dither + Overlay paths). Confirm widgets render, run completes, save/reload preserves params.

https://claude.ai/code/session_017Sbygfh52wCk9uJYDUEyLW

---
_Generated by [Claude Code](https://claude.ai/code/session_017Sbygfh52wCk9uJYDUEyLW)_