### PR TITLE
feat(sources): add CsvSource — first DATASET producer (Datenkrake #220)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,22 @@ once a first tagged release is cut.
 
 ## [Unreleased]
 
+## [0.2.38] — 2026-04-29
+
+### Added
+- **Datenkrake: ``CsvSource`` node.** First end-to-end producer of
+  the new ``DATASET`` payload. Reads any CSV (seismic export,
+  instrument log, simulation output, …) into a ``pandas.DataFrame``
+  and stamps the resolved file path into ``df.attrs["source_path"]``
+  for downstream UI / error messages. Reactive — editing any
+  parameter re-runs the flow, matching ``ImageSource``'s UX.
+  Parameters: ``file_path`` (FilePathParam, INPUT_DIR-relative),
+  ``delimiter`` (default ``","``; type ``\\t`` for tab),
+  ``has_header`` (default True; off → synthetic ``c0``, ``c1``, …
+  column names), ``decimal`` (default ``"."``; set to ``","`` for
+  European decimals). Issue: #220 (parent epic #218 — project
+  Datenkrake).
+
 ## [0.2.37] — 2026-04-29
 
 ### Added

--- a/doc/welcome.html
+++ b/doc/welcome.html
@@ -180,7 +180,7 @@
   <main class="content-col">
 
     <header class="hero">
-      <h1>Welcome to Stjörnhorn <span class="version">v0.2.37</span></h1>
+      <h1>Welcome to Stjörnhorn <span class="version">v0.2.38</span></h1>
       <div class="tagline">A node-based image- and video-processing playground.</div>
     </header>
 
@@ -210,6 +210,13 @@
           <p>Write frames to image files or encode video (MP4V, XVID) with live preview via the Display node.</p>
         </div>
       </div>
+    </section>
+
+    <section>
+      <h2>What's new in v0.2.38</h2>
+      <ul class="tips">
+        <li><strong>Datenkrake: <code>CsvSource</code> node.</strong> First end-to-end producer of the new <code>DATASET</code> payload. Reads any CSV (seismic export, instrument log, simulation output, …) into a <code>pandas.DataFrame</code>, stamps the resolved path into <code>df.attrs["source_path"]</code>, and emits it on a <code>dataset</code> output. Parameters: <code>file_path</code>, <code>delimiter</code> (default <code>","</code>; type <code>\t</code> for tab; <code>;</code> for European-style CSVs), <code>has_header</code> (off → synthetic <code>c0</code>, <code>c1</code>, … names), <code>decimal</code> (set to <code>","</code> for European decimals). Reactive: editing any parameter re-runs the flow, matching <code>ImageSource</code>'s UX. Issue #220 / epic #218.</li>
+      </ul>
     </section>
 
     <section>

--- a/src/constants.py
+++ b/src/constants.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 APP_NAME:         str = "Image-Inquest"
 APP_DISPLAY_NAME: str = "Stjörnhorn"
-APP_VERSION:      str = "0.2.37"
+APP_VERSION:      str = "0.2.38"
 API_URL:    str = "https://beltoforion.de"
 
 # Path resolution -----------------------------------------------------------

--- a/src/nodes/sources/csv_source.py
+++ b/src/nodes/sources/csv_source.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+from typing_extensions import override
+
+from constants import INPUT_DIR
+from core.io_data import IoData, IoDataType
+from core.node_base import SourceNodeBase
+from core.params import BoolParam, FilePathParam, StringParam
+from core.path_utils import resolve_against
+from core.port import OutputPort
+
+#: Literal "\t" (two chars: backslash + t) that the user can type into
+#: the delimiter line-edit when they need a real tab. The widget can't
+#: easily emit a real tab character, so we expand the escape ourselves.
+_TAB_ESCAPE: str = "\\t"
+
+
+class CsvSource(SourceNodeBase):
+    """Source node that reads a CSV file as an :data:`IoDataType.DATASET`.
+
+    First end-to-end producer of the new ``DATASET`` payload — load any
+    CSV (seismic export, instrument log, simulation output, …) and the
+    rest of the data-flow nodes pick it up. The DataFrame's columns
+    identify channels and ``df.attrs["source_path"]`` records the
+    resolved file path so downstream nodes can include it in error
+    messages or UI hints.
+
+    Paths inside :data:`constants.INPUT_DIR` are stored — and therefore
+    displayed — relative to that folder, so saved flows stay portable
+    across machines that share the same input layout. Paths outside
+    are kept absolute. Resolution back to an absolute path happens at
+    run time.
+
+    This source is *reactive*: editing any parameter re-runs the flow
+    immediately, matching :class:`~nodes.sources.image_source.ImageSource`'s
+    UX.
+
+    Parameters:
+      file_path  -- path to the CSV (relative to INPUT_DIR when possible).
+      delimiter  -- column separator. Default ``","``. Type ``\\t`` for
+                    a tab; ``;`` for European-style CSVs is supported
+                    natively.
+      has_header -- when True (default), the first row is treated as
+                    column names. When False, columns get synthetic
+                    ``c0``, ``c1``, … names so downstream column
+                    selectors still have something to bind to.
+      decimal    -- decimal separator inside numeric cells. Default
+                    ``"."``; set to ``","`` for European decimals.
+    """
+
+    file_path = FilePathParam(
+        "data.csv",
+        constant=True,
+        filter="CSV (*.csv);;Text (*.txt);;All files (*)",
+        base_dir=INPUT_DIR,
+        description=(
+            "Path to the CSV file. Paths inside the input folder are "
+            "stored relative to it so the flow stays portable."
+        ),
+    )
+
+    delimiter = StringParam(
+        ",",
+        constant=True,
+        max_length=4,
+        description=(
+            "Column separator. Default is comma. Type \\t for a tab, "
+            "or ; for European-style CSVs."
+        ),
+    )
+
+    has_header = BoolParam(
+        True,
+        constant=True,
+        description=(
+            "When checked, the first row is read as column names. "
+            "Otherwise columns are auto-named c0, c1, c2, …"
+        ),
+    )
+
+    decimal = StringParam(
+        ".",
+        constant=True,
+        max_length=1,
+        description=(
+            "Decimal separator inside numeric cells. Set to ',' for "
+            "European decimals; defaults to '.'."
+        ),
+    )
+
+    def __init__(self) -> None:
+        super().__init__("CSV Source", section="Sources")
+        self._add_output(OutputPort("dataset", {IoDataType.DATASET}))
+        self._apply_default_params()
+
+    @property
+    @override
+    def is_reactive(self) -> bool:
+        return True
+
+    @override
+    def process_impl(self) -> None:
+        resolved = self._resolved_path()
+        if not resolved.exists():
+            raise FileNotFoundError(f"CSV file not found: {resolved}")
+
+        sep = self._delimiter.replace(_TAB_ESCAPE, "\t") if self._delimiter else ","
+        header_row: int | None = 0 if self._has_header else None
+
+        df = pd.read_csv(
+            resolved,
+            sep=sep,
+            header=header_row,
+            decimal=self._decimal,
+        )
+
+        if not self._has_header:
+            # pandas auto-assigns 0,1,2,... as column names when
+            # header=None; rename to c0,c1,c2 so a downstream
+            # SelectColumns node can bind to something more meaningful
+            # than a bare integer.
+            df.columns = [f"c{i}" for i in range(len(df.columns))]
+
+        df.attrs["source_path"] = str(resolved)
+        self.outputs[0].send(IoData.from_dataset(df))
+
+    def _resolved_path(self) -> Path:
+        """Return an absolute path; relative values are joined with INPUT_DIR."""
+        return resolve_against(self._file_path, INPUT_DIR)

--- a/tests/test_csv_source.py
+++ b/tests/test_csv_source.py
@@ -1,0 +1,136 @@
+"""Tests for the :class:`~nodes.sources.csv_source.CsvSource` node."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from core.io_data import IoDataType
+from nodes.sources.csv_source import CsvSource
+
+
+def _run(node: CsvSource) -> pd.DataFrame:
+    """Drive ``node.process()`` once and return the emitted DataFrame."""
+    node.process()
+    out = node.outputs[0].last_emitted
+    assert out is not None, "CsvSource did not emit"
+    assert out.type is IoDataType.DATASET
+    return out.payload
+
+
+def _write_csv(path: Path, content: str) -> Path:
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+# ── Basic round-trip ──────────────────────────────────────────────────────────
+
+def test_emits_dataset_for_simple_csv(tmp_path: Path) -> None:
+    csv = _write_csv(tmp_path / "trace.csv", "t,Z\n0.0,1.0\n0.1,2.0\n0.2,3.0\n")
+    node = CsvSource()
+    node.file_path = str(csv)
+
+    df = _run(node)
+
+    assert list(df.columns) == ["t", "Z"]
+    assert df.shape == (3, 2)
+    assert df["Z"].tolist() == [1.0, 2.0, 3.0]
+
+
+def test_source_path_recorded_in_attrs(tmp_path: Path) -> None:
+    """Downstream nodes need to know where the data came from for
+    error messages and UI captions; CsvSource stamps it into ``attrs``."""
+    csv = _write_csv(tmp_path / "log.csv", "a,b\n1,2\n")
+    node = CsvSource()
+    node.file_path = str(csv)
+
+    df = _run(node)
+
+    assert df.attrs["source_path"] == str(csv)
+
+
+# ── Header handling ───────────────────────────────────────────────────────────
+
+def test_no_header_synthesizes_column_names(tmp_path: Path) -> None:
+    csv = _write_csv(tmp_path / "raw.csv", "1,2,3\n4,5,6\n")
+    node = CsvSource()
+    node.file_path = str(csv)
+    node.has_header = False
+
+    df = _run(node)
+
+    assert list(df.columns) == ["c0", "c1", "c2"]
+    assert df.shape == (2, 3)
+
+
+def test_with_header_takes_first_row_as_names(tmp_path: Path) -> None:
+    csv = _write_csv(tmp_path / "named.csv", "voltage,current\n0.0,0.0\n1.0,0.001\n")
+    node = CsvSource()
+    node.file_path = str(csv)
+
+    df = _run(node)
+
+    assert list(df.columns) == ["voltage", "current"]
+    assert len(df) == 2
+
+
+# ── Delimiter handling ────────────────────────────────────────────────────────
+
+def test_semicolon_delimiter(tmp_path: Path) -> None:
+    csv = _write_csv(tmp_path / "eu.csv", "a;b\n1;2\n3;4\n")
+    node = CsvSource()
+    node.file_path = str(csv)
+    node.delimiter = ";"
+
+    df = _run(node)
+
+    assert list(df.columns) == ["a", "b"]
+    assert df.iloc[1].tolist() == [3, 4]
+
+
+def test_tab_delimiter_via_backslash_t(tmp_path: Path) -> None:
+    """The widget can't easily emit a real tab character, so the user
+    types ``\\t`` literally and CsvSource expands the escape."""
+    csv = _write_csv(tmp_path / "tsv.csv", "x\ty\n1\t2\n")
+    node = CsvSource()
+    node.file_path = str(csv)
+    node.delimiter = "\\t"  # two-char string: backslash + t
+
+    df = _run(node)
+
+    assert list(df.columns) == ["x", "y"]
+    assert df.iloc[0].tolist() == [1, 2]
+
+
+# ── Decimal separator ─────────────────────────────────────────────────────────
+
+def test_european_decimal_separator(tmp_path: Path) -> None:
+    csv = _write_csv(tmp_path / "eu_dec.csv", "v;i\n0,5;1,25\n")
+    node = CsvSource()
+    node.file_path = str(csv)
+    node.delimiter = ";"
+    node.decimal = ","
+
+    df = _run(node)
+
+    assert df["v"].iloc[0] == pytest.approx(0.5)
+    assert df["i"].iloc[0] == pytest.approx(1.25)
+
+
+# ── Error paths ───────────────────────────────────────────────────────────────
+
+def test_missing_file_raises_file_not_found(tmp_path: Path) -> None:
+    node = CsvSource()
+    node.file_path = str(tmp_path / "does_not_exist.csv")
+
+    with pytest.raises(FileNotFoundError, match="CSV file not found"):
+        node.process()
+
+
+# ── Reactivity contract ───────────────────────────────────────────────────────
+
+def test_is_reactive(tmp_path: Path) -> None:
+    """File sources are one-shot: the editor re-runs the flow on any
+    parameter edit, same UX as :class:`ImageSource`."""
+    assert CsvSource().is_reactive is True


### PR DESCRIPTION
## Summary

Adds `CsvSource` — the first end-to-end producer of the new `DATASET` payload landed in #224. Reads any CSV (seismic export, instrument log, simulation output, …) into a `pandas.DataFrame`, stamps the resolved path into `df.attrs["source_path"]`, and emits it on a `dataset` output port.

**Stacked on #224** (target branch is `claude/plan-earthquake-nodes-Y1RFL` because `main` doesn't have `IoDataType.DATASET` yet). Once #224 merges I'll rebase this onto `main` and retarget the base.

Parameters:

- `file_path` — FilePathParam, INPUT_DIR-relative so saved flows stay portable.
- `delimiter` — default `","`. Type `\t` for tab; `;` works natively for European CSVs.
- `has_header` — default True. When off, columns get synthetic `c0`, `c1`, … names so downstream column selectors still have something to bind to.
- `decimal` — default `"."`. Set to `","` for European decimals.

Bumps `APP_VERSION` to 0.2.38; CHANGELOG + welcome.html updated.

Closes #220.

## Test plan

- [ ] CI green on the new tests in `tests/test_csv_source.py`:
  - simple round-trip (DataFrame shape, column names, values)
  - `attrs["source_path"]` recorded
  - header on/off (synthetic c0/c1/c2 when off)
  - delimiter `;` (European CSV)
  - delimiter `\t` via the typed `\\t` escape
  - European decimal separator `","`
  - missing file raises `FileNotFoundError`
  - `is_reactive` is True
- [ ] Drop a `CsvSource` in the editor; the file picker filters to `*.csv`.
- [ ] Editing a parameter re-runs the flow without a manual Run click.

https://claude.ai/code/session_01VeUsCbRo2t78AbT1gi3B7S

---
_Generated by [Claude Code](https://claude.ai/code/session_01VeUsCbRo2t78AbT1gi3B7S)_