### PR TITLE
Add CsvSource node for loading CSV files as datasets

### DIFF
--- a/src/nodes/sources/csv_source.py
+++ b/src/nodes/sources/csv_source.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+from typing_extensions import override
+
+from constants import INPUT_DIR
+from core.io_data import IoData, IoDataType
+from core.node_base import SourceNodeBase
+from core.params import BoolParam, FilePathParam, StringParam
+from core.path_utils import resolve_against
+from core.port import OutputPort
+
+#: Literal "\t" (two chars: backslash + t) that the user can type into
+#: the delimiter line-edit when they need a real tab. The widget can't
+#: easily emit a real tab character, so we expand the escape ourselves.
+_TAB_ESCAPE: str = "\\t"
+
+#: Lines beginning with this character are skipped when reading the CSV.
+#: Hard-coded rather than configurable so file formats that put a metadata
+#: line on top (e.g. seismic ASCII traces with a ``# stat … samp …`` header,
+#: gnuplot output, many instrument-log dumps) load without a node-level
+#: parameter twist. Free-form ``#`` comments inside the data section are
+#: vanishingly rare; opt-out can be added later via a param if a real
+#: file demands it.
+_COMMENT_CHAR: str = "#"
+
+
+class CsvSource(SourceNodeBase):
+    """Source node that reads a CSV file as an :data:`IoDataType.DATASET`.
+
+    First end-to-end producer of the new ``DATASET`` payload — load any
+    CSV (seismic export, instrument log, simulation output, …) and the
+    rest of the data-flow nodes pick it up. The DataFrame's columns
+    identify channels and ``df.attrs["source_path"]`` records the
+    resolved file path so downstream nodes can include it in error
+    messages or UI hints.
+
+    Paths inside :data:`constants.INPUT_DIR` are stored — and therefore
+    displayed — relative to that folder, so saved flows stay portable
+    across machines that share the same input layout. Paths outside
+    are kept absolute. Resolution back to an absolute path happens at
+    run time.
+
+    This source is *reactive*: editing any parameter re-runs the flow
+    immediately, matching :class:`~nodes.sources.image_source.ImageSource`'s
+    UX.
+
+    Lines beginning with ``#`` are always skipped, so files that lead
+    with a metadata header line (seismic ASCII traces with
+    ``# stat … samp …``, gnuplot output, many instrument-log dumps)
+    load without any extra configuration — the data section starts on
+    the first non-``#`` line.
+
+    Parameters:
+      file_path  -- path to the CSV (relative to INPUT_DIR when possible).
+      delimiter  -- column separator. Default ``","``. Type ``\\t`` for
+                    a tab; ``;`` for European-style CSVs is supported
+                    natively.
+      has_header -- when True (default), the first row is treated as
+                    column names. When False, columns get synthetic
+                    ``c0``, ``c1``, … names so downstream column
+                    selectors still have something to bind to.
+      decimal    -- decimal separator inside numeric cells. Default
+                    ``"."``; set to ``","`` for European decimals.
+    """
+
+    file_path = FilePathParam(
+        "data.csv",
+        constant=True,
+        filter="CSV (*.csv);;Text (*.txt);;All files (*)",
+        base_dir=INPUT_DIR,
+        description=(
+            "Path to the CSV file. Paths inside the input folder are "
+            "stored relative to it so the flow stays portable."
+        ),
+    )
+
+    delimiter = StringParam(
+        ",",
+        constant=True,
+        max_length=4,
+        description=(
+            "Column separator. Default is comma. Type \\t for a tab, "
+            "or ; for European-style CSVs."
+        ),
+    )
+
+    has_header = BoolParam(
+        True,
+        constant=True,
+        description=(
+            "When checked, the first row is read as column names. "
+            "Otherwise columns are auto-named c0, c1, c2, …"
+        ),
+    )
+
+    decimal = StringParam(
+        ".",
+        constant=True,
+        max_length=1,
+        description=(
+            "Decimal separator inside numeric cells. Set to ',' for "
+            "European decimals; defaults to '.'."
+        ),
+    )
+
+    def __init__(self) -> None:
+        super().__init__("CSV Source", section="Sources")
+        self._add_output(OutputPort("dataset", {IoDataType.DATASET}))
+        self._apply_default_params()
+
+    @property
+    @override
+    def is_reactive(self) -> bool:
+        return True
+
+    @override
+    def process_impl(self) -> None:
+        resolved = self._resolved_path()
+        if not resolved.exists():
+            raise FileNotFoundError(f"CSV file not found: {resolved}")
+
+        sep = self._delimiter.replace(_TAB_ESCAPE, "\t") if self._delimiter else ","
+        header_row: int | None = 0 if self._has_header else None
+
+        df = pd.read_csv(
+            resolved,
+            sep=sep,
+            header=header_row,
+            decimal=self._decimal,
+            comment=_COMMENT_CHAR,
+        )
+
+        if not self._has_header:
+            # pandas auto-assigns 0,1,2,... as column names when
+            # header=None; rename to c0,c1,c2 so a downstream
+            # SelectColumns node can bind to something more meaningful
+            # than a bare integer.
+            df.columns = [f"c{i}" for i in range(len(df.columns))]
+
+        df.attrs["source_path"] = str(resolved)
+        self.outputs[0].send(IoData.from_dataset(df))
+
+    def _resolved_path(self) -> Path:
+        """Return an absolute path; relative values are joined with INPUT_DIR."""
+        return resolve_against(self._file_path, INPUT_DIR)

--- a/tests/test_csv_source.py
+++ b/tests/test_csv_source.py
@@ -1,0 +1,197 @@
+"""Tests for the :class:`~nodes.sources.csv_source.CsvSource` node."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from core.io_data import IoDataType
+from nodes.sources.csv_source import CsvSource
+
+
+def _run(node: CsvSource) -> pd.DataFrame:
+    """Drive ``node.process()`` once and return the emitted DataFrame."""
+    node.process()
+    out = node.outputs[0].last_emitted
+    assert out is not None, "CsvSource did not emit"
+    assert out.type is IoDataType.DATASET
+    return out.payload
+
+
+def _write_csv(path: Path, content: str) -> Path:
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+# ── Basic round-trip ──────────────────────────────────────────────────────────
+
+def test_emits_dataset_for_simple_csv(tmp_path: Path) -> None:
+    csv = _write_csv(tmp_path / "trace.csv", "t,Z\n0.0,1.0\n0.1,2.0\n0.2,3.0\n")
+    node = CsvSource()
+    node.file_path = str(csv)
+
+    df = _run(node)
+
+    assert list(df.columns) == ["t", "Z"]
+    assert df.shape == (3, 2)
+    assert df["Z"].tolist() == [1.0, 2.0, 3.0]
+
+
+def test_source_path_recorded_in_attrs(tmp_path: Path) -> None:
+    """Downstream nodes need to know where the data came from for
+    error messages and UI captions; CsvSource stamps it into ``attrs``."""
+    csv = _write_csv(tmp_path / "log.csv", "a,b\n1,2\n")
+    node = CsvSource()
+    node.file_path = str(csv)
+
+    df = _run(node)
+
+    assert df.attrs["source_path"] == str(csv)
+
+
+# ── Header handling ───────────────────────────────────────────────────────────
+
+def test_no_header_synthesizes_column_names(tmp_path: Path) -> None:
+    csv = _write_csv(tmp_path / "raw.csv", "1,2,3\n4,5,6\n")
+    node = CsvSource()
+    node.file_path = str(csv)
+    node.has_header = False
+
+    df = _run(node)
+
+    assert list(df.columns) == ["c0", "c1", "c2"]
+    assert df.shape == (2, 3)
+
+
+def test_with_header_takes_first_row_as_names(tmp_path: Path) -> None:
+    csv = _write_csv(tmp_path / "named.csv", "voltage,current\n0.0,0.0\n1.0,0.001\n")
+    node = CsvSource()
+    node.file_path = str(csv)
+
+    df = _run(node)
+
+    assert list(df.columns) == ["voltage", "current"]
+    assert len(df) == 2
+
+
+# ── Delimiter handling ────────────────────────────────────────────────────────
+
+def test_semicolon_delimiter(tmp_path: Path) -> None:
+    csv = _write_csv(tmp_path / "eu.csv", "a;b\n1;2\n3;4\n")
+    node = CsvSource()
+    node.file_path = str(csv)
+    node.delimiter = ";"
+
+    df = _run(node)
+
+    assert list(df.columns) == ["a", "b"]
+    assert df.iloc[1].tolist() == [3, 4]
+
+
+def test_tab_delimiter_via_backslash_t(tmp_path: Path) -> None:
+    """The widget can't easily emit a real tab character, so the user
+    types ``\\t`` literally and CsvSource expands the escape."""
+    csv = _write_csv(tmp_path / "tsv.csv", "x\ty\n1\t2\n")
+    node = CsvSource()
+    node.file_path = str(csv)
+    node.delimiter = "\\t"  # two-char string: backslash + t
+
+    df = _run(node)
+
+    assert list(df.columns) == ["x", "y"]
+    assert df.iloc[0].tolist() == [1, 2]
+
+
+# ── Decimal separator ─────────────────────────────────────────────────────────
+
+def test_european_decimal_separator(tmp_path: Path) -> None:
+    csv = _write_csv(tmp_path / "eu_dec.csv", "v;i\n0,5;1,25\n")
+    node = CsvSource()
+    node.file_path = str(csv)
+    node.delimiter = ";"
+    node.decimal = ","
+
+    df = _run(node)
+
+    assert df["v"].iloc[0] == pytest.approx(0.5)
+    assert df["i"].iloc[0] == pytest.approx(1.25)
+
+
+# ── Error paths ───────────────────────────────────────────────────────────────
+
+def test_missing_file_raises_file_not_found(tmp_path: Path) -> None:
+    node = CsvSource()
+    node.file_path = str(tmp_path / "does_not_exist.csv")
+
+    with pytest.raises(FileNotFoundError, match="CSV file not found"):
+        node.process()
+
+
+# ── Comment-line handling ('#' is always skipped) ────────────────────────────
+
+def test_skips_hash_prefixed_metadata_header(tmp_path: Path) -> None:
+    """Files like the quake ASCII traces lead with a ``# key value …``
+    metadata line. CsvSource must skip it so the data section loads
+    without any extra configuration."""
+    csv = _write_csv(
+        tmp_path / "trace.001",
+        "# stat 417 comp 0 samp 8.0 ndat 3 start 2000-09-08 11:39:51\n"
+        "-6.41875e-07\n"
+        "-9.0625e-08\n"
+        "9.375e-08\n",
+    )
+    node = CsvSource()
+    node.file_path = str(csv)
+    node.has_header = False
+
+    df = _run(node)
+
+    assert list(df.columns) == ["c0"]
+    assert df.shape == (3, 1)
+    assert df["c0"].iloc[0] == pytest.approx(-6.41875e-07)
+
+
+def test_skips_hash_prefixed_lines_anywhere(tmp_path: Path) -> None:
+    """``#`` is a comment marker, not just a header marker — pandas
+    skips matching lines wherever they appear."""
+    csv = _write_csv(
+        tmp_path / "noisy.csv",
+        "x,y\n"
+        "1,2\n"
+        "# inline comment\n"
+        "3,4\n",
+    )
+    node = CsvSource()
+    node.file_path = str(csv)
+
+    df = _run(node)
+
+    assert list(df["x"]) == [1, 3]
+    assert list(df["y"]) == [2, 4]
+
+
+def test_loads_real_quake_sample_when_present() -> None:
+    """End-to-end smoke test against the bundled seismic ASCII trace
+    — only runs if the file is checked in (``input/quakedata/``)."""
+    project_root = Path(__file__).resolve().parent.parent
+    sample = project_root / "input" / "quakedata" / "quake_eib_20000908_1139.001"
+    if not sample.exists():
+        pytest.skip("quake sample not present; skipping real-file smoke test")
+
+    node = CsvSource()
+    node.file_path = str(sample)
+    node.has_header = False
+
+    df = _run(node)
+
+    assert df.shape == (5652, 1), f"unexpected shape {df.shape}"
+    assert df["c0"].iloc[0] == pytest.approx(-6.41875e-07)
+
+
+# ── Reactivity contract ───────────────────────────────────────────────────────
+
+def test_is_reactive(tmp_path: Path) -> None:
+    """File sources are one-shot: the editor re-runs the flow on any
+    parameter edit, same UX as :class:`ImageSource`."""
+    assert CsvSource().is_reactive is True


### PR DESCRIPTION
## Summary
Introduces `CsvSource`, a new source node that reads CSV files and emits them as `DATASET` payloads for downstream processing. This is the first end-to-end producer of the new `DATASET` data type in the node system.

## Key Changes
- **New `CsvSource` node** (`src/nodes/sources/csv_source.py`):
  - Reads CSV files with configurable delimiters (comma, semicolon, tab via `\t` escape)
  - Supports both header and headerless CSV formats (auto-generates `c0`, `c1`, … column names when needed)
  - Handles European-style decimals (`,` separator) via the `decimal` parameter
  - Automatically skips lines beginning with `#` to support metadata headers in seismic ASCII traces and other instrument logs
  - Records the resolved file path in `df.attrs["source_path"]` for downstream error messages and UI hints
  - Stores relative paths (within `INPUT_DIR`) to keep flows portable across machines
  - Implements reactive behavior (re-runs on parameter edits, matching `ImageSource` UX)

- **Comprehensive test suite** (`tests/test_csv_source.py`):
  - Basic round-trip tests for simple CSV loading and source path attribution
  - Header handling tests (with/without headers, synthetic column naming)
  - Delimiter tests (comma, semicolon, tab via escape sequence)
  - Decimal separator tests (European-style decimals)
  - Error path tests (missing file handling)
  - Comment-line handling tests (hash-prefixed metadata and inline comments)
  - Real-file smoke test against bundled seismic ASCII trace sample
  - Reactivity contract verification

## Notable Implementation Details
- Uses `pandas.read_csv()` with `comment="#"` parameter to skip metadata headers transparently
- Expands the `\t` escape sequence to a real tab character since UI widgets can't easily emit literal tabs
- All parameters are marked `constant=True` to trigger flow re-execution on edits
- Paths are resolved at runtime via `resolve_against()` to support both relative and absolute paths

https://claude.ai/code/session_01VeUsCbRo2t78AbT1gi3B7S