### PR TITLE
H2 PR-2f: retire legacy NodeBase paths; close H2/H3/H4/M9/L13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,48 @@ once a first tagged release is cut.
 
 ## [Unreleased]
 
+## [0.2.33] — 2026-04-28
+
+### Removed
+- **Legacy hand-rolled-port code paths in ``NodeBase``** (H2 PR-2f).
+  The two ``setattr`` loops at the end of
+  ``_apply_default_params`` (one walking ``self._inputs`` for ports
+  with ``"param_type"`` metadata, the other walking
+  ``self._params``) are gone. Every node in the codebase uses
+  class-level descriptors after PR-2e, and descriptors write their
+  defaults through the full ``__set__`` pipeline (coerce / validate
+  / shape) at ``NodeBase.__init__`` time. The loops were dead code
+  in production after PR-2e; this PR removes them and tightens the
+  contract.
+
+### Changed
+- **Default writes go through the descriptor pipeline at
+  construction time.** ``NodeBase.__init__`` previously used
+  ``object.__setattr__`` to skip validation when initialising each
+  descriptor's backing slot — the defaults were re-applied through
+  ``setattr`` later in ``_apply_default_params``. With the legacy
+  loop gone, ``__init__`` now uses ``setattr`` directly so the full
+  pipeline runs once, atomically. A misconfigured default (e.g. an
+  even value on an ``OddIntParam``) now fails loudly at
+  construction rather than landing silently.
+- **``_populate_port_driven_attributes`` gates on ``"param_type"``
+  metadata** instead of the silent ``hasattr`` skip that had been
+  papering over hand-rolled ports without backing attributes. The
+  intent is now explicit: only param-style ports (the ones a
+  descriptor auto-creates) participate in the per-frame
+  populate / restore dance; image / data-flow inputs are skipped
+  because the gate filters them out.
+
+### Resolved (refacturing backlog)
+- **H2** — convention-driven port↔attribute coupling — done across
+  PRs #208 / #209 / #211 / #212 / #213 / #214 and this PR.
+- **H3** — param-widget boilerplate — done in PR #205.
+- **H4** — port-construction boilerplate — subsumed by H2.
+- **M9** — parallel widget dispatch tables — subsumed by H2.
+- **L13** — ``_apply_default_params`` swallowing exceptions — the
+  exception-swallowing loop is gone with the rest of the legacy
+  path.
+
 ## [0.2.32] — 2026-04-28
 
 ### Changed

--- a/doc/welcome.html
+++ b/doc/welcome.html
@@ -180,7 +180,7 @@
   <main class="content-col">
 
     <header class="hero">
-      <h1>Welcome to Stjörnhorn <span class="version">v0.2.32</span></h1>
+      <h1>Welcome to Stjörnhorn <span class="version">v0.2.33</span></h1>
       <div class="tagline">A node-based image- and video-processing playground.</div>
     </header>
 
@@ -210,6 +210,13 @@
           <p>Write frames to image files or encode video (MP4V, XVID) with live preview via the Display node.</p>
         </div>
       </div>
+    </section>
+
+    <section>
+      <h2>What's new in v0.2.33</h2>
+      <ul class="tips">
+        <li><strong>H2 closed: descriptor migration complete.</strong> Final cleanup retires the legacy code paths in <code>NodeBase</code> now that every node uses class-level <code>core.params</code> descriptors. The setattr loops that walked <code>self._inputs</code> / <code>self._params</code> applying defaults are gone — defaults now flow exclusively through each descriptor's <code>__set__</code> pipeline at <code>NodeBase.__init__</code> time, so a misconfigured default fails loudly at construction rather than silently logging and carrying on. <code>_populate_port_driven_attributes</code> tightened to gate on <code>"param_type"</code> in port metadata (replacing the old silent <code>hasattr</code> skip). Backlog items <strong>H2</strong>, <strong>H3</strong>, <strong>H4</strong>, <strong>M9</strong>, and <strong>L13</strong> all moved to <em>Resolved</em> in <code>refacturing.txt</code>.</li>
+      </ul>
     </section>
 
     <section>

--- a/refacturing.txt
+++ b/refacturing.txt
@@ -13,7 +13,7 @@ Status markers:
   [DONE]      — landed on main; references PR/commit
   [WITHDRAWN] — reconsidered, no longer pursued (with reason)
 
-Last reviewed: 2026-04-28 (H2 design locked)
+Last reviewed: 2026-04-28 (H2/H3/H4/M9/L13 resolved via descriptor sweep)
 
 
 High
@@ -26,157 +26,6 @@ High
   skip pass-through, and run lifecycle.
   Direction: extract PortDispatcher, PortAttributeBridge, SkipStrategy;
   leave NodeBase as data shape + abstract process_impl.
-
-[WIP] H2. Convention-driven port↔attribute coupling via name reflection.
-  Hidden coupling. src/core/node_base.py:407-447 does
-  setattr(self, port.name, value) and snapshots
-  getattr(self, f"_{port.name}"). Every concrete node (e.g.
-  src/nodes/filters/gaussian_blur.py:23-25,68-74) must declare
-  self._<name>, a setter, and a port named <name> — three-place
-  duplication, silent skip when the attribute is missing.
-  Direction: a Param descriptor that owns storage, validation, default,
-  metadata, port wiring as one declaration.
-
-  Design (locked, 2026-04-28, pending implementation):
-    • Pure Python descriptors in core/params.py: IntParam, FloatParam,
-      BoolParam, StringParam, EnumParam, FilePathParam. __set_name__ /
-      __get__ / __set__ pattern; no metaclass.
-    • __set__ split into _coerce(value) + _validate(value) hooks so
-      domain-specific subclasses (OddIntParam, ProbabilityParam,
-      AngleParam, PercentParam, ColorParam) are 3–5 line subclasses.
-      OCP property: extension by subclassing, no edits to NodeBase
-      or IntParam itself.
-    • NodeBase.__init_subclass__ collects descriptors; NodeBase.__init__
-      writes each default into self._<name> AND auto-creates the matching
-      InputPort (subsumes H4 — port-construction factories are no longer
-      needed because the descriptor *is* the factory).
-    • Widget binding: option 2 (descriptor-side class hint). Each
-      descriptor exposes WIDGET_CLASS so a domain subclass like
-      OddIntParam can ship its own _OddSpinBox-backed widget without
-      growing IntParamWidget with metadata flags. This subsumes M9 —
-      the param-widget registry collapses to "ask the descriptor".
-    • Domain subclasses can drive widget-side affordances end-to-end.
-      Worked example (OddIntParam): widget uses _OddSpinBox with
-      setSingleStep(2) so arrows step 5→7→9, fixup() bumps even text
-      input on commit, descriptor's _coerce is the backstop for
-      port-driven and programmatic writes — invariant holds at every
-      layer with a single source.
-    • _populate_port_driven_attributes walks the registered descriptors
-      directly; the silent hasattr-skip path goes away.
-    • _apply_default_params retires — defaults written by the
-      descriptor-driven __init__ pass.
-
-  Migration: two PRs.
-    PR-1: land core.params + descriptor-aware NodeBase + migrate one
-          filter (GaussianBlur) as proof. Keep the legacy
-          _add_input(InputPort(...)) path alive alongside descriptors so
-          the other ~40 nodes are untouched. Full test suite must pass.
-    PR-2: sweep the remaining ~35 filter files + sources/sinks. Drop
-          the legacy path from NodeBase once empty.
-
-  Subsumes: H4 (port-construction boilerplate) and M9 (widget-registry
-  duplication) — both will move to Resolved citing H2 once PR-2 lands.
-  Simplifies: H6 (flow_io reflection) — serializer becomes
-  "iterate descriptors, read via __get__" rather than getattr-by-name.
-
-  Open questions (unresolved at PR-2):
-    1. on_change= instance hook for side-effect setters
-       (e.g. ImageSource.file_path triggers a re-decode)? Or do those
-       nodes opt out of the descriptor path with a plain @property?
-       PR-1 deferred — GaussianBlur has no side-effect setters, so the
-       hook isn't needed yet. Decide when the first node that needs
-       it shows up in the PR-2 sweep.
-    2. PR-1 strictness — kept silent-skip in PR-2 deferred; legacy
-       _add_input(InputPort(...)) path still alive in NodeBase. PR-2
-       will hard-fail once every node is descriptor-driven.
-    3. NodeParam (constants — file paths on sources, codecs on sinks):
-       merge into descriptors with a constant=True flag, or keep separate?
-       Defer until PR-2 hits a NodeParam-using node.
-    4. .flowjs back-compat — verified in PR-1 via tests/test_flow_back_compat.py.
-       Every saved flow under flow/ instantiates and indexed
-       connection access still works.
-
-  Status:
-    PR-1 (merged, 2026-04-28): core/params.py with _ParamBase +
-      IntParam + OddIntParam + FloatParam. NodeBase collects
-      descriptors via __init_subclass__; defaults written via
-      object.__setattr__ in __init__ before any subclass code runs;
-      descriptor-driven ports auto-created in _apply_default_params
-      after the explicit subclass ports so image-first ordering is
-      preserved. GaussianBlur migrated as proof: 95 → 57 lines.
-      tests/test_param_descriptors.py + tests/test_flow_back_compat.py.
-
-    PR-2a (merged): Sweep batch 1 — eight filters using only
-      IntParam / FloatParam / OddIntParam: Median, Delay, Clamp,
-      Shift, Temporal Mean, Temporal Median, Adaptive Gaussian
-      Threshold, Crop. Each lost 30–50% LoC. Descriptor protocol
-      gained a _shape hook running after _validate so 0 still
-      raises on Median.size (matching the old setter), even though
-      OddIntParam's shape would round it to 1.
-
-    PR-2b (merged): added BoolParam, EnumParam, ClampedFloatParam
-      and a min_exclusive / max_exclusive flag on FloatParam.
-      Migrated: Overlay (headline — exercises every new type),
-      Subpixel Mosaic, Flip, Dither, Rotate, Scale.
-
-    PR-2c (merged): added StringParam and FilePathParam (Path-typed
-      storage with base_dir-aware store_relative_to coerce). Migrated
-      NCC (full) and Notify (partial — message ported, severity
-      pending PR-2d).
-
-    PR-2d (in flight on branch claude/h2-pr2d-constants):
-      added constant=True flag on the descriptor protocol — constant
-      descriptors register themselves on node.params instead of
-      auto-creating an InputPort, and the descriptor satisfies the
-      NodeParam read interface directly (no wrapper). Migrated the
-      four remaining NodeParam-using filters: ApplyColormap, Resize,
-      Math (with a custom _ExpressionParam subclass that compiles
-      atomically on set), Notify (severity finished). Sources / sinks
-      defer to PR-2e since they decide the on_change= hook design.
-
-    PR-2e (in flight on branch claude/h2-pr2e-sources-sinks):
-      Migrated all 6 sources (constant_value, directory_source,
-      gradient_source, image_source, value_source, video_source),
-      both sinks (file_sink, video_sink), and the DebugParam test
-      fixture. After this PR every node in src/nodes/ uses class-
-      level descriptors; zero hand-rolled _add_input(InputPort(...))
-      + @property/@setter pairs remain for parameter ports.
-      The on_change= hook turned out unnecessary —
-      ImageSource.file_path's setter only normalises the path via
-      store_relative_to(INPUT_DIR), which FilePathParam._coerce
-      already does. Hook design parked in case a future side-effect
-      setter actually needs it.
-
-    PR-2f (planned): retire the legacy _add_input(InputPort(...)) +
-      @property path from NodeBase. The path-style branches in
-      NodeBase._apply_default_params and NodeBase._populate_port_
-      driven_attributes' silent hasattr-skip can both go away once
-      every InputPort is known to come from a descriptor. Move H2,
-      H4, M9 to Resolved.
-
-[WIP] H3. Param-widget subclasses duplicate >90% boilerplate.
-  Duplication / OCP. src/ui/param_widgets.py:138-289 — every widget
-  repeats QHBoxLayout(self), setContentsMargins(0,0,0,0), identical
-  _on_value_changed → _write_to_node + emit, identical _initial_value,
-  identical fixed-size calls.
-  Direction: a _SingleControlParamWidget base taking control factory +
-  value-coerce funcs; concrete widgets shrink to ~10 lines.
-  Status (2026-04-28): scope reduced after design-review pushback —
-  full template-method base would have been over-engineering. Landed
-  the minimal version on branch claude/refactor-param-widgets: two
-  helpers on ParamWidgetBase (_make_row_layout, _size_value_control)
-  that the six widgets call instead of inlining the layout dance.
-  _on_value_changed and the int()/float()/bool()/str() coercions stay
-  inline per subclass — they're already short and clearer there than
-  behind a hook. Move to Resolved on merge.
-
-[OPEN] H4. Identical port-construction boilerplate in ~35 filter files.
-  Duplication / OCP. E.g. src/nodes/filters/rotate.py:28-57,
-  src/nodes/filters/gaussian_blur.py:27-58. default_value and
-  metadata["default"] mirrored, descriptions freeform per node.
-  Direction: helper factories like
-  scalar_param("angle", default=0.0, unit="deg", desc=...) returning a
-  fully-formed InputPort; same factory keeps doc/metadata single-source.
 
 [OPEN] H5. NodeItem is a 1065-line god class.
   SRP. src/ui/node_item.py:336-1065 does layout, painting, geometry,
@@ -210,13 +59,6 @@ Medium
   outputs cannot override.
   Direction: strategy or overridable _skip_match(out) -> InputPort | None.
 
-[OPEN] M9. Two parallel widget dispatch tables.
-  Duplication. src/ui/param_widgets.py:546-553 (enum→class) vs
-  src/ui/preview_widgets.py:222-224 (type(node) dict); ENUM widget
-  re-hardcodes metadata["enum"] validation (304-312).
-  Direction: one WidgetRegistry, or push factory onto the Param
-  descriptor.
-
 [OPEN] M10. NodeEditorPage mixes page-shell with run orchestration & threading.
   SRP. src/ui/node_editor_page.py:580-720 assembles QThread, FlowRunner,
   signal chains, status messages, viewer auto-pick (_best_viewer_node).
@@ -240,10 +82,6 @@ Medium
 Low
 ---
 
-[OPEN] L13. _apply_default_params swallows every exception with debug log.
-  Robustness. src/core/node_base.py:208-222 — masks setter bugs at
-  construction time.
-
 [OPEN] L14. Magic numbers in NodeItem layout outside the constants block.
   src/ui/node_item.py:358-391 defines a clean block, but 100.0 (preview
   min height, line 947) and 2/4 paddings in boundingRect (line 501) are
@@ -259,4 +97,58 @@ Low
 Resolved
 --------
 
-(empty — fill as items land)
+[DONE] H2. Convention-driven port↔attribute coupling via name reflection.
+  Resolved 2026-04-28 across PRs #208, #209, #211, #212, #213, #214,
+  and PR-2f (this commit).
+    PR-1 (#208) — landed core.params with _ParamBase + IntParam +
+      OddIntParam + FloatParam; descriptor-aware NodeBase;
+      GaussianBlur as proof.
+    PR-2a (#209) — sweep batch 1 (8 numeric-only filters).
+    PR-2b (#211) — added BoolParam, EnumParam, ClampedFloatParam,
+      FloatParam(min/max_exclusive); migrated Overlay + 5 more.
+    PR-2c (#212) — added StringParam, FilePathParam (Path-typed
+      with base_dir-aware coerce); migrated NCC + Notify.message.
+    PR-2d (#213) — added constant=True flag; migrated Apply Colormap,
+      Resize, Math (with custom _ExpressionParam), Notify.severity.
+    PR-2e (#214) — migrated all 6 sources, both sinks, and
+      DebugParam. Zero hand-rolled NodeParam / param-style InputPort
+      remains in src/nodes/.
+    PR-2f (this PR) — retired the legacy setattr loops in
+      _apply_default_params and tightened
+      _populate_port_driven_attributes to gate on "param_type" in
+      port.metadata (replacing the silent hasattr-skip). Defaults
+      now flow exclusively through the descriptor's __set__
+      pipeline at NodeBase.__init__ time.
+  The on_change= hook flagged as an open question turned out
+  unnecessary in practice. Design notes parked in CHANGELOG /
+  PR-2e PR description in case a future side-effect setter actually
+  wants it.
+
+[DONE] H3. Param-widget subclasses duplicate >90% boilerplate.
+  Resolved 2026-04-28 in PR #205. Scope was reduced after design-
+  review pushback — a full template-method base would have been
+  over-engineering. Landed two small helpers on ParamWidgetBase
+  (_make_row_layout, _size_value_control) that every widget calls
+  instead of inlining the QHBoxLayout dance. _on_value_changed and
+  the int() / float() / bool() / str() coercions stay inline per
+  subclass.
+
+[DONE] H4. Identical port-construction boilerplate in ~35 filter files.
+  Resolved 2026-04-28 — subsumed by H2. The descriptor *is* the
+  port factory; class-level declarations replace the per-node
+  hand-rolled InputPort metadata blocks.
+
+[DONE] M9. Two parallel widget dispatch tables.
+  Resolved 2026-04-28 — subsumed by H2. The descriptor's optional
+  WIDGET_CLASS hint lets a domain subclass (OddIntParam,
+  ClampedFloatParam, …) ship its own widget without growing
+  IntParamWidget / the per-NodeParamType registry. Adding a new
+  widget for a new descriptor is now a self-contained change.
+
+[DONE] L13. _apply_default_params swallows every exception with debug log.
+  Resolved 2026-04-28 in PR-2f — the loop that ran setattr against
+  hand-rolled port defaults is gone, taking the broad
+  ``except Exception`` branch with it. Default writes go through
+  the descriptor's __set__ at __init__ time; a bad default fails
+  loudly at construction now rather than silently logging and
+  carrying on.

--- a/src/constants.py
+++ b/src/constants.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 APP_NAME:         str = "Image-Inquest"
 APP_DISPLAY_NAME: str = "Stjörnhorn"
-APP_VERSION:      str = "0.2.32"
+APP_VERSION:      str = "0.2.33"
 API_URL:    str = "https://beltoforion.de"
 
 # Path resolution -----------------------------------------------------------

--- a/src/core/node_base.py
+++ b/src/core/node_base.py
@@ -168,13 +168,13 @@ class NodeBase(ABC):
         # Initialise every descriptor's backing slot to its declared
         # default before subclass ``__init__`` runs, so ``self._<name>``
         # exists from the first line after ``super().__init__()``. The
-        # default is written via ``object.__setattr__`` to bypass the
-        # descriptor's ``__set__`` — the descriptor author is trusted to
-        # have provided a valid default, and this runs before validation
-        # rules that depend on other (not-yet-set) descriptor values
-        # would have any chance to trigger.
+        # default goes through the descriptor's ``__set__`` — full
+        # coerce / validate / shape pipeline — so a misconfigured
+        # default (e.g. an even value on an :class:`OddIntParam`)
+        # fails loudly at construction time, and a valid one lands as
+        # its canonical shaped form.
         for desc in self._param_descriptors:
-            object.__setattr__(self, desc._private, desc.default)
+            setattr(self, desc.name, desc.default)
 
     # ── Port registration (called from subclass __init__) ──────────────────────
 
@@ -201,85 +201,47 @@ class NodeBase(ABC):
     # ── Param defaults ─────────────────────────────────────────────────────────
 
     def _apply_default_params(self) -> None:
-        """Push every editable input port's ``default_value`` and every
-        registered :class:`NodeParam`'s default onto the matching
-        instance attribute via the normal property setter.
+        """Auto-create the :class:`InputPort` (or :class:`NodeParam`
+        registration) every class-level descriptor advertises.
 
-        Call this at the end of a subclass ``__init__`` so the node's
-        attributes match the values it advertises from the moment it
-        is constructed — *before* any UI builder, save routine or
-        scheduler can read stale data. Three sources of editable values
-        are honoured:
+        Call this at the end of a subclass ``__init__`` *after* the
+        node has registered its hand-rolled ports (image inputs,
+        outputs, etc.). Descriptor-driven ports land at the tail of
+        ``self._inputs`` so the visual layout preserves the
+        image-first / params-second convention.
 
-        * Descriptor-style: a class-level :class:`~core.params._ParamBase`
-          subclass (e.g. :class:`~core.params.IntParam`,
-          :class:`~core.params.OddIntParam`). Their matching
-          :class:`InputPort` is auto-created here — placed *after* the
-          explicit ports the subclass added in its ``__init__`` so the
-          image-first / params-second visual ordering is preserved.
-        * Port-style legacy: an :class:`InputPort` constructed by hand
-          in the subclass and registered via ``_add_input``, with
-          ``"param_type"`` in its metadata. Co-exists with descriptor-
-          style during the H2 migration; will retire once every node
-          has moved over.
-        * Constant-style: a :class:`NodeParam` registered via
-          ``_add_param`` — always edited inline only, never connection-
-          driven (sources / sinks use these for config like file paths
-          or codec choice).
+        Each descriptor produces either:
 
-        Setter exceptions are logged and swallowed — a property setter
-        may legitimately reject some defaults (range setters clip, file
-        dialogs validate paths). The subclass ``__init__`` already wrote
-        a fallback value before this method runs, so a rejected default
-        leaves the node in a still-valid state.
+        * A port-style :class:`InputPort` (default) — drivable from
+          upstream, exposed inline as a port-row widget.
+        * A constant-style entry on :attr:`params` — for descriptors
+          declared with ``constant=True``. The descriptor object
+          itself satisfies the NodeParam read interface
+          (``name`` / ``metadata`` / ``default_value`` / ``upstream``
+          — see :class:`core.params._ParamBase`) so the UI's existing
+          ``node.params`` dispatch picks it up without a wrapper.
+
+        Default *values* are written by :meth:`__init__` (which calls
+        each descriptor's full ``__set__`` pipeline before the
+        subclass body runs); this method does not touch attribute
+        state.
+
+        The existing-name guards make the method idempotent — calling
+        it twice doesn't double-add a port — and tolerate hand-rolled
+        ports that happen to share a name with a descriptor (the
+        hand-rolled one wins).
         """
-        # Auto-create descriptor-driven ports / register constant
-        # descriptors. Skip names the subclass already registered
-        # explicitly so a partial migration (mixing descriptor and
-        # legacy declarations) stays consistent.
         existing_input_names = {p.name for p in self._inputs}
         existing_param_names = {p.name for p in self._params}
         for desc in self._param_descriptors:
             if desc.constant:
                 if desc.name in existing_param_names:
                     continue
-                # The descriptor itself satisfies the NodeParam read
-                # interface (.name / .metadata / .default_value /
-                # .upstream — see core.params._ParamBase) so the UI's
-                # existing node.params dispatch picks it up without a
-                # wrapper.
                 self._params.append(desc)
             else:
                 if desc.name in existing_input_names:
                     continue
                 self._add_input(desc.make_port())
-        for port in self._inputs:
-            if not port.has_default:
-                continue
-            if "param_type" not in port.metadata:
-                continue
-            try:
-                setattr(self, port.name, port.default_value)
-            except AttributeError:
-                # No setter / backing attribute for this port name —
-                # legitimate when the node only consumes the port via
-                # ``self.inputs[i].data``; skip silently.
-                pass
-            except Exception:
-                logger.exception(
-                    "Failed to apply port default for %s.%s = %r",
-                    type(self).__name__, port.name, port.default_value,
-                )
-        for param in self._params:
-            if param.default_value is None and "default" not in param.metadata:
-                continue
-            try:
-                setattr(self, param.name, param.default_value)
-            except Exception:
-                logger.exception(
-                    "Failed to apply param default for %s.%s = %r",
-                    type(self).__name__, param.name, param.default_value,
-                )
 
     # ── Public accessors ───────────────────────────────────────────────────────
 
@@ -465,31 +427,33 @@ class NodeBase(ABC):
     # ── Port-driven attribute population ────────────────────────────────────────
 
     def _populate_port_driven_attributes(self) -> dict[str, object]:
-        """Write the current upstream value of every connected input
-        port into ``self._<port_name>`` and return a snapshot of the
-        previous values for :meth:`_restore_port_driven_attributes`.
+        """Write the current upstream value of every connected
+        param-style input port into ``self._<port_name>`` and return
+        a snapshot of the previous values for
+        :meth:`_restore_port_driven_attributes`.
 
-        Skips ports without upstream data and ports whose backing
-        attribute does not exist on the node — image inputs read via
-        ``self.inputs[i].data`` rather than via a Python attribute, so
-        they have no field to populate. The mapping is by convention:
-        port ``angle`` → attribute ``_angle``; assignment goes through
-        the public name (``setattr(self, 'angle', value)``) so a node's
-        ``@angle.setter`` runs and applies its validation /
-        clamping / coercion as if the user had moved the slider.
+        Image / data-flow inputs are skipped — the gate is the
+        ``"param_type"`` metadata key, which only param-style ports
+        (the ones a descriptor auto-creates) carry. Image inputs read
+        via ``self.inputs[i].data`` rather than via a Python
+        attribute, so they have no field to populate.
 
-        On any error during populate (e.g. a setter rejecting a
-        streamed value), already-applied writes are rolled back via
-        the partial snapshot so the node's state stays consistent.
+        Assignment goes through the public name
+        (``setattr(self, 'angle', value)``) so the descriptor's
+        ``__set__`` runs and applies its validation / clamping /
+        shaping as if the user had moved the slider. On any error
+        during populate (e.g. a descriptor rejecting a streamed
+        value), already-applied writes are rolled back via the
+        partial snapshot so the node's state stays consistent.
         """
         snapshot: dict[str, object] = {}
         try:
             for port in self._inputs:
                 if not port.has_data:
                     continue
-                attr_name = f"_{port.name}"
-                if not hasattr(self, attr_name):
+                if "param_type" not in port.metadata:
                     continue
+                attr_name = f"_{port.name}"
                 snapshot[attr_name] = getattr(self, attr_name)
                 value = self._extract_driven_value(port.data)
                 setattr(self, port.name, value)

--- a/tests/test_auto_param_ports.py
+++ b/tests/test_auto_param_ports.py
@@ -119,32 +119,23 @@ def test_port_metadata_carries_widget_hints() -> None:
     assert md.get("step") == 1
 
 
-def test_apply_default_params_writes_default_to_attribute() -> None:
-    """``_apply_default_params`` reads each editable port's
-    ``default_value`` and writes it onto the matching instance
-    attribute via the property setter."""
+def test_descriptor_default_lands_on_attribute_at_construction() -> None:
+    """Each descriptor's declared default flows through its full
+    ``__set__`` pipeline (coerce / validate / shape) at
+    :meth:`NodeBase.__init__` time, so the public attribute matches
+    the descriptor's declared default the moment the node is
+    constructed — before any UI builder, save routine or scheduler
+    can read stale data.
+    """
+    from core.params import FloatParam
 
     class _ScaledEcho(NodeBase):
+        factor = FloatParam(2.5)
+
         def __init__(self) -> None:
             super().__init__("scaled-echo", section="Filters")
-            self._factor: float = 0.0
-            self._add_input(InputPort(
-                "factor",
-                {IoDataType.SCALAR},
-                optional=True,
-                default_value=2.5,
-                metadata={"default": 2.5, "param_type": NodeParamType.FLOAT},
-            ))
             self._add_output(OutputPort("out", {IoDataType.SCALAR}))
             self._apply_default_params()
-
-        @property
-        def factor(self) -> float:
-            return self._factor
-
-        @factor.setter
-        def factor(self, value: float) -> None:
-            self._factor = float(value)
 
         @override
         def process_impl(self) -> None:  # pragma: no cover

--- a/tests/test_port_driven_attributes.py
+++ b/tests/test_port_driven_attributes.py
@@ -10,8 +10,25 @@ from __future__ import annotations
 from typing_extensions import override
 
 from core.io_data import IoData, IoDataType
-from core.node_base import NodeBase
+from core.node_base import NodeBase, NodeParamType
 from core.port import InputPort, OutputPort
+
+
+def _param_port(name: str, **kwargs) -> InputPort:
+    """Build a SCALAR param-style InputPort for these tests.
+
+    The framework's port-driven attribute machinery skips ports
+    without ``"param_type"`` metadata (those are image / data-flow
+    sockets that have no ``self._<name>`` attribute to populate).
+    Real production code goes through :mod:`core.params` descriptors,
+    which always set the metadata; this helper keeps the test ports
+    consistent with that contract without pulling a full descriptor
+    declaration into every test fixture.
+    """
+    metadata = kwargs.pop("metadata", None) or {}
+    metadata.setdefault("param_type", NodeParamType.FLOAT)
+    metadata.setdefault("default", 0.0)
+    return InputPort(name, {IoDataType.SCALAR}, metadata=metadata, **kwargs)
 
 
 class _AngleNode(NodeBase):
@@ -23,7 +40,7 @@ class _AngleNode(NodeBase):
         super().__init__("angle-node", section="Filters")
         self._angle: float = 0.0
         self._fired_with: list[float] = []
-        self._add_input(InputPort("angle", {IoDataType.SCALAR}))
+        self._add_input(_param_port("angle"))
         self._add_output(OutputPort("out", {IoDataType.SCALAR}))
 
     @property
@@ -108,8 +125,10 @@ def test_unconnected_port_does_not_overwrite_attribute() -> None:
             self._observed: list[float] = []
             # Required image input so the dispatcher fires (we need
             # *some* trigger), and an optional unconnected angle port.
+            # trigger has no metadata — it's just a fire-the-dispatcher
+            # input, not a param-style port that should be auto-populated.
             self._add_input(InputPort("trigger", {IoDataType.SCALAR}))
-            self._add_input(InputPort("angle", {IoDataType.SCALAR}, optional=True))
+            self._add_input(_param_port("angle", optional=True))
             self._add_output(OutputPort("out", {IoDataType.SCALAR}))
 
         @property
@@ -181,7 +200,7 @@ def test_setter_validation_runs_on_streamed_value() -> None:
             super().__init__("scale-node", section="Filters")
             self._scale: float = 1.0
             self._fired_with: list[float] = []
-            self._add_input(InputPort("scale", {IoDataType.SCALAR}))
+            self._add_input(_param_port("scale"))
             self._add_output(OutputPort("out", {IoDataType.SCALAR}))
 
         @property
@@ -229,8 +248,8 @@ def test_setter_rejection_rolls_back_partial_writes() -> None:
             super().__init__("two-setter", section="Filters")
             self._a: int = 100
             self._b: float = 1.0
-            self._add_input(InputPort("a", {IoDataType.SCALAR}))
-            self._add_input(InputPort("b", {IoDataType.SCALAR}))
+            self._add_input(_param_port("a"))
+            self._add_input(_param_port("b"))
             self._add_output(OutputPort("out", {IoDataType.SCALAR}))
 
         @property


### PR DESCRIPTION
## Summary

Final step of the H2 descriptor migration. Now that every node uses class-level descriptors (after PR-2e), the legacy hand-rolled-port code paths in `NodeBase` are dead. This PR removes them, tightens the contract, and moves **H2 / H3 / H4 / M9 / L13** to *Resolved* in `refacturing.txt`.

## NodeBase changes

- **`__init__` uses `setattr` directly** instead of `object.__setattr__` for descriptor defaults. Defaults flow through the descriptor's full `__set__` pipeline (coerce / validate / shape) once at construction time, atomically. A misconfigured default — e.g. an even value on `OddIntParam` — now fails loudly at construction instead of landing silently.
- **`_apply_default_params` shrunk.** The two `setattr` loops at the end (one walking `self._inputs` for `param_type`-tagged ports, one walking `self._params`) are gone. They were dead code after PR-2e since defaults are already applied via the descriptor's `__set__` at `__init__`. The method now does one thing — auto-create the descriptor's port (or register the constant descriptor on `self._params`) — with idempotent existing-name guards.
- **`_populate_port_driven_attributes` gates on `"param_type"` in port metadata** instead of the old silent `hasattr` skip. The intent is now explicit: only param-style ports (the ones a descriptor auto-creates) participate in the per-frame populate / restore dance; image / data-flow inputs are skipped because the gate filters them out.

## Tests

- `tests/test_auto_param_ports.py::test_apply_default_params_writes_default_to_attribute` renamed and rewritten with a descriptor — the legacy hand-rolled-port codepath it exercised is the one this PR removed. The other ten tests in that file still exercise port metadata / `params` filtering / port-driven population and pass unchanged.
- `tests/test_port_driven_attributes.py` — added a small `_param_port` helper that builds an `InputPort` with `metadata={"param_type": ..., "default": 0.0}` so test fixtures match the production contract. One bare `InputPort("trigger")` stays unchanged because it intentionally isn't a param port.
- **Full non-Qt suite: 517 passed, 0 regressions.**

## Resolved (refacturing backlog)

| Item | How |
|---|---|
| **H2** | Done across PRs #208, #209, #211, #212, #213, #214 and this PR. |
| **H3** | Done in PR #205 (two helpers on `ParamWidgetBase`, scope intentionally reduced). |
| **H4** | Subsumed by H2 — descriptors *are* the port factory. |
| **M9** | Subsumed by H2 — descriptor's `WIDGET_CLASS` hint replaces the parallel per-NodeParamType dispatch table. |
| **L13** | Done in this PR — the exception-swallowing branch is gone with the rest of the legacy path. |

After this PR the *High* bucket of `refacturing.txt` is **H1, H5, H6** (NodeBase god class, NodeItem god class, flow_io reflection). The *Medium* bucket is **M7, M8, M10, M11, M12**. The *Low* bucket is **L14, L15**.

## Test plan

- [x] 517 non-Qt tests passing, 0 regressions.
- [x] `.flowjs` back-compat round-trips clean (15 saved flows).
- [ ] CI green on Python 3.13.
- [ ] Open `flow/image_rgb_dither.flowjs` and confirm every node's params (Dither method combo, GaussianBlur ksize/sigma if used, Overlay's full param set) render and edit cleanly.
- [ ] Drop a `Math` node, type a bad expression, confirm the error surfaces immediately at the inline editor (the descriptor's `_compile_expression` raises through `__set__`).

https://claude.ai/code/session_017Sbygfh52wCk9uJYDUEyLW

---
_Generated by [Claude Code](https://claude.ai/code/session_017Sbygfh52wCk9uJYDUEyLW)_