### PR TITLE
H2 PR-2c: StringParam + FilePathParam; migrate NCC + Notify

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,32 @@ once a first tagged release is cut.
 
 ## [Unreleased]
 
+## [0.2.30] — 2026-04-28
+
+### Added
+- **``StringParam`` and ``FilePathParam`` descriptors.** The last
+  two pieces of the H2 descriptor surface for port-style params:
+  - ``StringParam`` — line-edit-backed text param with optional
+    ``placeholder`` / ``max_length`` widget metadata.
+  - ``FilePathParam`` — path picker with ``mode`` (open / save /
+    directory), ``filter``, ``base_dir``, ``caption``. Storage
+    type is ``pathlib.Path``; ``_coerce`` runs incoming values
+    through ``store_relative_to(base_dir)`` so paths inside
+    ``base_dir`` end up in their portable relative form (matches
+    the legacy hand-rolled setter on every file-path-using
+    node).
+
+### Changed
+- **Param descriptor sweep — batch 3 (H2 PR-2c).** Migrated NCC
+  (full — ``template`` to ``FilePathParam`` and ``retain_size`` to
+  ``BoolParam``) and Notify (partial — ``message`` to
+  ``StringParam``; ``severity`` stays as a ``NodeParam`` until the
+  descriptor protocol gains a ``constant=True`` flag in PR-2d).
+  NCC's loaded-template-image slot was renamed
+  ``self._template`` → ``self._template_image`` so it doesn't
+  collide with the descriptor's ``Path`` storage on the same
+  attribute name.
+
 ## [0.2.29] — 2026-04-28
 
 ### Added

--- a/doc/welcome.html
+++ b/doc/welcome.html
@@ -180,7 +180,7 @@
   <main class="content-col">
 
     <header class="hero">
-      <h1>Welcome to Stjörnhorn <span class="version">v0.2.29</span></h1>
+      <h1>Welcome to Stjörnhorn <span class="version">v0.2.30</span></h1>
       <div class="tagline">A node-based image- and video-processing playground.</div>
     </header>
 
@@ -210,6 +210,13 @@
           <p>Write frames to image files or encode video (MP4V, XVID) with live preview via the Display node.</p>
         </div>
       </div>
+    </section>
+
+    <section>
+      <h2>What's new in v0.2.30</h2>
+      <ul class="tips">
+        <li><strong>Param descriptor sweep — third batch (PR-2c of H2).</strong> Added <code>StringParam</code> and <code>FilePathParam</code> descriptors to <code>core.params</code>. <code>FilePathParam</code> stores <code>pathlib.Path</code> and applies <code>store_relative_to(base_dir)</code> in coerce so paths inside the base directory are stashed in their portable relative form (matching the saved-flow representation). Migrated <code>NCC</code> (full — both <code>template</code> and <code>retain_size</code>) and <code>Notify</code> (partial — <code>message</code> ports to <code>StringParam</code>; <code>severity</code> stays as a <code>NodeParam</code> until the descriptor protocol gains a <code>constant=True</code> flag in PR-2d). Backlog item H2.</li>
+      </ul>
     </section>
 
     <section>

--- a/refacturing.txt
+++ b/refacturing.txt
@@ -114,22 +114,30 @@ High
       raises on Median.size (matching the old setter), even though
       OddIntParam's shape would round it to 1.
 
-    PR-2b (in flight on branch claude/h2-pr2b-bool-enum-overlay):
-      Added BoolParam, EnumParam, ClampedFloatParam and a
-      min_exclusive / max_exclusive flag on FloatParam. Migrated:
-      Overlay, Subpixel Mosaic, Flip, Dither, Rotate, Scale.
-      Overlay is the headline since it exercises every new type in
-      one node. StringParam + FilePathParam still TODO; they land
-      with the filters that use them in PR-2c (Notify, NCC).
+    PR-2b (merged): added BoolParam, EnumParam, ClampedFloatParam
+      and a min_exclusive / max_exclusive flag on FloatParam.
+      Migrated: Overlay (headline — exercises every new type),
+      Subpixel Mosaic, Flip, Dither, Rotate, Scale.
 
-    PR-2c (planned): add StringParam + FilePathParam. Migrate the
-      remaining port-style filters: Notify (STRING + ENUM), NCC
-      (BOOL + FILE_PATH), Math (FLOAT + STRING). Then tackle
-      sources + sinks, deciding the NodeParam merger question
-      (open question 3). file_path setters with side effects
-      (open question 1) drive the on_change= hook design.
+    PR-2c (in flight on branch claude/h2-pr2c-string-filepath):
+      added StringParam and FilePathParam (Path-typed storage with
+      base_dir-aware store_relative_to coerce). Migrated NCC (full)
+      and Notify (partial — message ported, severity stays as
+      NodeParam until constant=True lands). Math NOT migrated:
+      its expression param has compile-on-set semantics, will move
+      with PR-2d's NodeParam merger work.
 
-    PR-2d (planned): retire the legacy _add_input(InputPort(...)) +
+    PR-2d (planned): introduce constant=True flag on the descriptor
+      protocol so NodeParam can subsume into the descriptor model
+      cleanly (constant params don't auto-create an InputPort and
+      render inline in the UI's params slot). Migrate the remaining
+      NodeParam-using filters: Apply Colormap, Resize, Math
+      (expression), Notify (severity). Then tackle sources / sinks,
+      which mostly use NodeParam for file paths and codec choices —
+      the on_change= hook design (open question 1) lands with
+      ImageSource since its file_path setter triggers a re-decode.
+
+    PR-2e (planned): retire the legacy _add_input(InputPort(...)) +
       @property path from NodeBase once empty. Move H2, H4, M9 to
       Resolved.
 

--- a/src/constants.py
+++ b/src/constants.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 APP_NAME:         str = "Image-Inquest"
 APP_DISPLAY_NAME: str = "Stjörnhorn"
-APP_VERSION:      str = "0.2.29"
+APP_VERSION:      str = "0.2.30"
 API_URL:    str = "https://beltoforion.de"
 
 # Path resolution -----------------------------------------------------------

--- a/src/core/params.py
+++ b/src/core/params.py
@@ -28,6 +28,7 @@ Backlog item H2 (see ``refacturing.txt``).
 from __future__ import annotations
 
 from enum import Enum
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from core.io_data import IoDataType
@@ -428,3 +429,127 @@ class EnumParam(_ParamBase):
         meta["enum"] = self.enum_cls
         return meta
 
+
+
+class StringParam(_ParamBase):
+    """String node parameter.
+
+    Coerces incoming values via ``str(value)``. Optional ``placeholder``
+    is rendered by the line-edit widget when the field is empty;
+    optional ``max_length`` caps the typed text at the widget level (the
+    descriptor still accepts arbitrary input, the widget enforces).
+    """
+
+    _NODE_PARAM_TYPE = NodeParamType.STRING
+    _PORT_TYPE = IoDataType.STRING
+
+    def __init__(
+        self,
+        default: str = "",
+        *,
+        placeholder: str | None = None,
+        max_length: int | None = None,
+        description: str | None = None,
+        optional: bool = True,
+    ) -> None:
+        super().__init__(
+            default,
+            description=description,
+            optional=optional,
+        )
+        self.placeholder: str | None = placeholder
+        self.max_length: int | None = max_length
+
+    def _coerce(self, value: object) -> str:
+        return str(value)
+
+    def _build_metadata(self) -> dict[str, object]:
+        meta = super()._build_metadata()
+        if self.placeholder is not None:
+            meta["placeholder"] = self.placeholder
+        if self.max_length is not None:
+            meta["max_length"] = self.max_length
+        return meta
+
+
+class FilePathParam(_ParamBase):
+    """File-path node parameter (open / save / directory).
+
+    The widget renders a line edit + browse button + view-in-OS button.
+    ``mode`` selects the dialog flavour:
+
+      * ``"open"`` (default) — pick an existing file.
+      * ``"save"`` — choose a destination file (can be new).
+      * ``"directory"`` — pick a folder.
+
+    ``filter`` is the file-dialog filter string (e.g.
+    ``"PNG (*.png);;All files (*)"``); ignored in directory mode.
+    ``base_dir`` is the root for relative paths the line edit displays
+    *and* the anchor :func:`core.path_utils.store_relative_to` uses
+    when normalising an incoming path. ``None`` skips the normalising
+    step and lets the widget pick the display fallback
+    (``constants.OUTPUT_DIR`` for save mode, ``constants.INPUT_DIR``
+    otherwise — same fallback the legacy hand-rolled widget used).
+
+    Storage type is :class:`pathlib.Path`. ``_coerce`` runs incoming
+    str / Path inputs through :func:`store_relative_to(base_dir)` so
+    paths inside ``base_dir`` are stashed in their portable relative
+    form (matching the saved-flow representation). When ``base_dir``
+    is ``None`` the value is converted to :class:`Path` unchanged.
+    """
+
+    _NODE_PARAM_TYPE = NodeParamType.FILE_PATH
+    _PORT_TYPE = IoDataType.PATH
+
+    _VALID_MODES = ("open", "save", "directory")
+
+    def __init__(
+        self,
+        default: str | Path = "",
+        *,
+        mode: str = "open",
+        filter: str | None = None,
+        base_dir: Path | None = None,
+        caption: str | None = None,
+        description: str | None = None,
+        optional: bool = True,
+    ) -> None:
+        if mode not in self._VALID_MODES:
+            raise ValueError(
+                f"FilePathParam mode must be one of {self._VALID_MODES} "
+                f"(got {mode!r})"
+            )
+        super().__init__(
+            default,
+            description=description,
+            optional=optional,
+        )
+        self.mode: str = mode
+        self.filter: str | None = filter
+        self.base_dir: Path | None = base_dir
+        self.caption: str | None = caption
+
+    def _coerce(self, value: object) -> Path:
+        # Late import — path_utils sits below the core/ tree and pulling
+        # it in at module load time would extend the import graph for
+        # every node that doesn't actually use a FilePathParam.
+        from core.path_utils import store_relative_to
+
+        if self.base_dir is not None:
+            return store_relative_to(value, self.base_dir)
+        return Path(value) if not isinstance(value, Path) else value
+
+    def _build_metadata(self) -> dict[str, object]:
+        meta = super()._build_metadata()
+        # The widget reads ``mode`` / ``filter`` / ``base_dir`` /
+        # ``caption`` from metadata; only emit non-default values to
+        # keep the dict small and the saved-flow representation tidy.
+        if self.mode != "open":
+            meta["mode"] = self.mode
+        if self.filter is not None:
+            meta["filter"] = self.filter
+        if self.base_dir is not None:
+            meta["base_dir"] = self.base_dir
+        if self.caption is not None:
+            meta["caption"] = self.caption
+        return meta

--- a/src/nodes/filters/ncc.py
+++ b/src/nodes/filters/ncc.py
@@ -8,8 +8,9 @@ from typing_extensions import override
 
 from constants import INPUT_DIR
 from core.io_data import IoData, IoDataType
-from core.node_base import NodeBase, NodeParamType
-from core.path_utils import resolve_against, store_relative_to
+from core.node_base import NodeBase
+from core.params import BoolParam, FilePathParam
+from core.path_utils import resolve_against
 from core.port import InputPort, OutputPort
 
 _SUPPORTED_EXTS = {".jpg", ".jpeg", ".png", ".webp", ".bmp", ".tif", ".tiff"}
@@ -33,85 +34,53 @@ class Ncc(NodeBase):
     on each axis.
     """
 
+    template = FilePathParam(
+        "pad.jpg",
+        filter="Images (*.png *.jpg *.jpeg *.webp *.bmp *.tif *.tiff)",
+        base_dir=INPUT_DIR,
+        description=(
+            "Path to the template image to search for. Loaded "
+            "once per run and converted to greyscale at load "
+            "time, so the per-frame cost is the matchTemplate "
+            "call only."
+        ),
+    )
+    retain_size = BoolParam(
+        True,
+        description=(
+            "When on, the match map is pasted onto a canvas the "
+            "same size as the input, with each response at the "
+            "template-centre pixel. When off, the raw response "
+            "is emitted (smaller than the input by template "
+            "size minus one on each axis)."
+        ),
+    )
+
     def __init__(self) -> None:
         super().__init__("NCC", section="Processing")
-        self._retain_size: bool = True
-        self._template_path: Path = Path()
-        self._template: np.ndarray | None = None
+        # Loaded template image (lazy — populated by before_run /
+        # process_impl). Distinct slot from ``self._template`` (which
+        # is the descriptor's ``Path`` storage) so the two don't
+        # collide.
+        self._template_image: np.ndarray | None = None
 
         self._add_input(InputPort("image", {IoDataType.IMAGE_GREY}))
-        self._add_input(InputPort(
-            "template",
-            {IoDataType.PATH},
-            optional=True,
-            default_value="pad.jpg",
-            metadata={
-                "default": "pad.jpg",
-                "filter": "Images (*.png *.jpg *.jpeg *.webp *.bmp *.tif *.tiff)",
-                "base_dir": INPUT_DIR,
-                "param_type": NodeParamType.FILE_PATH,
-                "description": (
-                    "Path to the template image to search for. Loaded "
-                    "once per run and converted to greyscale at load "
-                    "time, so the per-frame cost is the matchTemplate "
-                    "call only."
-                ),
-            },
-        ))
-        self._add_input(InputPort(
-            "retain_size",
-            {IoDataType.BOOL},
-            optional=True,
-            default_value=True,
-            metadata={
-                "default": True,
-                "param_type": NodeParamType.BOOL,
-                "description": (
-                    "When on, the match map is pasted onto a canvas the "
-                    "same size as the input, with each response at the "
-                    "template-centre pixel. When off, the raw response "
-                    "is emitted (smaller than the input by template "
-                    "size minus one on each axis)."
-                ),
-            },
-        ))
         self._add_output(OutputPort("image", {IoDataType.IMAGE_GREY}))
-
         self._apply_default_params()
-
-    # ── Properties ─────────────────────────────────────────────────────────────
-
-    @property
-    def retain_size(self) -> bool:
-        return self._retain_size
-
-    @retain_size.setter
-    def retain_size(self, value: bool) -> None:
-        self._retain_size = bool(value)
-
-    @property
-    def template(self) -> Path:
-        return self._template_path
-
-    @template.setter
-    def template(self, path: str | Path) -> None:
-        self._template_path = store_relative_to(path, INPUT_DIR)
-
-    # ── NodeBase interface ─────────────────────────────────────────────────────
 
     @override
     def _before_run_impl(self) -> None:
         super()._before_run_impl()
-        self._template = self._load_template()
+        self._template_image = self._load_template()
 
     @override
     def process_impl(self) -> None:
-        if self._template is None:
+        if self._template_image is None:
             # before_run wasn't called (e.g. direct unit-test use); load lazily.
-            self._template = self._load_template()
+            self._template_image = self._load_template()
 
         image: np.ndarray = self.inputs[0].data.image
-        template = self._template
+        template = self._template_image
 
         res = cv2.matchTemplate(image, template, cv2.TM_CCORR_NORMED)
         res = cv2.normalize(
@@ -141,7 +110,7 @@ class Ncc(NodeBase):
     # ── Internals ──────────────────────────────────────────────────────────────
 
     def _resolved_template_path(self) -> Path:
-        return resolve_against(self._template_path, INPUT_DIR)
+        return resolve_against(self._template, INPUT_DIR)
 
     def _load_template(self) -> np.ndarray:
         resolved = self._resolved_template_path()

--- a/src/nodes/filters/notify.py
+++ b/src/nodes/filters/notify.py
@@ -5,8 +5,9 @@ from enum import IntEnum
 from typing_extensions import override
 
 from core import notifications
-from core.io_data import IMAGE_TYPES, IoDataType
+from core.io_data import IMAGE_TYPES
 from core.node_base import NodeBase, NodeParam, NodeParamType
+from core.params import StringParam
 from core.port import InputPort, OutputPort
 
 
@@ -47,29 +48,28 @@ class Notify(NodeBase):
                   are forwarded verbatim.
     """
 
+    message = StringParam(
+        "",
+        placeholder="message shown in the banner",
+        description=(
+            "Text shown in the floating banner (or carried by "
+            "the raised RuntimeError when severity is ERROR). "
+            "Wire any STRING source in to drive the message "
+            "per frame."
+        ),
+    )
+
     def __init__(self) -> None:
         super().__init__("Notify", section="UI")
+        # ``severity`` stays a NodeParam (constant — UI renders it
+        # inline with no socket dot) until the descriptor protocol
+        # gains a ``constant=True`` flag in PR-2d. The hand-rolled
+        # @property/@setter below validates the same way EnumParam
+        # would; merging it cleanly into the descriptor model is
+        # blocked on the broader NodeParam-merger decision.
         self._severity: NotifySeverity = NotifySeverity.INFO
-        self._message:  str = ""
 
         self._add_input(InputPort("image", set(IMAGE_TYPES)))
-        self._add_input(InputPort(
-            "message",
-            {IoDataType.STRING},
-            optional=True,
-            default_value="",
-            metadata={
-                "default":     "",
-                "placeholder": "message shown in the banner",
-                "param_type":  NodeParamType.STRING,
-                "description": (
-                    "Text shown in the floating banner (or carried by "
-                    "the raised RuntimeError when severity is ERROR). "
-                    "Wire any STRING source in to drive the message "
-                    "per frame."
-                ),
-            },
-        ))
         self._add_param(NodeParam(
             "severity",
             NodeParamType.ENUM,
@@ -87,8 +87,6 @@ class Notify(NodeBase):
 
         self._apply_default_params()
 
-    # ── Properties ─────────────────────────────────────────────────────────────
-
     @property
     def severity(self) -> NotifySeverity:
         return self._severity
@@ -102,16 +100,6 @@ class Notify(NodeBase):
                 f"severity must be one of {[s.value for s in NotifySeverity]} "
                 f"(got {value!r})"
             ) from exc
-
-    @property
-    def message(self) -> str:
-        return self._message
-
-    @message.setter
-    def message(self, value: str) -> None:
-        self._message = str(value)
-
-    # ── NodeBase interface ─────────────────────────────────────────────────────
 
     @override
     def process_impl(self) -> None:

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -287,6 +287,9 @@ def test_ncc_converts_colour_template_to_greyscale_at_before_run(tmp_path: Path)
     node.template = tpl_path
     node.before_run()
 
-    assert node._template is not None
-    assert node._template.ndim == 2
-    assert node._template.shape == template_grey.shape
+    # The descriptor's storage slot ``_template`` holds the Path; the
+    # loaded greyscale image lives on ``_template_image`` after
+    # ``before_run`` runs.
+    assert node._template_image is not None
+    assert node._template_image.ndim == 2
+    assert node._template_image.shape == template_grey.shape

--- a/tests/test_param_descriptors.py
+++ b/tests/test_param_descriptors.py
@@ -24,9 +24,11 @@ from core.params import (
     BoolParam,
     ClampedFloatParam,
     EnumParam,
+    FilePathParam,
     FloatParam,
     IntParam,
     OddIntParam,
+    StringParam,
 )
 from core.port import InputPort, OutputPort
 
@@ -313,3 +315,86 @@ def test_float_min_exclusive_accepts_just_above_boundary() -> None:
     node = _ExtraParamsNode()
     node.factor = 0.001
     assert node.factor == 0.001
+
+
+# ── String / FilePath ────────────────────────────────────────────────────────
+
+class _PathishNode(NodeBase):
+    """Test node exercising StringParam / FilePathParam."""
+
+    label = StringParam("hi", placeholder="Type a label", max_length=64)
+    notes = StringParam("", description="Free-form notes")
+    target = FilePathParam("out.png", mode="save", filter="PNG (*.png)")
+
+    def __init__(self) -> None:
+        super().__init__("Pathish", section="Tests")
+        self._add_output(OutputPort("image", set(IMAGE_TYPES)))
+        self._apply_default_params()
+
+    def process_impl(self) -> None: pass
+
+
+def test_string_param_coerces_to_str() -> None:
+    node = _PathishNode()
+    node.label = 42
+    assert node.label == "42"
+    assert isinstance(node.label, str)
+
+
+def test_string_param_metadata_carries_placeholder_and_max_length() -> None:
+    node = _PathishNode()
+    port = next(p for p in node.inputs if p.name == "label")
+    assert port.metadata["placeholder"] == "Type a label"
+    assert port.metadata["max_length"] == 64
+
+
+def test_string_param_uses_string_io_type() -> None:
+    node = _PathishNode()
+    port = next(p for p in node.inputs if p.name == "label")
+    assert IoDataType.STRING in port.accepted_types
+
+
+def test_filepath_param_metadata_carries_mode_and_filter() -> None:
+    node = _PathishNode()
+    port = next(p for p in node.inputs if p.name == "target")
+    assert port.metadata["mode"] == "save"
+    assert port.metadata["filter"] == "PNG (*.png)"
+
+
+def test_filepath_param_uses_path_io_type() -> None:
+    node = _PathishNode()
+    port = next(p for p in node.inputs if p.name == "target")
+    assert IoDataType.PATH in port.accepted_types
+
+
+def test_filepath_param_default_open_mode_omits_metadata_key() -> None:
+    """Default mode (``"open"``) is not emitted into metadata to keep
+    saved-flow representations small."""
+
+    class _OpenNode(NodeBase):
+        path = FilePathParam("a.png")
+
+        def __init__(self) -> None:
+            super().__init__("Open", section="Tests")
+            self._add_output(OutputPort("image", set(IMAGE_TYPES)))
+            self._apply_default_params()
+
+        def process_impl(self) -> None: pass
+
+    node = _OpenNode()
+    port = next(p for p in node.inputs if p.name == "path")
+    assert "mode" not in port.metadata
+
+
+def test_filepath_param_invalid_mode_raises() -> None:
+    with pytest.raises(ValueError, match=r"FilePathParam mode"):
+        FilePathParam("x", mode="bogus")
+
+
+def test_filepath_param_coerce_returns_path() -> None:
+    """``_coerce`` produces a :class:`Path`, not a :class:`str`, so
+    ``cv2``-side filesystem helpers work without a separate cast."""
+    from pathlib import Path
+    node = _PathishNode()
+    node.target = "foo.png"
+    assert isinstance(node.target, Path)


### PR DESCRIPTION
## Summary

Sweep **batch 3** of H2 PR-2. Adds the last two descriptor types for port-style params (`StringParam`, `FilePathParam`) and migrates the two filters that need them (NCC, Notify partial).

## New descriptor primitives

| Piece | Purpose | First user |
|---|---|---|
| `StringParam` | Line-edit-backed text param with optional `placeholder` / `max_length` widget metadata. Coerces via `str()` | `Notify.message` |
| `FilePathParam` | Path picker with `mode` (open / save / directory), `filter`, `base_dir`, `caption`. **Storage type is `pathlib.Path`**; `_coerce` runs incoming values through `store_relative_to(base_dir)` so paths inside the base directory are stashed in their portable relative form (matches what every saved `.flowjs` already holds) | `NCC.template` |

## Filters migrated

| Filter | Descriptors used | Notes |
|---|---|---|
| **NCC** (full) | `FilePathParam(template)`, `BoolParam(retain_size)` | The loaded-template-image slot renamed `self._template` → `self._template_image` so it doesn't collide with the descriptor's `Path` storage on the same attribute name. |
| **Notify** (partial) | `StringParam(message)` | `severity` stays as a `NodeParam` — constant params don't fit the current descriptor model (they auto-create an `InputPort`, which would change the no-socket UX). PR-2d lands a `constant=True` flag on the descriptor protocol and completes Notify's migration. |

## Not migrated in this PR

- **Math** — `expression` has compile-on-set semantics (the setter compiles the AST and stores the bytecode). Splitting it into a custom `MathExpressionParam` descriptor is fine but also wants the `constant=True` flag landing in PR-2d, so move Math wholesale then.
- **Apply Colormap, Resize** — NodeParam-only filters, wait for PR-2d.
- **Sources / sinks** — heavy NodeParam use; PR-2d.

## Tests

- **`tests/test_param_descriptors.py`** +8 tests covering `StringParam` (coerce, metadata, IO type) and `FilePathParam` (metadata, IO type, invalid-mode rejection, `Path` return type, default-mode metadata-omission).
- **`tests/test_filters.py`** — the existing NCC test that read `node._template` updated to read the renamed `node._template_image` slot.
- Full non-Qt suite: **512 passed, 0 regressions**.
- `tests/test_flow_back_compat.py` round-trips all 15 `.flowjs` files unchanged.

## Test plan

- [x] 38/38 descriptor tests passing.
- [x] All 512 non-Qt tests green.
- [x] `.flowjs` back-compat round-trips clean.
- [ ] CI green on Python 3.13.
- [ ] Open `flow/image_ncc.flowjs` (uses NCC). Confirm template path widget edits / saves / reloads cleanly.
- [ ] Drop a `Notify` node, type a message, run the flow — banner pops with the configured severity.

## What's left for H2

- **PR-2d**: `constant=True` flag on the descriptor protocol → migrate Apply Colormap, Resize, Math, sources, sinks. Decides the `on_change=` hook design (driven by `ImageSource.file_path` re-decoding).
- **PR-2e**: retire the legacy `_add_input(InputPort(...))` + `@property` path from NodeBase; move H2/H4/M9 to *Resolved*.

https://claude.ai/code/session_017Sbygfh52wCk9uJYDUEyLW

---
_Generated by [Claude Code](https://claude.ai/code/session_017Sbygfh52wCk9uJYDUEyLW)_