### PR TITLE
feat(filters): add PlotXY renderer — Dataset → IMAGE (Datenkrake #221)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,25 @@ once a first tagged release is cut.
 
 ## [Unreleased]
 
+## [0.2.39] — 2026-04-29
+
+### Added
+- **Datenkrake: ``PlotXY`` renderer.** New filter node that turns two
+  columns of a ``DATASET`` into a labeled XY line plot (3-channel BGR
+  image), so any ``Dataset`` flow can produce a viewer-ready picture
+  without leaving the graph. Single piece of code covers waveforms,
+  CV curves, diode I-V, spectra and any other "Y vs X" view —
+  Datenkrake's payoff for keeping the payload generic. Parameters:
+  ``x_column`` / ``y_column`` (empty → first / second columns of the
+  input), ``width`` / ``height`` in pixels (≥ 64), optional ``title``,
+  ``grid`` toggle. Axis labels include the column unit when the
+  upstream stamps a ``df.attrs["units"]`` dict (``"V [V]"`` etc.).
+  Renders off-screen via matplotlib's ``Agg`` backend and always
+  closes the figure on exit, including error paths, so a
+  long-running flow doesn't leak figures across frames. Adds
+  ``matplotlib`` to ``requirements.txt``. Issue: #221 (parent
+  epic #218 — project Datenkrake).
+
 ## [0.2.38] — 2026-04-29
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ once a first tagged release is cut.
 
 ## [Unreleased]
 
+## [0.2.40] — 2026-04-29
+
+### Added
+- **``PlotXY``: single-column Datasets plot against the row index.**
+  A one-column ``DATASET`` (e.g. a seismic ASCII trace loaded by
+  ``CsvSource`` with ``has_header=False``) now renders out of the box
+  with the default settings — X axis is the sample number, Y axis is
+  the only column. Multi-column behaviour is unchanged. New
+  ``x_column = "_index"`` sentinel forces row-index X regardless of
+  column count, useful for picking one column out of a wide Dataset
+  and viewing it against position. Issue: #231.
+
 ## [0.2.39] — 2026-04-29
 
 ### Added

--- a/doc/welcome.html
+++ b/doc/welcome.html
@@ -180,7 +180,7 @@
   <main class="content-col">
 
     <header class="hero">
-      <h1>Welcome to Stjörnhorn <span class="version">v0.2.39</span></h1>
+      <h1>Welcome to Stjörnhorn <span class="version">v0.2.40</span></h1>
       <div class="tagline">A node-based image- and video-processing playground.</div>
     </header>
 
@@ -210,6 +210,13 @@
           <p>Write frames to image files or encode video (MP4V, XVID) with live preview via the Display node.</p>
         </div>
       </div>
+    </section>
+
+    <section>
+      <h2>What's new in v0.2.40</h2>
+      <ul class="tips">
+        <li><strong><code>PlotXY</code>: single-column Datasets plot against the row index.</strong> A one-column <code>DATASET</code> (e.g. a seismic ASCII trace loaded with <code>has_header=False</code>) now renders out of the box — X axis is the sample number, Y axis is the only column. Multi-column behaviour is unchanged. New <code>x_column = "_index"</code> sentinel forces row-index X regardless of column count, useful for picking one column out of a wide Dataset and viewing it against position. Issue #231.</li>
+      </ul>
     </section>
 
     <section>

--- a/doc/welcome.html
+++ b/doc/welcome.html
@@ -180,7 +180,7 @@
   <main class="content-col">
 
     <header class="hero">
-      <h1>Welcome to Stjörnhorn <span class="version">v0.2.38</span></h1>
+      <h1>Welcome to Stjörnhorn <span class="version">v0.2.39</span></h1>
       <div class="tagline">A node-based image- and video-processing playground.</div>
     </header>
 
@@ -210,6 +210,13 @@
           <p>Write frames to image files or encode video (MP4V, XVID) with live preview via the Display node.</p>
         </div>
       </div>
+    </section>
+
+    <section>
+      <h2>What's new in v0.2.39</h2>
+      <ul class="tips">
+        <li><strong>Datenkrake: <code>PlotXY</code> renderer.</strong> New filter node that turns two columns of a <code>DATASET</code> into a labeled XY line plot (3-channel BGR image) so any <code>Dataset</code> flow can produce a viewer-ready picture without leaving the graph. One node covers waveforms, CV curves, diode I-V, spectra and any other "Y vs X" view — the payoff for keeping the payload generic. Parameters: <code>x_column</code> / <code>y_column</code> (empty → first / second columns), <code>width</code> / <code>height</code> in pixels, optional <code>title</code>, <code>grid</code> toggle. Axis labels include the column unit when the upstream stamps a <code>df.attrs["units"]</code> dict (<code>"V [V]"</code> etc.). Renders off-screen via matplotlib's <code>Agg</code> backend and always closes the figure on exit. <code>matplotlib</code> added to <code>requirements.txt</code>. Issue #221 / epic #218.</li>
+      </ul>
     </section>
 
     <section>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 rawpy
 numpy
 pandas
+matplotlib
 opencv-python
 PySide6
 typing_extensions

--- a/src/constants.py
+++ b/src/constants.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 APP_NAME:         str = "Image-Inquest"
 APP_DISPLAY_NAME: str = "Stjörnhorn"
-APP_VERSION:      str = "0.2.39"
+APP_VERSION:      str = "0.2.40"
 API_URL:    str = "https://beltoforion.de"
 
 # Path resolution -----------------------------------------------------------

--- a/src/constants.py
+++ b/src/constants.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 APP_NAME:         str = "Image-Inquest"
 APP_DISPLAY_NAME: str = "Stjörnhorn"
-APP_VERSION:      str = "0.2.38"
+APP_VERSION:      str = "0.2.39"
 API_URL:    str = "https://beltoforion.de"
 
 # Path resolution -----------------------------------------------------------

--- a/src/nodes/filters/plot_xy.py
+++ b/src/nodes/filters/plot_xy.py
@@ -1,0 +1,199 @@
+from __future__ import annotations
+
+# Switch matplotlib to the off-screen Agg backend BEFORE pyplot is
+# imported anywhere in the module — this keeps figure rendering
+# self-contained and prevents matplotlib from claiming the default
+# Qt/Tk backend that the host editor already runs.
+import matplotlib
+
+matplotlib.use("Agg")
+
+import cv2
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+from typing_extensions import override
+
+from core.io_data import IoData, IoDataType
+from core.node_base import NodeBase
+from core.params import BoolParam, IntParam, StringParam
+from core.port import InputPort, OutputPort
+
+#: Render DPI used when sizing the matplotlib figure. Width / height in
+#: pixels are converted to inches via ``size_px / _RENDER_DPI`` because
+#: matplotlib expects inches; 100 keeps the math simple and produces
+#: text-readable plots at typical pixel sizes.
+_RENDER_DPI: int = 100
+
+
+class PlotXY(NodeBase):
+    """Render two columns of a :data:`IoDataType.DATASET` as an XY line plot.
+
+    Generic enough to cover waveforms (time vs amplitude), CV curves
+    (voltage vs capacitance), diode I-V characteristics, spectra, and
+    any other "Y vs X" view from a single ``Dataset`` payload — that
+    breadth is the whole point of project Datenkrake's single
+    ``DATASET`` payload kind.
+
+    Output is a 3-channel BGR image so it slots into the existing
+    viewer / file-sink pipeline without a special path. Matplotlib's
+    off-screen ``Agg`` backend is used for rendering; no GUI thread
+    is touched.
+
+    Axis labels come from the column names. If ``df.attrs["units"]``
+    is set (a ``{column: unit_string}`` dict, populated by upstream
+    nodes like ``SetUnits`` or by a domain-aware source), the unit is
+    appended to each label as ``"col [unit]"``.
+
+    Parameters:
+      x_column -- column name for the X axis. Empty (default) → first
+                  column of the input dataset.
+      y_column -- column name for Y. Empty (default) → second column.
+      width    -- output image width in pixels (≥ 64).
+      height   -- output image height in pixels (≥ 64).
+      title    -- overlay title; empty (default) shows none.
+      grid     -- when True (default), draws a faint grid.
+    """
+
+    x_column = StringParam(
+        "",
+        placeholder="(first column)",
+        description=(
+            "Column name for the X axis. Leave empty to use the first "
+            "column of the input dataset."
+        ),
+    )
+    y_column = StringParam(
+        "",
+        placeholder="(second column)",
+        description=(
+            "Column name for the Y axis. Leave empty to use the second "
+            "column of the input dataset."
+        ),
+    )
+    width = IntParam(
+        640,
+        min=64,
+        unit="px",
+        description="Output image width in pixels.",
+    )
+    height = IntParam(
+        360,
+        min=64,
+        unit="px",
+        description="Output image height in pixels.",
+    )
+    title = StringParam(
+        "",
+        placeholder="(no title)",
+        description="Optional plot title rendered above the axes.",
+    )
+    grid = BoolParam(
+        True,
+        description="Draw a faint grid across the plot area.",
+    )
+
+    def __init__(self) -> None:
+        super().__init__("Plot XY", section="Visualization")
+        self._add_input(InputPort("dataset", {IoDataType.DATASET}))
+        self._add_output(OutputPort("image", {IoDataType.IMAGE}))
+        self._apply_default_params()
+
+    @override
+    def process_impl(self) -> None:
+        df: pd.DataFrame = self.inputs[0].data.payload
+        x_col = self._resolve_column(df, self._x_column, default_index=0)
+        y_col = self._resolve_column(df, self._y_column, default_index=1)
+
+        bgr = self._render(
+            df[x_col].to_numpy(),
+            df[y_col].to_numpy(),
+            x_label=self._axis_label(df, x_col),
+            y_label=self._axis_label(df, y_col),
+            width=self._width,
+            height=self._height,
+            title=self._title,
+            grid=self._grid,
+        )
+        self.outputs[0].send(IoData.from_image(bgr))
+
+    # ── Pure helpers (testable without rendering) ─────────────────────────────
+
+    @staticmethod
+    def _resolve_column(
+        df: pd.DataFrame, requested: str, *, default_index: int
+    ) -> str:
+        """Return the column name to plot, raising on miss.
+
+        An empty ``requested`` falls back to the column at
+        ``default_index`` so a freshly-dropped node renders without
+        the user having to type column names. A non-empty miss raises
+        :class:`KeyError` with the available columns listed.
+        """
+        if requested:
+            if requested not in df.columns:
+                raise KeyError(
+                    f"Column {requested!r} not in dataset; "
+                    f"available: {list(df.columns)}"
+                )
+            return requested
+        if default_index >= len(df.columns):
+            raise KeyError(
+                f"Dataset has only {len(df.columns)} column(s); "
+                f"need at least {default_index + 1} to plot"
+            )
+        return str(df.columns[default_index])
+
+    @staticmethod
+    def _axis_label(df: pd.DataFrame, column: str) -> str:
+        """Compose an axis label, appending the column's unit when known.
+
+        ``df.attrs["units"]`` is a ``{column: unit_string}`` dict
+        populated by upstream nodes (``SetUnits``) or domain-aware
+        sources. Missing entries yield a bare column-name label.
+        """
+        units = df.attrs.get("units")
+        if isinstance(units, dict):
+            unit = units.get(column)
+            if unit:
+                return f"{column} [{unit}]"
+        return str(column)
+
+    # ── Rendering (off-screen) ────────────────────────────────────────────────
+
+    @staticmethod
+    def _render(
+        x: np.ndarray,
+        y: np.ndarray,
+        *,
+        x_label: str,
+        y_label: str,
+        width: int,
+        height: int,
+        title: str,
+        grid: bool,
+    ) -> np.ndarray:
+        """Render the plot to a BGR ``uint8`` array via matplotlib Agg.
+
+        Always closes the figure before returning so a long-running
+        flow doesn't leak figures across frames.
+        """
+        fig = plt.figure(
+            figsize=(width / _RENDER_DPI, height / _RENDER_DPI),
+            dpi=_RENDER_DPI,
+        )
+        try:
+            ax = fig.add_subplot(111)
+            ax.plot(x, y)
+            ax.set_xlabel(x_label)
+            ax.set_ylabel(y_label)
+            if title:
+                ax.set_title(title)
+            if grid:
+                ax.grid(True, alpha=0.3)
+            fig.tight_layout()
+            fig.canvas.draw()
+            rgba = np.asarray(fig.canvas.buffer_rgba())
+            return cv2.cvtColor(rgba, cv2.COLOR_RGBA2BGR)
+        finally:
+            plt.close(fig)

--- a/src/nodes/filters/plot_xy.py
+++ b/src/nodes/filters/plot_xy.py
@@ -25,6 +25,18 @@ from core.port import InputPort, OutputPort
 #: text-readable plots at typical pixel sizes.
 _RENDER_DPI: int = 100
 
+#: Sentinel value for ``x_column`` that forces the X axis to be the
+#: row index regardless of the input Dataset's column count. Useful
+#: when a multi-column Dataset should be plotted against position
+#: (e.g. a single recording where the time axis isn't a stored
+#: column). The ``"sample"`` label below is the matching display name.
+_INDEX_SENTINEL: str = "_index"
+
+#: Axis label used whenever the X axis is the row index rather than a
+#: stored column. ``"sample"`` reads correctly for time-series
+#: (sample number) and stays domain-agnostic for non-temporal data.
+_INDEX_LABEL: str = "sample"
+
 
 class PlotXY(NodeBase):
     """Render two columns of a :data:`IoDataType.DATASET` as an XY line plot.
@@ -46,9 +58,15 @@ class PlotXY(NodeBase):
     appended to each label as ``"col [unit]"``.
 
     Parameters:
-      x_column -- column name for the X axis. Empty (default) → first
-                  column of the input dataset.
-      y_column -- column name for Y. Empty (default) → second column.
+      x_column -- column name for the X axis. Empty (default) picks the
+                  first column when the Dataset has ≥ 2 columns; with a
+                  single-column Dataset it falls back to the row index
+                  so a one-channel trace plots out of the box. Set to
+                  ``"_index"`` to force row-index X regardless of the
+                  Dataset's column count.
+      y_column -- column name for Y. Empty (default) → second column on
+                  multi-column Datasets, first (only) column on
+                  single-column Datasets.
       width    -- output image width in pixels (≥ 64).
       height   -- output image height in pixels (≥ 64).
       title    -- overlay title; empty (default) shows none.
@@ -57,18 +75,20 @@ class PlotXY(NodeBase):
 
     x_column = StringParam(
         "",
-        placeholder="(first column)",
+        placeholder="(first column / index for 1-col)",
         description=(
-            "Column name for the X axis. Leave empty to use the first "
-            "column of the input dataset."
+            "Column name for the X axis. Leave empty to auto-pick: "
+            "first column for multi-column Datasets, row index for "
+            "single-column. Set to '_index' to force row-index X."
         ),
     )
     y_column = StringParam(
         "",
-        placeholder="(second column)",
+        placeholder="(second column / first for 1-col)",
         description=(
-            "Column name for the Y axis. Leave empty to use the second "
-            "column of the input dataset."
+            "Column name for the Y axis. Leave empty to auto-pick: "
+            "second column for multi-column Datasets, the only column "
+            "for single-column."
         ),
     )
     width = IntParam(
@@ -102,14 +122,15 @@ class PlotXY(NodeBase):
     @override
     def process_impl(self) -> None:
         df: pd.DataFrame = self.inputs[0].data.payload
-        x_col = self._resolve_column(df, self._x_column, default_index=0)
-        y_col = self._resolve_column(df, self._y_column, default_index=1)
+        x, x_label, y, y_label = self._resolve_xy(
+            df, self._x_column, self._y_column
+        )
 
         bgr = self._render(
-            df[x_col].to_numpy(),
-            df[y_col].to_numpy(),
-            x_label=self._axis_label(df, x_col),
-            y_label=self._axis_label(df, y_col),
+            x,
+            y,
+            x_label=x_label,
+            y_label=y_label,
             width=self._width,
             height=self._height,
             title=self._title,
@@ -118,6 +139,53 @@ class PlotXY(NodeBase):
         self.outputs[0].send(IoData.from_image(bgr))
 
     # ── Pure helpers (testable without rendering) ─────────────────────────────
+
+    @classmethod
+    def _resolve_xy(
+        cls,
+        df: pd.DataFrame,
+        x_column: str,
+        y_column: str,
+    ) -> tuple[np.ndarray, str, np.ndarray, str]:
+        """Pick the X / Y arrays and their axis labels.
+
+        Three paths share this helper:
+
+        1. ``x_column == "_index"`` — X is the row index regardless of
+           how many columns the Dataset has. Y resolves normally
+           (defaulting to the first column).
+
+        2. Single-column Dataset with empty ``x_column`` — same
+           row-index treatment, so a one-column trace (a seismic
+           recording, a one-channel sensor log) plots out of the box
+           without the user having to type a column name. Issue: #231.
+
+        3. Multi-column Dataset — empty ``x_column`` picks the first
+           column for X, empty ``y_column`` picks the second.
+
+        Raises :class:`KeyError` on a non-empty miss or when there
+        aren't enough columns for the chosen defaults.
+        """
+        n_cols = len(df.columns)
+        if n_cols == 0:
+            raise KeyError("Dataset has no columns to plot")
+
+        use_index = x_column == _INDEX_SENTINEL or (not x_column and n_cols == 1)
+
+        if use_index:
+            y_default = 0
+            y_col = cls._resolve_column(df, y_column, default_index=y_default)
+            x_arr = np.arange(len(df))
+            x_label = _INDEX_LABEL
+        else:
+            x_col = cls._resolve_column(df, x_column, default_index=0)
+            y_col = cls._resolve_column(df, y_column, default_index=1)
+            x_arr = df[x_col].to_numpy()
+            x_label = cls._axis_label(df, x_col)
+
+        y_arr = df[y_col].to_numpy()
+        y_label = cls._axis_label(df, y_col)
+        return x_arr, x_label, y_arr, y_label
 
     @staticmethod
     def _resolve_column(

--- a/tests/test_plot_xy.py
+++ b/tests/test_plot_xy.py
@@ -73,12 +73,62 @@ def test_missing_column_raises_keyerror() -> None:
         _run(node, df)
 
 
-def test_too_few_columns_for_default_indices_raises() -> None:
-    df = pd.DataFrame({"only_one": [1, 2, 3]})
-    node = PlotXY()  # defaults need at least 2 columns
-
-    with pytest.raises(KeyError, match="need at least 2"):
+def test_empty_dataset_raises() -> None:
+    df = pd.DataFrame()
+    node = PlotXY()
+    with pytest.raises(KeyError, match="no columns"):
         _run(node, df)
+
+
+# ── Single-column Datasets (issue #231) ──────────────────────────────────────
+
+def test_single_column_default_plots_against_row_index() -> None:
+    """A one-column DataFrame (e.g. a seismic ASCII trace loaded by
+    CsvSource with has_header=False) plots out of the box: row index
+    on X, the column on Y. Default x_column / y_column are empty."""
+    df = pd.DataFrame({"velocity": np.linspace(0.0, 1.0, 8)})
+    node = PlotXY()  # all defaults
+    img = _run(node, df)
+    assert img.size > 0
+
+
+def test_single_column_uses_sample_label_for_x() -> None:
+    df = pd.DataFrame({"v": [0.0, 1.0, 2.0]})
+    x_arr, x_label, y_arr, y_label = PlotXY._resolve_xy(df, "", "")
+    assert x_label == "sample"
+    assert y_label == "v"
+    np.testing.assert_array_equal(x_arr, np.array([0, 1, 2]))
+    np.testing.assert_array_equal(y_arr, np.array([0.0, 1.0, 2.0]))
+
+
+def test_index_sentinel_forces_row_index_on_multi_column_data() -> None:
+    """An explicit x_column='_index' plots Y against position even
+    when the Dataset has multiple columns — useful for picking a
+    single column out of a wide DF and viewing it against position."""
+    df = pd.DataFrame({"V": [0.0, 1.0, 2.0], "I": [10.0, 20.0, 30.0]})
+    x_arr, x_label, y_arr, y_label = PlotXY._resolve_xy(df, "_index", "I")
+    assert x_label == "sample"
+    assert y_label == "I"
+    np.testing.assert_array_equal(x_arr, np.array([0, 1, 2]))
+    np.testing.assert_array_equal(y_arr, np.array([10.0, 20.0, 30.0]))
+
+
+def test_index_sentinel_with_empty_y_picks_first_column() -> None:
+    df = pd.DataFrame({"a": [1.0, 2.0], "b": [3.0, 4.0]})
+    _, _, y_arr, y_label = PlotXY._resolve_xy(df, "_index", "")
+    assert y_label == "a"
+    np.testing.assert_array_equal(y_arr, np.array([1.0, 2.0]))
+
+
+def test_multi_column_default_unchanged() -> None:
+    """The original "first vs second" default still applies for any
+    Dataset with ≥ 2 columns, so existing CV / I-V flows are unaffected."""
+    df = pd.DataFrame({"V": [0.0, 1.0], "I": [0.0, 1e-3], "T": [300.0, 300.0]})
+    x_arr, x_label, y_arr, y_label = PlotXY._resolve_xy(df, "", "")
+    assert x_label == "V"
+    assert y_label == "I"
+    np.testing.assert_array_equal(x_arr, np.array([0.0, 1.0]))
+    np.testing.assert_array_equal(y_arr, np.array([0.0, 1e-3]))
 
 
 # ── Pure helpers ──────────────────────────────────────────────────────────────

--- a/tests/test_plot_xy.py
+++ b/tests/test_plot_xy.py
@@ -1,0 +1,142 @@
+"""Tests for the :class:`~nodes.filters.plot_xy.PlotXY` node."""
+from __future__ import annotations
+
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import pytest
+
+from core.io_data import IoData, IoDataType
+from nodes.filters.plot_xy import PlotXY
+
+
+def _xy_df(n: int = 16) -> pd.DataFrame:
+    """A minimal two-column DataFrame for plotting."""
+    x = np.linspace(0.0, 1.0, n)
+    return pd.DataFrame({"t": x, "v": np.sin(2 * np.pi * x)})
+
+
+def _run(node: PlotXY, df: pd.DataFrame) -> np.ndarray:
+    """Feed *df* into the node's input and return the emitted image."""
+    node.inputs[0].receive(IoData.from_dataset(df))
+    out = node.outputs[0].last_emitted
+    assert out is not None, "PlotXY did not emit"
+    assert out.type is IoDataType.IMAGE
+    return out.image
+
+
+# ── Render output shape ───────────────────────────────────────────────────────
+
+def test_emits_image_of_requested_shape() -> None:
+    node = PlotXY()
+    node.width = 200
+    node.height = 100
+
+    img = _run(node, _xy_df())
+
+    assert img.dtype == np.uint8
+    assert img.ndim == 3
+    assert img.shape[2] == 3  # BGR
+    # matplotlib's Agg may produce ±1 pixel from the requested size at
+    # tight_layout — assert exact match because we set figsize from the
+    # explicit dpi/size relation. If matplotlib changes this assumption
+    # the test will flag it.
+    assert img.shape[:2] == (100, 200)
+
+
+def test_default_columns_pick_first_two() -> None:
+    """Empty x_column / y_column → first / second columns of the input."""
+    node = PlotXY()  # defaults: x_column="", y_column=""
+    img = _run(node, _xy_df())
+    assert img.shape == (360, 640, 3)
+
+
+def test_explicit_columns_select_those() -> None:
+    df = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6], "c": [7, 8, 9]})
+    node = PlotXY()
+    node.x_column = "a"
+    node.y_column = "c"
+    img = _run(node, df)
+    assert img.size > 0
+
+
+# ── Error paths ───────────────────────────────────────────────────────────────
+
+def test_missing_column_raises_keyerror() -> None:
+    df = _xy_df()
+    node = PlotXY()
+    node.x_column = "nope"
+
+    with pytest.raises(KeyError, match="not in dataset"):
+        _run(node, df)
+
+
+def test_too_few_columns_for_default_indices_raises() -> None:
+    df = pd.DataFrame({"only_one": [1, 2, 3]})
+    node = PlotXY()  # defaults need at least 2 columns
+
+    with pytest.raises(KeyError, match="need at least 2"):
+        _run(node, df)
+
+
+# ── Pure helpers ──────────────────────────────────────────────────────────────
+
+def test_axis_label_falls_back_to_column_name_without_units() -> None:
+    df = pd.DataFrame({"x": [0], "y": [0]})
+    assert PlotXY._axis_label(df, "x") == "x"
+
+
+def test_axis_label_appends_unit_when_attrs_units_set() -> None:
+    df = pd.DataFrame({"V": [0.0], "I": [0.0]})
+    df.attrs["units"] = {"V": "V", "I": "A"}
+    assert PlotXY._axis_label(df, "V") == "V [V]"
+    assert PlotXY._axis_label(df, "I") == "I [A]"
+
+
+def test_axis_label_handles_missing_unit_for_known_column() -> None:
+    df = pd.DataFrame({"x": [0], "y": [0]})
+    df.attrs["units"] = {"x": "s"}  # no entry for 'y'
+    assert PlotXY._axis_label(df, "y") == "y"
+
+
+def test_resolve_column_default_index_picks_by_position() -> None:
+    df = pd.DataFrame({"first": [0], "second": [0], "third": [0]})
+    assert PlotXY._resolve_column(df, "", default_index=0) == "first"
+    assert PlotXY._resolve_column(df, "", default_index=1) == "second"
+    assert PlotXY._resolve_column(df, "third", default_index=0) == "third"
+
+
+# ── Memory leak guard ─────────────────────────────────────────────────────────
+
+def test_no_open_figures_after_process() -> None:
+    """A long-running flow renders one plot per frame; matplotlib leaks
+    figures unless they are explicitly closed. PlotXY must close every
+    figure it opens after a successful render."""
+    plt.close("all")  # baseline
+    node = PlotXY()
+    df = _xy_df()
+    for _ in range(5):
+        node.inputs[0].receive(IoData.from_dataset(df))
+    assert plt.get_fignums() == [], "PlotXY left matplotlib figures open"
+
+
+def test_no_open_figures_after_render_error() -> None:
+    """If something goes wrong during rendering after the figure has
+    been created, the ``finally`` in ``_render`` must still close it.
+    Drives ``_render`` directly with a mismatched-shape pair so plot()
+    raises mid-render."""
+    plt.close("all")
+    with pytest.raises(ValueError):
+        PlotXY._render(
+            np.array([0.0, 1.0, 2.0]),
+            np.array([0.0, 1.0]),  # length mismatch → matplotlib raises
+            x_label="x",
+            y_label="y",
+            width=120,
+            height=80,
+            title="",
+            grid=False,
+        )
+    assert plt.get_fignums() == []


### PR DESCRIPTION
## Summary

Adds `PlotXY` — a generic Dataset → IMAGE renderer. Picks two columns from a `DATASET` and produces a labeled XY line plot as a BGR image so any `Dataset` flow can yield a viewer-ready picture without leaving the graph. One node covers waveforms (time vs amplitude), CV curves, diode I-V characteristics, spectra, and any other "Y vs X" view — that breadth is the payoff for keeping the `DATASET` payload generic.

**Includes the fix for #231** — a follow-up bug filed after the initial commit when single-column inputs (e.g. the bundled `quake_eib_*` ASCII traces, every row a single amplitude) tripped the original "need ≥ 2 columns" assumption. PlotXY now falls back to the row index for X when the Dataset has only one column, so `CsvSource → PlotXY → Display` works out of the box for one-channel time-series. Filed and fixed in this PR rather than a separate one because #221 hadn't merged yet.

## Parameters

- `x_column` / `y_column` — empty (default) auto-picks: first / second columns for multi-column Datasets, **row index** vs the only column for single-column. Set `x_column = "_index"` to force row-index X regardless of column count.
- `width` / `height` — pixels (≥ 64), default 640×360.
- `title` — optional plot title.
- `grid` — faint grid toggle (default on).

Axis labels include the column unit when the upstream stamps a `df.attrs["units"]` dict (`{"V": "V", "I": "A"}` → `"V [V]"`, `"I [A]"`). In the row-index mode the X label is `"sample"`.

Renders off-screen via matplotlib's `Agg` backend; the figure is always closed in a `finally` so a long-running flow doesn't leak figures. Pure helpers (`_resolve_xy`, `_resolve_column`, `_axis_label`, `_render`) are static / classmethods so they're unit-testable without driving the node dispatcher.

`matplotlib` added to `requirements.txt`.

Bumps `APP_VERSION` to 0.2.40; CHANGELOG + welcome.html updated.

Closes #221, closes #231.

## Test plan

- [ ] CI green on `tests/test_plot_xy.py`:
  - emits IMAGE of requested shape (200×100 explicit, 640×360 default)
  - default columns pick first/second on multi-column data; explicit columns honored
  - missing column → `KeyError` with available-column list
  - empty Dataset → `KeyError`
  - axis label falls back to column name when no units; appends `[unit]` when present; gracefully handles missing-per-column unit entries
  - **NEW:** single-column Dataset plots against row index with X label `"sample"`
  - **NEW:** `x_column="_index"` sentinel forces row-index X on multi-column data
  - **NEW:** `_index` with empty y_column picks the first column
  - multi-column default unchanged ("V vs I"-style flows still work)
  - no matplotlib figures left open after 5 successive renders
  - no figures left open when `_render` raises mid-render
- [ ] Drop a `CsvSource → PlotXY → Display` flow against `input/quakedata/quake_eib_20000908_1139.001` (with `has_header=False`); the trace renders.

https://claude.ai/code/session_01VeUsCbRo2t78AbT1gi3B7S