### PR TITLE
H2 PR-2e: migrate all sources, sinks, and DebugParam to descriptors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,30 @@ once a first tagged release is cut.
 
 ## [Unreleased]
 
+## [0.2.32] — 2026-04-28
+
+### Changed
+- **Param descriptor sweep — batch 5, final node migration
+  (H2 PR-2e).** Migrated the remaining nine nodes:
+  - Sources: ``ConstantValue``, ``DirectorySource``,
+    ``GradientSource``, ``ImageSource``, ``ValueSource``,
+    ``VideoSource``.
+  - Sinks: ``FileSink``, ``VideoSink``.
+  - Test fixture: ``DebugParam`` (one parameter of every type, used
+    to exercise the param-widget code paths during development).
+  After this PR every node in the codebase uses class-level
+  ``core.params`` descriptors for its parameters; zero hand-rolled
+  ``_add_input(InputPort(...))`` + ``@property``/``@setter`` pairs
+  for parameter ports remain anywhere under ``src/nodes/``.
+
+### Notes
+- The ``on_change=`` hook flagged in ``refacturing.txt`` H2 as an
+  open question for ``ImageSource.file_path`` turned out
+  unnecessary — the existing setter only normalises the path via
+  ``store_relative_to(INPUT_DIR)``, and ``FilePathParam._coerce``
+  already does that. The hook stays parked in the design notes in
+  case a future side-effect setter actually needs it.
+
 ## [0.2.31] — 2026-04-28
 
 ### Added

--- a/doc/welcome.html
+++ b/doc/welcome.html
@@ -180,7 +180,7 @@
   <main class="content-col">
 
     <header class="hero">
-      <h1>Welcome to Stjörnhorn <span class="version">v0.2.31</span></h1>
+      <h1>Welcome to Stjörnhorn <span class="version">v0.2.32</span></h1>
       <div class="tagline">A node-based image- and video-processing playground.</div>
     </header>
 
@@ -210,6 +210,13 @@
           <p>Write frames to image files or encode video (MP4V, XVID) with live preview via the Display node.</p>
         </div>
       </div>
+    </section>
+
+    <section>
+      <h2>What's new in v0.2.32</h2>
+      <ul class="tips">
+        <li><strong>Param descriptor sweep — final batch (PR-2e of H2).</strong> Migrated all six sources (Constant Value, Directory Source, Gradient Source, Image Source, Value Source, Video Source) and both sinks (File Sink, Video Sink), plus the Debug Param test node. Every node in the codebase now uses class-level <code>core.params</code> descriptors for its parameters; zero hand-rolled <code>InputPort</code>+<code>@property</code>/<code>@setter</code> declarations remain. The <code>on_change=</code> hook flagged as an open question for <code>ImageSource.file_path</code> turned out unnecessary — the existing setter only normalises the path via <code>store_relative_to</code>, which <code>FilePathParam._coerce</code> already does for free. Backlog item H2 — PR-2f next will retire the legacy paths from <code>NodeBase</code> and move H2 / H4 / M9 to <em>Resolved</em>.</li>
+      </ul>
     </section>
 
     <section>

--- a/refacturing.txt
+++ b/refacturing.txt
@@ -134,16 +134,25 @@ High
       atomically on set), Notify (severity finished). Sources / sinks
       defer to PR-2e since they decide the on_change= hook design.
 
-    PR-2e (planned): migrate sources + sinks (constant_value,
-      directory_source, gradient_source, image_source, value_source,
-      video_source, file_sink, video_sink). image_source.file_path
-      drives the on_change= hook design — the setter triggers a
-      re-decode, which the descriptor needs to invoke per-instance
-      after the value lands.
+    PR-2e (in flight on branch claude/h2-pr2e-sources-sinks):
+      Migrated all 6 sources (constant_value, directory_source,
+      gradient_source, image_source, value_source, video_source),
+      both sinks (file_sink, video_sink), and the DebugParam test
+      fixture. After this PR every node in src/nodes/ uses class-
+      level descriptors; zero hand-rolled _add_input(InputPort(...))
+      + @property/@setter pairs remain for parameter ports.
+      The on_change= hook turned out unnecessary —
+      ImageSource.file_path's setter only normalises the path via
+      store_relative_to(INPUT_DIR), which FilePathParam._coerce
+      already does. Hook design parked in case a future side-effect
+      setter actually needs it.
 
     PR-2f (planned): retire the legacy _add_input(InputPort(...)) +
-      @property path from NodeBase once every node is descriptor-
-      based. Move H2, H4, M9 to Resolved.
+      @property path from NodeBase. The path-style branches in
+      NodeBase._apply_default_params and NodeBase._populate_port_
+      driven_attributes' silent hasattr-skip can both go away once
+      every InputPort is known to come from a descriptor. Move H2,
+      H4, M9 to Resolved.
 
 [WIP] H3. Param-widget subclasses duplicate >90% boilerplate.
   Duplication / OCP. src/ui/param_widgets.py:138-289 — every widget

--- a/src/constants.py
+++ b/src/constants.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 APP_NAME:         str = "Image-Inquest"
 APP_DISPLAY_NAME: str = "Stjörnhorn"
-APP_VERSION:      str = "0.2.31"
+APP_VERSION:      str = "0.2.32"
 API_URL:    str = "https://beltoforion.de"
 
 # Path resolution -----------------------------------------------------------

--- a/src/nodes/filters/debug_param.py
+++ b/src/nodes/filters/debug_param.py
@@ -1,13 +1,20 @@
 from __future__ import annotations
 
 from enum import IntEnum
-from pathlib import Path
 
 from typing_extensions import override
 
 from constants import INPUT_DIR
-from core.io_data import IMAGE_TYPES, IoDataType
-from core.node_base import NodeBase, NodeParamType
+from core.io_data import IMAGE_TYPES
+from core.node_base import NodeBase
+from core.params import (
+    BoolParam,
+    EnumParam,
+    FilePathParam,
+    FloatParam,
+    IntParam,
+    StringParam,
+)
 from core.port import InputPort, OutputPort
 
 
@@ -27,143 +34,31 @@ class DebugParam(NodeBase):
     the param-widget code paths during development.
     """
 
+    file_path = FilePathParam(
+        "",
+        filter="All files (*)",
+        base_dir=INPUT_DIR,
+        description="Demo FILE_PATH parameter — exercises the path widget.",
+    )
+    count = IntParam(0, description="Demo INT parameter — exercises the int spinbox widget.")
+    factor = FloatParam(1.0, description="Demo FLOAT parameter — exercises the float spinbox widget.")
+    label = StringParam(
+        "",
+        placeholder="text…",
+        description="Demo STRING parameter — exercises the line-edit widget.",
+    )
+    enabled = BoolParam(False, description="Demo BOOL parameter — exercises the checkbox widget.")
+    mode = EnumParam(
+        DebugMode,
+        DebugMode.ALPHA,
+        description="Demo ENUM parameter — exercises the combo-box widget.",
+    )
+
     def __init__(self) -> None:
         super().__init__("Debug Params", section="Debug")
-
-        self._file_path: Path = Path()
-        self._count:     int   = 0
-        self._factor:    float = 1.0
-        self._label:     str   = ""
-        self._enabled:   bool  = False
-        self._mode:      DebugMode = DebugMode.ALPHA
-
         self._add_input(InputPort("image", set(IMAGE_TYPES)))
-        self._add_input(InputPort(
-            "file_path",
-            {IoDataType.PATH},
-            optional=True,
-            default_value="",
-            metadata={
-                "default": "",
-                "mode": "open",
-                "filter": "All files (*)",
-                "base_dir": INPUT_DIR,
-                "param_type": NodeParamType.FILE_PATH,
-                "description": "Demo FILE_PATH parameter — exercises the path widget.",
-            },
-        ))
-        self._add_input(InputPort(
-            "count",
-            {IoDataType.SCALAR},
-            optional=True,
-            default_value=0,
-            metadata={
-                "default": 0,
-                "param_type": NodeParamType.INT,
-                "description": "Demo INT parameter — exercises the int spinbox widget.",
-            },
-        ))
-        self._add_input(InputPort(
-            "factor",
-            {IoDataType.SCALAR},
-            optional=True,
-            default_value=1.0,
-            metadata={
-                "default": 1.0,
-                "param_type": NodeParamType.FLOAT,
-                "description": "Demo FLOAT parameter — exercises the float spinbox widget.",
-            },
-        ))
-        self._add_input(InputPort(
-            "label",
-            {IoDataType.STRING},
-            optional=True,
-            default_value="",
-            metadata={
-                "default": "",
-                "placeholder": "text…",
-                "param_type": NodeParamType.STRING,
-                "description": "Demo STRING parameter — exercises the line-edit widget.",
-            },
-        ))
-        self._add_input(InputPort(
-            "enabled",
-            {IoDataType.BOOL},
-            optional=True,
-            default_value=False,
-            metadata={
-                "default": False,
-                "param_type": NodeParamType.BOOL,
-                "description": "Demo BOOL parameter — exercises the checkbox widget.",
-            },
-        ))
-        self._add_input(InputPort(
-            "mode",
-            {IoDataType.ENUM},
-            optional=True,
-            default_value=DebugMode.ALPHA,
-            metadata={
-                "default": DebugMode.ALPHA,
-                "enum": DebugMode,
-                "param_type": NodeParamType.ENUM,
-                "description": "Demo ENUM parameter — exercises the combo-box widget.",
-            },
-        ))
         self._add_output(OutputPort("image", set(IMAGE_TYPES)))
-
         self._apply_default_params()
-
-    # ── Properties ─────────────────────────────────────────────────────────────
-
-    @property
-    def file_path(self) -> Path:
-        return self._file_path
-
-    @file_path.setter
-    def file_path(self, value: str | Path) -> None:
-        self._file_path = Path(value)
-
-    @property
-    def count(self) -> int:
-        return self._count
-
-    @count.setter
-    def count(self, value: int) -> None:
-        self._count = int(value)
-
-    @property
-    def factor(self) -> float:
-        return self._factor
-
-    @factor.setter
-    def factor(self, value: float) -> None:
-        self._factor = float(value)
-
-    @property
-    def label(self) -> str:
-        return self._label
-
-    @label.setter
-    def label(self, value: str) -> None:
-        self._label = str(value)
-
-    @property
-    def enabled(self) -> bool:
-        return self._enabled
-
-    @enabled.setter
-    def enabled(self, value: bool) -> None:
-        self._enabled = bool(value)
-
-    @property
-    def mode(self) -> DebugMode:
-        return self._mode
-
-    @mode.setter
-    def mode(self, value: int | DebugMode) -> None:
-        self._mode = DebugMode(value)
-
-    # ── NodeBase interface ─────────────────────────────────────────────────────
 
     @override
     def process_impl(self) -> None:

--- a/src/nodes/sinks/file_sink.py
+++ b/src/nodes/sinks/file_sink.py
@@ -8,8 +8,9 @@ from typing_extensions import override
 
 from constants import OUTPUT_DIR
 from core.io_data import IMAGE_TYPES
-from core.node_base import NodeParam, NodeParamType, SinkNodeBase
-from core.path_utils import resolve_against, store_relative_to
+from core.node_base import SinkNodeBase
+from core.params import FilePathParam
+from core.path_utils import resolve_against
 from core.port import InputPort
 
 
@@ -28,34 +29,27 @@ class FileSink(SinkNodeBase):
     share the same output layout.
     """
 
+    output_path = FilePathParam(
+        "out.png",
+        constant=True,
+        mode="save",
+        filter="Images (*.png *.jpg *.jpeg)",
+        base_dir=OUTPUT_DIR,
+        description=(
+            "Where to write each frame. The file is overwritten on "
+            "every frame, so this sink fits a single still or the "
+            "last frame of a stream — chain a unique filename per "
+            "frame upstream if you need a sequence."
+        ),
+    )
+
     def __init__(self):
         super().__init__("File Sink", section="Sinks")
-
-        self._output_path: Path = Path("out.png")
+        # ``output_format`` is set programmatically (not a UI param) so
+        # it stays as a plain attribute with a hand-rolled property.
         self._output_format: OutputFormat = OutputFormat.SAME_AS_INPUT
-
         self._add_input(InputPort("image", set(IMAGE_TYPES)))
-        self._add_param(NodeParam(
-            "output_path",
-            NodeParamType.FILE_PATH,
-            default="out.png",
-            metadata={
-                "mode": "save",
-                "filter": "Images (*.png *.jpg *.jpeg)",
-                "base_dir": OUTPUT_DIR,
-                "description": (
-                    "Where to write each frame. The file is overwritten on "
-                    "every frame, so this sink fits a single still or the "
-                    "last frame of a stream — chain a unique filename per "
-                    "frame upstream if you need a sequence."
-                ),
-            },
-        ))
-        # Sync attributes with declared port defaults; see
-        # NodeBase._apply_default_params for rationale.
         self._apply_default_params()
-
-    # ── Properties ─────────────────────────────────────────────────────────────
 
     @property
     def output_format(self) -> OutputFormat:
@@ -64,16 +58,6 @@ class FileSink(SinkNodeBase):
     @output_format.setter
     def output_format(self, output_format: OutputFormat) -> None:
         self._output_format = output_format
-
-    @property
-    def output_path(self) -> Path:
-        return self._output_path
-
-    @output_path.setter
-    def output_path(self, output_path: str | Path) -> None:
-        self._output_path = store_relative_to(output_path, OUTPUT_DIR)
-
-    # ── SinkNodeBase interface ──────────────────────────────────────────────────
 
     @override
     def process_impl(self) -> None:

--- a/src/nodes/sinks/video_sink.py
+++ b/src/nodes/sinks/video_sink.py
@@ -9,8 +9,9 @@ from typing_extensions import override
 
 from constants import OUTPUT_DIR
 from core.io_data import IMAGE_TYPES
-from core.node_base import NodeParam, NodeParamType, SinkNodeBase
-from core.path_utils import resolve_against, store_relative_to
+from core.node_base import SinkNodeBase
+from core.params import EnumParam, FilePathParam, FloatParam
+from core.path_utils import resolve_against
 from core.port import InputPort
 
 
@@ -48,71 +49,22 @@ class VideoSink(SinkNodeBase):
     ``imageio`` isn't a pipeline dependency.
     """
 
+    output_path = FilePathParam(
+        "out.mp4",
+        constant=True,
+        mode="save",
+        filter="Video (*.mp4)",
+        base_dir=OUTPUT_DIR,
+    )
+    fps = FloatParam(30.0, min=0.0, min_exclusive=True, constant=True)
+    codec = EnumParam(VideoCodec, VideoCodec.MP4V, constant=True)
+
     def __init__(self) -> None:
         super().__init__("Video Sink", section="Sinks")
-
-        self._output_path: Path = Path("out.mp4")
-        self._fps: float = 30.0
-        self._codec: VideoCodec = VideoCodec.MP4V
-
         self._writer: cv2.VideoWriter | None = None
         self._frame_shape: tuple[int, ...] | None = None
-
         self._add_input(InputPort("image", set(IMAGE_TYPES)))
-        self._add_param(NodeParam(
-            "output_path",
-            NodeParamType.FILE_PATH,
-            default="out.mp4",
-            metadata={"mode": "save", "filter": "Video (*.mp4)", "base_dir": OUTPUT_DIR},
-        ))
-        self._add_param(NodeParam(
-            "fps",
-            NodeParamType.FLOAT,
-            default=30.0,
-        ))
-        self._add_param(NodeParam(
-            "codec",
-            NodeParamType.ENUM,
-            default=VideoCodec.MP4V,
-            metadata={"enum": VideoCodec},
-        ))
         self._apply_default_params()
-
-    # ── Properties ─────────────────────────────────────────────────────────────
-
-    @property
-    def output_path(self) -> Path:
-        return self._output_path
-
-    @output_path.setter
-    def output_path(self, output_path: str | Path) -> None:
-        self._output_path = store_relative_to(output_path, OUTPUT_DIR)
-
-    @property
-    def fps(self) -> float:
-        return self._fps
-
-    @fps.setter
-    def fps(self, value: float) -> None:
-        v = float(value)
-        if v <= 0:
-            raise ValueError(f"fps must be > 0 (got {v})")
-        self._fps = v
-
-    @property
-    def codec(self) -> VideoCodec:
-        return self._codec
-
-    @codec.setter
-    def codec(self, value: int | VideoCodec) -> None:
-        try:
-            self._codec = VideoCodec(value)
-        except ValueError as e:
-            raise ValueError(
-                f"codec must be one of {[c.value for c in VideoCodec]} (got {value!r})"
-            ) from e
-
-    # ── SinkNodeBase interface ──────────────────────────────────────────────────
 
     @override
     def _before_run_impl(self) -> None:

--- a/src/nodes/sources/constant_value.py
+++ b/src/nodes/sources/constant_value.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 from typing_extensions import override
 
 from core.io_data import IoData, IoDataType
-from core.node_base import NodeParam, NodeParamType, SourceNodeBase
+from core.node_base import SourceNodeBase
+from core.params import FloatParam
 from core.port import OutputPort
 
 
@@ -23,26 +24,12 @@ class ConstantValue(SourceNodeBase):
     when the file path changes.
     """
 
+    value = FloatParam(0.0, constant=True)
+
     def __init__(self) -> None:
         super().__init__("Constant Value", section="Sources")
-        self._value: float = 0.0
-        self._add_param(NodeParam(
-            "value",
-            NodeParamType.FLOAT,
-            default=0.0,
-        ))
         self._add_output(OutputPort("value", {IoDataType.SCALAR}))
         self._apply_default_params()
-
-    @property
-    def value(self) -> float:
-        return self._value
-
-    @value.setter
-    def value(self, v: float) -> None:
-        self._value = float(v)
-
-    # ── SourceNodeBase interface ────────────────────────────────────────────────
 
     @property
     @override

--- a/src/nodes/sources/directory_source.py
+++ b/src/nodes/sources/directory_source.py
@@ -11,8 +11,9 @@ from typing_extensions import override
 
 from constants import INPUT_DIR
 from core.io_data import IoData, IoDataType
-from core.node_base import NodeParam, NodeParamType, SourceNodeBase
-from core.path_utils import resolve_against, store_relative_to
+from core.node_base import SourceNodeBase
+from core.params import BoolParam, FilePathParam
+from core.path_utils import resolve_against
 from core.port import OutputPort
 
 
@@ -52,45 +53,19 @@ class DirectorySource(SourceNodeBase):
       include_subdirectories  -- recurse into nested folders when True
     """
 
+    directory = FilePathParam(
+        "",
+        constant=True,
+        mode="directory",
+        base_dir=INPUT_DIR,
+        caption="Select Image Directory",
+    )
+    include_subdirectories = BoolParam(False, constant=True)
+
     def __init__(self) -> None:
         super().__init__("Directory Source", section="Sources")
-        self._directory: Path = Path()
-        self._include_subdirectories: bool = False
-        self._add_param(NodeParam(
-            "directory",
-            NodeParamType.FILE_PATH,
-            default="",
-            metadata={
-                "mode":     "directory",
-                "base_dir": INPUT_DIR,
-                "caption":  "Select Image Directory",
-            },
-        ))
-        self._add_param(NodeParam(
-            "include_subdirectories",
-            NodeParamType.BOOL,
-            default=False,
-        ))
         self._add_output(OutputPort("image", {IoDataType.IMAGE}))
         self._apply_default_params()
-
-    @property
-    def directory(self) -> Path:
-        return self._directory
-
-    @directory.setter
-    def directory(self, path: str | Path) -> None:
-        self._directory = store_relative_to(path, INPUT_DIR)
-
-    @property
-    def include_subdirectories(self) -> bool:
-        return self._include_subdirectories
-
-    @include_subdirectories.setter
-    def include_subdirectories(self, value: bool) -> None:
-        self._include_subdirectories = bool(value)
-
-    # ── SourceNodeBase interface ────────────────────────────────────────────────
 
     @override
     def iter_frames(self) -> Iterator[None]:

--- a/src/nodes/sources/gradient_source.py
+++ b/src/nodes/sources/gradient_source.py
@@ -6,7 +6,8 @@ import numpy as np
 from typing_extensions import override
 
 from core.io_data import IoData, IoDataType
-from core.node_base import NodeParam, NodeParamType, SourceNodeBase
+from core.node_base import SourceNodeBase
+from core.params import BoolParam, ClampedFloatParam, EnumParam, IntParam
 from core.port import OutputPort
 
 
@@ -84,108 +85,20 @@ class GradientSource(SourceNodeBase):
     update the downstream preview live without pressing Run.
     """
 
+    width = IntParam(512, min=1, constant=True)
+    height = IntParam(512, min=1, constant=True)
+    direction = EnumParam(GradientDirection, GradientDirection.VERTICAL, constant=True)
+    mode = EnumParam(GradientMode, GradientMode.SYMMETRIC, constant=True)
+    # band_width clamps to [0, 0.999]: at 1.0 the ramp denominator is
+    # zero (all-zero image), so clip a hair below — and clamp instead
+    # of raising so a slider sweep past the extreme just saturates.
+    band_width = ClampedFloatParam(0.2, min=0.0, max=0.999, constant=True)
+    smooth = BoolParam(True, constant=True)
+
     def __init__(self) -> None:
         super().__init__("Gradient Source", section="Sources")
-        self._width:      int   = 512
-        self._height:     int   = 512
-        self._direction:  GradientDirection = GradientDirection.VERTICAL
-        self._mode:       GradientMode      = GradientMode.SYMMETRIC
-        self._band_width: float = 0.2
-        self._smooth:     bool  = True
-
-        self._add_param(NodeParam("width",  NodeParamType.INT,  default=512))
-        self._add_param(NodeParam("height", NodeParamType.INT,  default=512))
-        self._add_param(NodeParam(
-            "direction",
-            NodeParamType.ENUM,
-            default=GradientDirection.VERTICAL,
-            metadata={"enum": GradientDirection},
-        ))
-        self._add_param(NodeParam(
-            "mode",
-            NodeParamType.ENUM,
-            default=GradientMode.SYMMETRIC,
-            metadata={"enum": GradientMode},
-        ))
-        self._add_param(NodeParam("band_width", NodeParamType.FLOAT, default=0.2))
-        self._add_param(NodeParam("smooth",     NodeParamType.BOOL,  default=True))
         self._add_output(OutputPort("image", {IoDataType.IMAGE_GREY}))
-
         self._apply_default_params()
-
-    # ── Properties ─────────────────────────────────────────────────────────────
-
-    @property
-    def width(self) -> int:
-        return self._width
-
-    @width.setter
-    def width(self, value: int) -> None:
-        v = int(value)
-        if v < 1:
-            raise ValueError(f"width must be >= 1 (got {v})")
-        self._width = v
-
-    @property
-    def height(self) -> int:
-        return self._height
-
-    @height.setter
-    def height(self, value: int) -> None:
-        v = int(value)
-        if v < 1:
-            raise ValueError(f"height must be >= 1 (got {v})")
-        self._height = v
-
-    @property
-    def direction(self) -> GradientDirection:
-        return self._direction
-
-    @direction.setter
-    def direction(self, value: int | GradientDirection) -> None:
-        try:
-            self._direction = GradientDirection(value)
-        except ValueError as e:
-            raise ValueError(
-                f"direction must be one of {[m.value for m in GradientDirection]} "
-                f"(got {value!r})"
-            ) from e
-
-    @property
-    def mode(self) -> GradientMode:
-        return self._mode
-
-    @mode.setter
-    def mode(self, value: int | GradientMode) -> None:
-        try:
-            self._mode = GradientMode(value)
-        except ValueError as e:
-            raise ValueError(
-                f"mode must be one of {[m.value for m in GradientMode]} "
-                f"(got {value!r})"
-            ) from e
-
-    @property
-    def band_width(self) -> float:
-        return self._band_width
-
-    @band_width.setter
-    def band_width(self, value: float) -> None:
-        v = float(value)
-        # Clamp to [0, 1) — at exactly 1.0 the ramp denominator is zero,
-        # which would just produce an all-zero image; clip a hair below
-        # so the node still emits a meaningful gradient at the extreme.
-        self._band_width = max(0.0, min(0.999, v))
-
-    @property
-    def smooth(self) -> bool:
-        return self._smooth
-
-    @smooth.setter
-    def smooth(self, value: bool) -> None:
-        self._smooth = bool(value)
-
-    # ── SourceNodeBase interface ────────────────────────────────────────────────
 
     @property
     @override

--- a/src/nodes/sources/image_source.py
+++ b/src/nodes/sources/image_source.py
@@ -9,8 +9,9 @@ from typing_extensions import override
 
 from constants import INPUT_DIR
 from core.io_data import IoData, IoDataType
-from core.node_base import NodeParam, NodeParamType, SourceNodeBase
-from core.path_utils import resolve_against, store_relative_to
+from core.node_base import SourceNodeBase
+from core.params import FilePathParam
+from core.path_utils import resolve_against
 from core.port import OutputPort
 
 _SUPPORTED_EXTS = {".jpg", ".jpeg", ".png", ".webp", ".cr2"}
@@ -35,35 +36,22 @@ class ImageSource(SourceNodeBase):
       file_path -- path to the input image (relative to INPUT_DIR when possible)
     """
 
+    file_path = FilePathParam(
+        "ship.jpg",
+        constant=True,
+        filter="Images (*.webp *.png *.jpg *.jpeg *.cr2)",
+        base_dir=INPUT_DIR,
+        description=(
+            "Path to the input image. JPEG, PNG, WebP and CR2 (RAW) "
+            "are supported. Paths inside the input folder are stored "
+            "relative to it so the flow stays portable."
+        ),
+    )
+
     def __init__(self) -> None:
         super().__init__("Image Source", section="Sources")
-        self._file_path: Path = Path()
-        self._add_param(NodeParam(
-            "file_path",
-            NodeParamType.FILE_PATH,
-            default="ship.jpg",
-            metadata={
-                "filter": "Images (*.webp *.png *.jpg *.jpeg *.cr2)",
-                "base_dir": INPUT_DIR,
-                "description": (
-                    "Path to the input image. JPEG, PNG, WebP and CR2 (RAW) "
-                    "are supported. Paths inside the input folder are stored "
-                    "relative to it so the flow stays portable."
-                ),
-            },
-        ))
         self._add_output(OutputPort("image", {IoDataType.IMAGE}))
         self._apply_default_params()
-
-    @property
-    def file_path(self) -> Path:
-        return self._file_path
-
-    @file_path.setter
-    def file_path(self, path: str | Path) -> None:
-        self._file_path = store_relative_to(path, INPUT_DIR)
-
-    # ── SourceNodeBase interface ────────────────────────────────────────────────
 
     @property
     @override
@@ -100,8 +88,6 @@ class ImageSource(SourceNodeBase):
                 image = cv2.cvtColor(image, cv2.COLOR_GRAY2BGR)
 
         self.outputs[0].send(IoData.from_image(image))
-
-    # ── Internals ──────────────────────────────────────────────────────────────
 
     def _resolved_path(self) -> Path:
         """Return an absolute path; relative values are joined with INPUT_DIR."""

--- a/src/nodes/sources/value_source.py
+++ b/src/nodes/sources/value_source.py
@@ -5,7 +5,8 @@ from collections.abc import Iterator
 from typing_extensions import override
 
 from core.io_data import IoData, IoDataType
-from core.node_base import NodeParam, NodeParamType, SourceNodeBase
+from core.node_base import SourceNodeBase
+from core.params import BoolParam, FloatParam, IntParam
 from core.port import OutputPort
 
 
@@ -39,73 +40,15 @@ class ValueSource(SourceNodeBase):
     #: walks away.
     _LOOP_CYCLES: int = 10
 
+    min_value = IntParam(0, constant=True)
+    max_value = IntParam(99, constant=True)
+    increment = FloatParam(1.0, min=0.0, min_exclusive=True, constant=True)
+    loop = BoolParam(False, constant=True)
+
     def __init__(self) -> None:
         super().__init__("Value Source", section="Sources")
-        self._min_value: int = 0
-        self._max_value: int = 99
-        self._increment: float = 1.0
-        self._loop: bool = False
-        self._add_param(NodeParam(
-            "min_value",
-            NodeParamType.INT,
-            default=0,
-        ))
-        self._add_param(NodeParam(
-            "max_value",
-            NodeParamType.INT,
-            default=99,
-        ))
-        self._add_param(NodeParam(
-            "increment",
-            NodeParamType.FLOAT,
-            default=1.0,
-        ))
-        self._add_param(NodeParam(
-            "loop",
-            NodeParamType.BOOL,
-            default=False,
-        ))
         self._add_output(OutputPort("value", {IoDataType.SCALAR}))
         self._apply_default_params()
-
-    # ── Properties ─────────────────────────────────────────────────────────────
-
-    @property
-    def min_value(self) -> int:
-        return self._min_value
-
-    @min_value.setter
-    def min_value(self, value: int) -> None:
-        self._min_value = int(value)
-
-    @property
-    def max_value(self) -> int:
-        return self._max_value
-
-    @max_value.setter
-    def max_value(self, value: int) -> None:
-        self._max_value = int(value)
-
-    @property
-    def increment(self) -> float:
-        return self._increment
-
-    @increment.setter
-    def increment(self, value: float) -> None:
-        v = float(value)
-        if v <= 0.0:
-            raise ValueError(f"increment must be > 0 (got {v})")
-        self._increment = v
-
-    @property
-    def loop(self) -> bool:
-        return self._loop
-
-    @loop.setter
-    def loop(self, value: bool) -> None:
-        self._loop = bool(value)
-
-    # ── SourceNodeBase interface ────────────────────────────────────────────────
 
     @override
     def iter_frames(self) -> Iterator[None]:

--- a/src/nodes/sources/video_source.py
+++ b/src/nodes/sources/video_source.py
@@ -8,8 +8,9 @@ from typing_extensions import override
 
 from constants import INPUT_DIR
 from core.io_data import IoData, IoDataType
-from core.node_base import NodeParam, NodeParamType, SourceNodeBase
-from core.path_utils import resolve_against, store_relative_to
+from core.node_base import SourceNodeBase
+from core.params import FilePathParam, IntParam
+from core.path_utils import resolve_against
 from core.port import OutputPort
 
 _SUPPORTED_EXTS = {".mp4", ".avi", ".mov", ".mkv"}
@@ -35,44 +36,18 @@ class VideoSource(SourceNodeBase):
       max_num_frames -- maximum number of frames to decode (-1 = all)
     """
 
+    file_path = FilePathParam(
+        "video.mp4",
+        constant=True,
+        filter="Video (*.mp4 *.avi *.mov *.mkv)",
+        base_dir=INPUT_DIR,
+    )
+    max_num_frames = IntParam(-1, constant=True)
+
     def __init__(self) -> None:
         super().__init__("Video Source", section="Sources")
-        self._file_path: Path = Path()
-        self._max_num_frames: int = -1
-        self._add_param(NodeParam(
-            "file_path",
-            NodeParamType.FILE_PATH,
-            default="video.mp4",
-            metadata={
-                "filter": "Video (*.mp4 *.avi *.mov *.mkv)",
-                "base_dir": INPUT_DIR,
-            },
-        ))
-        self._add_param(NodeParam(
-            "max_num_frames",
-            NodeParamType.INT,
-            default=-1,
-        ))
         self._add_output(OutputPort("image", {IoDataType.IMAGE}))
         self._apply_default_params()
-
-    @property
-    def file_path(self) -> Path:
-        return self._file_path
-
-    @file_path.setter
-    def file_path(self, path: str | Path) -> None:
-        self._file_path = store_relative_to(path, INPUT_DIR)
-
-    @property
-    def max_num_frames(self) -> int:
-        return self._max_num_frames
-
-    @max_num_frames.setter
-    def max_num_frames(self, value: int) -> None:
-        self._max_num_frames = int(value)
-
-    # ── SourceNodeBase interface ────────────────────────────────────────────────
 
     @override
     def iter_frames(self) -> Iterator[None]:


### PR DESCRIPTION
## Summary

Final node-side sweep of the H2 migration. Ports the remaining **nine nodes** to class-level `core.params` descriptors. After this PR every node under `src/nodes/` uses descriptors for its parameters — zero hand-rolled `NodeParam` / param-style `InputPort` / `@property`+`@setter` declarations remain.

## Filters / sources / sinks migrated

| Node | Descriptors | Lines |
|---|---|---|
| ConstantValue | FloatParam (constant) | 54 → 41 |
| DirectorySource | FilePathParam + BoolParam (both constant) | 163 → 116 |
| GradientSource | IntParam × 2 + EnumParam × 2 + ClampedFloatParam + BoolParam (all constant) | 254 → 145 |
| ImageSource | FilePathParam (constant) | 108 → 91 |
| ValueSource | IntParam × 2 + FloatParam(min_exclusive) + BoolParam (all constant) | 154 → 88 |
| VideoSource | FilePathParam + IntParam (both constant) | 121 → 91 |
| FileSink | FilePathParam (constant); `output_format` stays a plain `@property` since it's not a UI-exposed param | 95 → 73 |
| VideoSink | FilePathParam + FloatParam(min_exclusive) + EnumParam (all constant) | 179 → 124 |
| DebugParam (test fixture — one of every type) | FilePath / Int / Float / String / Bool / Enum, all port-style | 170 → 73 |

Net **−350 LoC** across the migrated files.

## `on_change=` hook — turned out unnecessary

The `on_change=` instance hook flagged in `refacturing.txt` H2 as the open design question for `ImageSource.file_path` (the file with the supposed re-decode side effect on set) turned out not needed. The existing setter only normalised the path via `store_relative_to(INPUT_DIR)`, which `FilePathParam._coerce` already does. Re-decode happens in `process_impl`, lazy. The hook design stays parked in the H2 notes in case a future side-effect setter actually wants it.

## Tests

- Full non-Qt suite: **517 passed, 0 regressions**.
- Existing per-node tests (`test_constant_value`, `test_directory_source`, `test_gradient_source`, `test_value_source`, `test_video_sink`, `test_filters` for ImageSource, etc.) all pass unchanged.
- `tests/test_flow_back_compat.py` round-trips all 15 `.flowjs` files unchanged.

## What's still in NodeBase

`_apply_default_params` still walks `self._inputs` looking for `param_type` metadata, and `_populate_port_driven_attributes` still has the silent `hasattr`-skip for ports without a corresponding attribute. Both are now *unreachable* in production (no hand-rolled param-style ports remain), but staying present makes this PR independently landable. **PR-2f** retires them and moves H2 / H4 / M9 to *Resolved* in `refacturing.txt`.

## Test plan

- [x] 517 non-Qt tests passing, 0 regressions.
- [x] `.flowjs` back-compat round-trips clean.
- [ ] CI green on Python 3.13.
- [ ] Open `flow/video_dither.flowjs` (uses VideoSource + VideoSink). Confirm path widgets, fps spinner and codec combo render and save/reload cleanly.
- [ ] Open `flow/folder_resize.flowjs` (uses DirectorySource). Confirm the directory picker opens with `INPUT_DIR` as base.
- [ ] Drop a DebugParam node and confirm every widget kind (file path, int, float, string, bool, enum) renders.

https://claude.ai/code/session_017Sbygfh52wCk9uJYDUEyLW

---
_Generated by [Claude Code](https://claude.ai/code/session_017Sbygfh52wCk9uJYDUEyLW)_