### PR TITLE
feat(io_data): add IoDataType.DATASET payload — Datenkrake foundation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,21 @@ once a first tagged release is cut.
 
 ## [Unreleased]
 
+## [0.2.37] — 2026-04-29
+
+### Added
+- **Datenkrake foundation: ``IoDataType.DATASET`` payload.** New
+  payload kind on the ``IoData`` envelope that carries a
+  ``pandas.DataFrame``. Columns identify channels (``"time"``,
+  ``"Z"``, ``"N"``, ``"E"`` for seismic; ``"V"``, ``"I"`` for diode
+  I-V; etc.) and ``df.attrs`` carries free-form metadata
+  (``sample_rate``, ``units``, ``station``, …). One generic payload
+  kind serves every tabular domain so the same downstream nodes
+  compose across them. ``IoData.from_dataset(df)`` factory rejects
+  non-DataFrame input to keep the contract explicit. ``pandas`` added
+  to ``requirements.txt``. Issue: #219 (parent epic #218 — project
+  Datenkrake).
+
 ## [0.2.36] — 2026-04-29
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,7 @@
 - When a pull request changes source code, increment the version number as part of the PR. Skip the bump for PRs that only touch docs, config, CI, or similar non-source changes.
 - Whenever `APP_VERSION` in `src/constants.py` is bumped, also update the version references in `doc/welcome.html` (the `<span class="version">` in the hero header and the "What's new in …" heading) in the same PR. These are the user-facing "About / Welcome" surface and go stale silently otherwise.
 - Keep the PR description and the `CHANGELOG.md` entry in sync with what's actually on the branch. Whenever you add, remove, or rescope commits on a PR branch, update the PR title/body and the CHANGELOG so they reflect the branch's current state — not the PR's original proposal.
+- Claude may open pull requests autonomously when the change directly addresses an existing GitHub issue (Claude-filed or user-filed-and-explicitly-handed-off). Always reference the issue with `Fixes #N` / `Closes #N` in the PR body so it auto-closes on merge. For changes that don't tie to an existing issue, still wait for explicit permission before opening a PR.
 
 ## Branch Hygiene
 - Keep working branches regularly updated from the main branch (fetch + merge/rebase from `main`) while work is in progress.

--- a/doc/welcome.html
+++ b/doc/welcome.html
@@ -180,7 +180,7 @@
   <main class="content-col">
 
     <header class="hero">
-      <h1>Welcome to Stjörnhorn <span class="version">v0.2.36</span></h1>
+      <h1>Welcome to Stjörnhorn <span class="version">v0.2.37</span></h1>
       <div class="tagline">A node-based image- and video-processing playground.</div>
     </header>
 
@@ -210,6 +210,13 @@
           <p>Write frames to image files or encode video (MP4V, XVID) with live preview via the Display node.</p>
         </div>
       </div>
+    </section>
+
+    <section>
+      <h2>What's new in v0.2.37</h2>
+      <ul class="tips">
+        <li><strong>Datenkrake foundation: <code>IoDataType.DATASET</code> payload.</strong> A new payload kind on the <code>IoData</code> envelope that carries a <code>pandas.DataFrame</code>. Columns identify channels (e.g. <code>"time"</code>, <code>"Z"</code>, <code>"N"</code>, <code>"E"</code> for seismic; <code>"V"</code>, <code>"I"</code> for diode I-V) and <code>df.attrs</code> carries free-form metadata (sample rate, units, station, …). One generic payload kind serves every tabular domain so the same downstream nodes will compose across seismic, CV, and I-V flows. <code>IoData.from_dataset(df)</code> factory rejects non-DataFrame input. Foundation for project Datenkrake — see issues #218 / #219. <code>pandas</code> added to <code>requirements.txt</code>.</li>
+      </ul>
     </section>
 
     <section>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 rawpy
 numpy
+pandas
 opencv-python
 PySide6
 typing_extensions

--- a/src/constants.py
+++ b/src/constants.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 APP_NAME:         str = "Image-Inquest"
 APP_DISPLAY_NAME: str = "Stjörnhorn"
-APP_VERSION:      str = "0.2.36"
+APP_VERSION:      str = "0.2.37"
 API_URL:    str = "https://beltoforion.de"
 
 # Path resolution -----------------------------------------------------------

--- a/src/core/io_data.py
+++ b/src/core/io_data.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from typing import Any
 
 import numpy as np
+import pandas as pd
 
 
 class IoDataType(Enum):
@@ -12,6 +13,7 @@ class IoDataType(Enum):
     IMAGE_GREY = "ImageGrey"
     SCALAR = "Scalar"
     MATRIX = "Matrix"
+    DATASET = "Dataset"
     BOOL = "Bool"
     STRING = "String"
     ENUM = "Enum"
@@ -39,6 +41,12 @@ class IoData:
         as a Python scalar.
       - :data:`IoDataType.MATRIX` — a 2-D numpy array of arbitrary dtype
         and shape; treats a single value as a 1×1 matrix.
+      - :data:`IoDataType.DATASET` — a :class:`pandas.DataFrame` carrying
+        labeled tabular data (seismic traces, CV curves, diode I-V,
+        spectra, …). Column names identify channels; ``df.attrs`` carries
+        free-form metadata (sample rate, units, station, sweep direction,
+        …). One generic payload kind serves every domain so the same
+        nodes (``Trim``, ``Resample``, ``PlotXY``, …) compose across them.
       - :data:`IoDataType.BOOL` / :data:`IoDataType.STRING` /
         :data:`IoDataType.ENUM` / :data:`IoDataType.PATH` — non-numeric
         payloads stored as raw Python objects (``bool``, ``str``,
@@ -104,6 +112,27 @@ class IoData:
                 f"Matrix payload must be 2-d (ndim==2), got shape {arr.shape}"
             )
         return cls(IoDataType.MATRIX, payload=arr)
+
+    @classmethod
+    def from_dataset(cls, df: pd.DataFrame) -> IoData:
+        """Wrap a :class:`pandas.DataFrame` as :data:`IoDataType.DATASET`.
+
+        The DataFrame is stored verbatim — its columns identify channels
+        and ``df.attrs`` carries domain metadata (``sample_rate``,
+        ``units``, ``station``, ``sweep_dir``, …) that downstream nodes
+        consume. Stored by reference, so a producer that mutates the
+        DataFrame after sending will be visible to consumers; producers
+        that need isolation should ``df.copy()`` before wrapping.
+
+        Rejects non-DataFrame inputs to keep the contract explicit; a
+        consumer's ``data.payload`` is always a DataFrame.
+        """
+        if not isinstance(df, pd.DataFrame):
+            raise TypeError(
+                f"Dataset payload must be a pandas.DataFrame, "
+                f"got {type(df).__name__}"
+            )
+        return cls(IoDataType.DATASET, payload=df)
 
     @classmethod
     def from_bool(cls, value: object) -> IoData:

--- a/tests/test_io_data.py
+++ b/tests/test_io_data.py
@@ -112,6 +112,53 @@ def test_from_matrix_rejects_scalar() -> None:
         IoData.from_matrix(np.array(7))
 
 
+# ── Dataset payload ───────────────────────────────────────────────────────────
+
+import pandas as pd
+
+
+def test_from_dataset_round_trips_dataframe() -> None:
+    df = pd.DataFrame({"V": [0.0, 0.5, 1.0], "I": [0.0, 1e-3, 5e-3]})
+    data = IoData.from_dataset(df)
+    assert data.type is IoDataType.DATASET
+    assert data.payload is df
+    assert data.is_image() is False
+
+
+def test_from_dataset_preserves_attrs() -> None:
+    """``df.attrs`` is the metadata channel for sample_rate, units,
+    station, etc. Filters rely on it surviving the wrapping."""
+    df = pd.DataFrame({"Z": [1.0, 2.0]})
+    df.attrs["sample_rate"] = 100.0
+    df.attrs["units"] = {"Z": "m/s"}
+    data = IoData.from_dataset(df)
+    assert data.payload.attrs["sample_rate"] == 100.0
+    assert data.payload.attrs["units"] == {"Z": "m/s"}
+
+
+def test_from_dataset_rejects_non_dataframe() -> None:
+    with pytest.raises(TypeError, match="pandas.DataFrame"):
+        IoData.from_dataset(np.array([[1, 2], [3, 4]]))
+
+
+def test_from_dataset_rejects_dict() -> None:
+    """A dict is a common 'almost-a-DataFrame' miss; the factory rejects
+    rather than silently coercing so the producer's contract is explicit."""
+    with pytest.raises(TypeError, match="pandas.DataFrame"):
+        IoData.from_dataset({"V": [0.0, 1.0]})  # type: ignore[arg-type]
+
+
+def test_repr_includes_shape_for_dataset() -> None:
+    df = pd.DataFrame({"V": [0.0, 1.0, 2.0], "I": [0.0, 1.0, 2.0]})
+    r = repr(IoData.from_dataset(df))
+    assert "DATASET" in r
+    assert "(3, 2)" in r
+
+
+def test_dataset_not_in_image_types() -> None:
+    assert IoDataType.DATASET not in IMAGE_TYPES
+
+
 # ── repr / metadata ───────────────────────────────────────────────────────────
 
 def test_repr_includes_type_and_shape_for_scalar() -> None:


### PR DESCRIPTION
## Summary

- Adds `IoDataType.DATASET` to the `IoData` envelope, payload is a `pandas.DataFrame`. Columns identify channels; `df.attrs` carries domain metadata (sample rate, units, station, …) so downstream filters can self-validate without sidecar ports.
- `IoData.from_dataset(df)` factory rejects non-DataFrame input — explicit contract.
- `pandas` added to `requirements.txt`.
- Bumps `APP_VERSION` to 0.2.37; CHANGELOG + welcome.html updated.
- CLAUDE.md tweaks (folded in since CLAUDE.md edits are pushed directly per repo rules):
  - Allow Claude to open PRs autonomously when the change ties to an existing issue.
  - Auto-subscribe to any PR Claude opens, so CI / review activity streams into the session.

This is the foundation for project Datenkrake (epic #218). Once it lands, the next sub-issues (#220 `CsvSource`, #221 `PlotXY`, #222 `Hodogram`, #223 `StackImages`) can build on the new payload.

Closes #219.

## Test plan

- [ ] CI green on the new tests in `tests/test_io_data.py` (DataFrame round-trip, `attrs` preservation, non-DataFrame and dict rejection, `__repr__` shape, `IMAGE_TYPES` disjointness).
- [ ] Existing test suite still passes (no behavioural change to image / scalar / matrix payload paths).
- [ ] `pip install -r requirements.txt` resolves cleanly with `pandas` added.
- [ ] Welcome dialog shows v0.2.37 with the new "What's new" entry.

https://claude.ai/code/session_01VeUsCbRo2t78AbT1gi3B7S