### PR TITLE
feat(sources): re-land CsvSource with `#` comment-line handling (Datenkrake #220)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,26 @@ once a first tagged release is cut.
 
 ## [Unreleased]
 
+## [0.2.38] — 2026-04-29
+
+### Added
+- **Datenkrake: ``CsvSource`` node.** First end-to-end producer of
+  the new ``DATASET`` payload. Reads any CSV (seismic export,
+  instrument log, simulation output, …) into a ``pandas.DataFrame``
+  and stamps the resolved file path into ``df.attrs["source_path"]``
+  for downstream UI / error messages. Reactive — editing any
+  parameter re-runs the flow, matching ``ImageSource``'s UX.
+  Parameters: ``file_path`` (FilePathParam, INPUT_DIR-relative),
+  ``delimiter`` (default ``","``; type ``\\t`` for tab),
+  ``has_header`` (default True; off → synthetic ``c0``, ``c1``, …
+  column names), ``decimal`` (default ``"."``; set to ``","`` for
+  European decimals). Lines beginning with ``#`` are always treated
+  as comments and skipped, so files that lead with a metadata header
+  (seismic ASCII traces, gnuplot output, instrument logs) load
+  without configuration. Issue: #220 (parent epic #218 — project
+  Datenkrake). Re-lands #220 after the original PR #225 merged into
+  the now-deleted feature branch instead of ``main``.
+
 ## [0.2.37] — 2026-04-29
 
 ### Added

--- a/doc/welcome.html
+++ b/doc/welcome.html
@@ -180,7 +180,7 @@
   <main class="content-col">
 
     <header class="hero">
-      <h1>Welcome to Stjörnhorn <span class="version">v0.2.37</span></h1>
+      <h1>Welcome to Stjörnhorn <span class="version">v0.2.38</span></h1>
       <div class="tagline">A node-based image- and video-processing playground.</div>
     </header>
 
@@ -210,6 +210,13 @@
           <p>Write frames to image files or encode video (MP4V, XVID) with live preview via the Display node.</p>
         </div>
       </div>
+    </section>
+
+    <section>
+      <h2>What's new in v0.2.38</h2>
+      <ul class="tips">
+        <li><strong>Datenkrake: <code>CsvSource</code> node.</strong> First end-to-end producer of the new <code>DATASET</code> payload. Reads any CSV into a <code>pandas.DataFrame</code>, stamps the resolved path into <code>df.attrs["source_path"]</code>, and emits it on a <code>dataset</code> output. Parameters: <code>file_path</code>, <code>delimiter</code> (default <code>","</code>; type <code>\t</code> for tab; <code>;</code> for European-style CSVs), <code>has_header</code> (off → synthetic <code>c0</code>, <code>c1</code>, … names), <code>decimal</code> (set to <code>","</code> for European decimals). Lines beginning with <code>#</code> are always skipped, so files with a metadata header (seismic ASCII traces, gnuplot output, instrument logs) load without configuration. Reactive: editing any parameter re-runs the flow. Issue #220 / epic #218.</li>
+      </ul>
     </section>
 
     <section>

--- a/src/constants.py
+++ b/src/constants.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 APP_NAME:         str = "Image-Inquest"
 APP_DISPLAY_NAME: str = "Stjörnhorn"
-APP_VERSION:      str = "0.2.37"
+APP_VERSION:      str = "0.2.38"
 API_URL:    str = "https://beltoforion.de"
 
 # Path resolution -----------------------------------------------------------


### PR DESCRIPTION
## Summary

Re-lands the `CsvSource` node from the original PR #225, which merged into the now-deleted `claude/plan-earthquake-nodes-Y1RFL` feature branch instead of `main` and so never reached the trunk. Adds one behavioural change on top: lines beginning with `#` are always treated as comments and skipped, so files with a metadata header (seismic ASCII traces like the new `input/quakedata/quake_eib_*.001`, gnuplot output, many instrument-log dumps) load without any node-level configuration.

Hard-coded as a comment char rather than a configurable param — free-form `#` inside the data section is vanishingly rare; opt-out can be added later if a real file demands it.

`CsvSource` parameters:

- `file_path` — FilePathParam, INPUT_DIR-relative for portable saved flows.
- `delimiter` — default `","`. Type `\t` for tab; `;` works natively.
- `has_header` — default True. When off, columns get synthetic `c0`, `c1`, … names.
- `decimal` — default `"."`. Set to `","` for European decimals.

Bumps `APP_VERSION` to 0.2.38; CHANGELOG + welcome.html updated.

Closes #220.

## Test plan

- [ ] CI green on `tests/test_csv_source.py`:
  - simple round-trip, header on/off, semicolon delimiter, tab via `\\t`, European decimals
  - missing file → `FileNotFoundError`
  - **NEW:** `#`-prefixed metadata header is skipped (synthetic-name path)
  - **NEW:** inline `#` comment lines are skipped mid-file
  - **NEW:** smoke test loads the real `input/quakedata/quake_eib_20000908_1139.001` (5652 samples, first value `-6.41875e-07`); skips gracefully if the file isn't checked in
- [ ] Drop a `CsvSource` in the editor; the file picker filters to `*.csv` / `*.txt`.
- [ ] Editing a parameter re-runs the flow without a manual Run click.

https://claude.ai/code/session_01VeUsCbRo2t78AbT1gi3B7S

---
_Generated by [Claude Code](https://claude.ai/code/session_01VeUsCbRo2t78AbT1gi3B7S)_