### PR TITLE
core.port: import IoDataType, drop dead TYPE_CHECKING block, codify proactive-cleanup rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,26 @@ once a first tagged release is cut.
 
 ## [Unreleased]
 
+## [0.2.36] — 2026-04-29
+
+### Fixed
+- **Type-checker hygiene in ``core.port``.** ``IoDataType`` is now
+  imported alongside ``IoData``. The annotations across ``InputPort``
+  / ``OutputPort`` referenced it without an import; this worked at
+  runtime because ``from __future__ import annotations`` keeps
+  annotations as strings, but Pylance flagged it as unresolved.
+
+### Removed
+- **Empty ``if TYPE_CHECKING: pass`` block in ``core.port``** and the
+  now-unused ``TYPE_CHECKING`` import. Leftover from an earlier
+  import shape; carried no symbols.
+
+### Repository Rules
+- New CLAUDE.md guideline: opportunistic dead-code cleanup
+  (empty ``TYPE_CHECKING`` blocks, unused imports, commented-out
+  code, stale TODOs, leftover debug prints) is folded into whatever
+  change is in flight rather than waiting to be asked.
+
 ## [0.2.34] — 2026-04-29
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,6 +5,7 @@
 - Don't use magic numbers or magic strings
 - Always have code maintainability in mind. Avoid code duplication and code smells in general. If you find issues whilst working on the code bring them up and suggest improvements.
 - Maintain `refacturing.txt` at the repo root as the living architectural / SOLID / code-quality backlog. When you spot a new finding while working, append it (with file:line refs and a one-line direction) under the right severity bucket. When a refactor lands, move the entry to the *Resolved* section with the date and PR/commit, don't delete it. Update the "Last reviewed" stamp when you do a sweep. This file may be edited and pushed directly without asking.
+- Whenever you touch a file, opportunistically clean up dead code in it without being asked: empty `if TYPE_CHECKING: pass` blocks, unused imports, unreferenced variables, commented-out code, stale `# TODO` markers that no longer match the surrounding code, leftover debug prints. Don't make this a separate PR — fold it into whatever change you're already making. If a cleanup would balloon the diff or change behaviour, surface it instead of doing it silently.
 
 ## Pull Requests
 - When a pull request changes source code, increment the version number as part of the PR. Skip the bump for PRs that only touch docs, config, CI, or similar non-source changes.

--- a/doc/welcome.html
+++ b/doc/welcome.html
@@ -180,7 +180,7 @@
   <main class="content-col">
 
     <header class="hero">
-      <h1>Welcome to Stjörnhorn <span class="version">v0.2.34</span></h1>
+      <h1>Welcome to Stjörnhorn <span class="version">v0.2.36</span></h1>
       <div class="tagline">A node-based image- and video-processing playground.</div>
     </header>
 
@@ -210,6 +210,13 @@
           <p>Write frames to image files or encode video (MP4V, XVID) with live preview via the Display node.</p>
         </div>
       </div>
+    </section>
+
+    <section>
+      <h2>What's new in v0.2.36</h2>
+      <ul class="tips">
+        <li><strong>Type-checker hygiene in <code>core.port</code>.</strong> <code>IoDataType</code> is now imported (annotations referenced it but relied on <code>from __future__ import annotations</code> to stay quiet at runtime — Pylance flagged it as unresolved). Dropped a leftover empty <code>if TYPE_CHECKING: pass</code> block and the now-unused import. No behaviour change.</li>
+      </ul>
     </section>
 
     <section>

--- a/src/constants.py
+++ b/src/constants.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 APP_NAME:         str = "Image-Inquest"
 APP_DISPLAY_NAME: str = "Stjörnhorn"
-APP_VERSION:      str = "0.2.34"
+APP_VERSION:      str = "0.2.36"
 API_URL:    str = "https://beltoforion.de"
 
 # Path resolution -----------------------------------------------------------

--- a/src/core/port.py
+++ b/src/core/port.py
@@ -1,11 +1,8 @@
 from __future__ import annotations
 
-from typing import Callable, TYPE_CHECKING
+from typing import Callable
 
 from core.io_data import IoData, IoDataType
-
-if TYPE_CHECKING:
-    pass
 
 
 class InputPort:

--- a/src/core/port.py
+++ b/src/core/port.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Callable, TYPE_CHECKING
 
-from core.io_data import IoData
+from core.io_data import IoData, IoDataType
 
 if TYPE_CHECKING:
     pass


### PR DESCRIPTION
## Summary

Three small, related touches in `src/core/port.py` plus a new repository rule.

### Pylance fix
`InputPort` / `OutputPort` annotations reference `IoDataType` (`accepted_types: set[IoDataType]`, `frozenset[IoDataType]`, `emits: set[IoDataType]`, …) but the module only ever imported `IoData`. It worked at runtime because `from __future__ import annotations` keeps annotations as strings, but Pylance flagged it as unresolved. Added `IoDataType` to the existing import.

### Dead code removed
The module had a stale `if TYPE_CHECKING: pass` block (and the now-unused `TYPE_CHECKING` import) — leftover from an earlier import shape, carrying no symbols. Removed.

### CLAUDE.md rule
New guideline under *Code Quality and Maintainability*: opportunistic cleanup of dead code (empty `TYPE_CHECKING` blocks, unused imports, commented-out code, stale TODOs, leftover debug prints) is folded into whatever change is in flight rather than waiting to be asked. Triggered by exactly this round-trip — Pylance flagged the missing import, fix landed, *then* the empty block was noticed in a separate pass. The rule pulls that observation into the first pass next time.

### Why a separate PR (not folded into #216)
PR #216 is scoped to the M11 multi-listener API. The Pylance gap pre-dates M11 (the missing import has been in the file for a while), and the CLAUDE.md change is unrelated to the listener refactor. Splitting keeps #216's diff narrow.

## Version

- `APP_VERSION` → `0.2.36`. Source change in `src/core/port.py` (the `IoDataType` import, even though it has no runtime effect, is a `.py` edit). `0.2.35` is reserved for #216 if it lands first.
- `doc/welcome.html` and `CHANGELOG.md` updated to match.

## Test plan

- [x] All non-Qt tests touching `core.port` pass locally (`test_clamp`, `test_constant_value`, `test_directory_source`, `test_math`, `test_value_source` — 89 passed).
- [x] `python -c "from core.port import InputPort, OutputPort"` succeeds (annotations still resolve).
- [ ] CI green.


---
_Generated by [Claude Code](https://claude.ai/code/session_01NV9sVCSk2unLrc3bkEs5GE)_