### PR TITLE
fix(ui): Node Documentation dock no longer auto-resizes to its content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,21 @@ once a first tagged release is cut.
 
 ## [Unreleased]
 
+## [0.2.42] — 2026-04-29
+
+### Fixed
+- **Node Documentation dock no longer auto-resizes to its content.**
+  Selecting a node with a long docstring or many parameters (e.g.
+  the new ``Hodogram``) was pushing the dock taller and squashing
+  the sibling Node List dock. Root cause: the summary ``QLabel``'s
+  word-wrap-driven minimum height bled through ``sizeHint`` /
+  ``minimumSizeHint`` to the enclosing ``QDockWidget``. Fix: wrap
+  the panel body in a ``QScrollArea`` and override the panel's
+  size-hint methods to fixed defaults (``280×360`` /
+  ``180×80``). Long content now produces a vertical scroll bar
+  inside the panel; the dock retains the user's chosen size.
+  Issue: #233.
+
 ## [0.2.41] — 2026-04-29
 
 ### Added

--- a/doc/welcome.html
+++ b/doc/welcome.html
@@ -180,7 +180,7 @@
   <main class="content-col">
 
     <header class="hero">
-      <h1>Welcome to Stjörnhorn <span class="version">v0.2.41</span></h1>
+      <h1>Welcome to Stjörnhorn <span class="version">v0.2.42</span></h1>
       <div class="tagline">A node-based image- and video-processing playground.</div>
     </header>
 
@@ -210,6 +210,13 @@
           <p>Write frames to image files or encode video (MP4V, XVID) with live preview via the Display node.</p>
         </div>
       </div>
+    </section>
+
+    <section>
+      <h2>What's new in v0.2.42</h2>
+      <ul class="tips">
+        <li><strong>Node Documentation dock no longer auto-resizes to its content.</strong> Selecting a node with a long docstring or many parameters (the new <code>Hodogram</code>, for instance) was pushing the documentation dock taller and squashing the sibling Node List dock. Root cause was the summary <code>QLabel</code>'s word-wrap-driven minimum height bleeding through <code>sizeHint</code> / <code>minimumSizeHint</code> to the enclosing <code>QDockWidget</code>. Fix: wrap the panel body in a <code>QScrollArea</code> and override the panel's size-hint methods to fixed defaults. Long content now produces a vertical scroll bar inside the panel; the dock retains the user's chosen size. Issue #233.</li>
+      </ul>
     </section>
 
     <section>

--- a/src/constants.py
+++ b/src/constants.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 APP_NAME:         str = "Image-Inquest"
 APP_DISPLAY_NAME: str = "Stjörnhorn"
-APP_VERSION:      str = "0.2.41"
+APP_VERSION:      str = "0.2.42"
 API_URL:    str = "https://beltoforion.de"
 
 # Path resolution -----------------------------------------------------------

--- a/src/ui/node_doc_panel.py
+++ b/src/ui/node_doc_panel.py
@@ -34,10 +34,11 @@ import inspect
 import re
 from typing import TYPE_CHECKING
 
-from PySide6.QtCore import Qt
+from PySide6.QtCore import QSize, Qt
 from PySide6.QtWidgets import (
     QFrame,
     QLabel,
+    QScrollArea,
     QSizePolicy,
     QTextBrowser,
     QToolButton,
@@ -367,6 +368,25 @@ def has_details(desc: dict) -> bool:
     return False
 
 
+#: Default size the panel reports to its container. Constant — does **not**
+#: depend on the rendered docstring length — so a node with a long docstring
+#: never grows the dock and squashes its siblings (e.g. the Node List). When
+#: content overflows, the inner ``QScrollArea`` produces a scroll bar instead.
+#: Issue: #233.
+_PANEL_DEFAULT_HINT: QSize = QSize(280, 360)
+
+#: Smallest size the panel will accept. Stays well below the default hint
+#: so the user can shrink the dock without the panel shouldering it back up.
+_PANEL_MIN_HINT: QSize = QSize(180, 80)
+
+#: Floor height for the collapsible details ``QTextBrowser``. The browser
+#: scrolls internally when its content is taller than this; together with
+#: a ``QSizePolicy.Ignored`` vertical policy, it keeps the body from
+#: pushing the outer scroll bar around when long Parameters tables are
+#: open. Also #233.
+_DETAILS_MIN_HEIGHT: int = 120
+
+
 class NodeDocPanel(QWidget):
     """Dockable panel that renders the docs of the currently selected node.
 
@@ -392,9 +412,37 @@ class NodeDocPanel(QWidget):
         # never ``show()``-n.
         self._has_details: bool = False
 
-        layout = QVBoxLayout(self)
+        # Outer layout holds a ``QScrollArea`` that owns the actual body
+        # widget. Wrapping the body in a scroll area decouples the
+        # panel's reported size from its rendered docstring length —
+        # without this, a long docstring grew ``minimumSizeHint`` and
+        # pushed the dock taller, squashing the sibling Node List dock.
+        # Issue: #233.
+        outer = QVBoxLayout(self)
+        outer.setContentsMargins(0, 0, 0, 0)
+        outer.setSpacing(0)
+
+        self._scroll = QScrollArea(self)
+        self._scroll.setWidgetResizable(True)
+        # Wrap text rather than scrolling horizontally — narrow docks
+        # are common and a horizontal bar inside a vertical dock reads
+        # like a sizing bug.
+        self._scroll.setHorizontalScrollBarPolicy(
+            Qt.ScrollBarPolicy.ScrollBarAlwaysOff
+        )
+        self._scroll.setVerticalScrollBarPolicy(
+            Qt.ScrollBarPolicy.ScrollBarAsNeeded
+        )
+        # The QScrollArea's default frame draws a 1-px border that
+        # collides with the dock's own border; drop it.
+        self._scroll.setFrameShape(QFrame.Shape.NoFrame)
+        outer.addWidget(self._scroll)
+
+        body = QWidget()
+        layout = QVBoxLayout(body)
         layout.setContentsMargins(8, 6, 8, 6)
         layout.setSpacing(4)
+        self._scroll.setWidget(body)
 
         # ── Summary head: rich-text QLabel sized to its content ───
         # Using QLabel rather than a second QTextBrowser keeps the
@@ -448,6 +496,12 @@ class NodeDocPanel(QWidget):
         layout.addWidget(self._rule)
 
         # ── Details body: full-height QTextBrowser ───────────────
+        # ``Ignored`` vertical policy + a small ``setMinimumHeight``
+        # together prevent the browser's own (potentially huge) content
+        # height from leaking into the body's ``sizeHint`` and forcing
+        # the outer scroll bar to appear. The browser scrolls internally
+        # whenever its content overflows the height the layout gives it.
+        # Issue: #233.
         self._details = QTextBrowser()
         self._details.setOpenExternalLinks(True)
         self._details.setVisible(False)
@@ -455,9 +509,33 @@ class NodeDocPanel(QWidget):
             Qt.TextInteractionFlag.TextSelectableByMouse
             | Qt.TextInteractionFlag.TextSelectableByKeyboard
         )
+        self._details.setSizePolicy(
+            QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Ignored,
+        )
+        self._details.setMinimumHeight(_DETAILS_MIN_HEIGHT)
         layout.addWidget(self._details, 1)
 
         self.clear()
+
+    # ── Size negotiation ──────────────────────────────────────────────────────
+
+    def sizeHint(self) -> QSize:  # noqa: D401 — overrides Qt method
+        """Return a constant default size, decoupled from content length.
+
+        Without this, ``QWidget.sizeHint`` is derived from the layout
+        and grows with the rendered docstring; the enclosing
+        ``QDockWidget`` then resizes itself on every selection change
+        and squashes neighbouring docks. Returning a fixed value
+        keeps the dock at the user's chosen height; overflow is
+        handled by the inner ``QScrollArea``. Issue: #233.
+        """
+        return _PANEL_DEFAULT_HINT
+
+    def minimumSizeHint(self) -> QSize:  # noqa: D401 — overrides Qt method
+        """Floor for the panel's size — small so the user can shrink
+        the dock without the panel pushing back. The ``QScrollArea``
+        kicks in well before this floor matters in practice. #233."""
+        return _PANEL_MIN_HINT
 
     # ── Public slots ───────────────────────────────────────────────────────────
 

--- a/tests/test_node_doc_panel_widget.py
+++ b/tests/test_node_doc_panel_widget.py
@@ -192,3 +192,53 @@ def _find_leaf(node_list: NodeList, class_name: str) -> QTreeWidgetItem:
             if json.loads(payload).get("class_name") == class_name:
                 return child
     pytest.fail(f"leaf {class_name!r} not found in palette")
+
+
+# ── Size negotiation (issue #233) ────────────────────────────────────────────
+#
+# Regression guard: a long docstring must not push the panel taller than its
+# default hint. Without the QScrollArea + sizeHint override added in #233,
+# the QLabel summary's wordwrap-driven height bled through to
+# ``minimumSizeHint``, and the enclosing QDockWidget grew on every selection
+# change — squashing the sibling Node List dock.
+
+from core.node_base import NodeBase
+
+
+class _LongDocNode(NodeBase):
+    __doc__ = "Short summary line.\n\n" + "\n\n".join(
+        f"Paragraph {i}: " + ("filler text " * 40) for i in range(1, 11)
+    )
+
+    def __init__(self) -> None:
+        super().__init__("Long Doc Test", section="Test")
+
+    def process_impl(self) -> None:  # pragma: no cover - never executed
+        pass
+
+
+def test_size_hint_constant_across_show_class(qapp: QApplication) -> None:
+    """Selecting different classes must not change the panel's reported
+    size — that's what kept the dock from auto-resizing in #233."""
+    panel = NodeDocPanel()
+    initial = panel.sizeHint()
+    initial_min = panel.minimumSizeHint()
+
+    # Render docs for a real built-in node (short docstring).
+    panel.show_class(GaussianBlur)
+    assert panel.sizeHint() == initial
+    assert panel.minimumSizeHint() == initial_min
+
+    # Then a NodeBase subclass with a much longer docstring — the case
+    # that originally pushed the dock taller.
+    panel.show_class(_LongDocNode)
+    assert panel.sizeHint() == initial
+    assert panel.minimumSizeHint() == initial_min
+
+
+def test_minimum_size_hint_below_default(qapp: QApplication) -> None:
+    """The minimum size must be smaller than the default hint so the
+    user can shrink the dock without the panel pushing back."""
+    panel = NodeDocPanel()
+    assert panel.minimumSizeHint().height() < panel.sizeHint().height()
+    assert panel.minimumSizeHint().width() < panel.sizeHint().width()


### PR DESCRIPTION
## Summary

Selecting a node with a long docstring or many parameters (e.g. the new `Hodogram` from #222) was pushing the **Node Documentation** dock taller on every selection, squashing the **Node List** dock above it. The user's splitter position got overridden every time.

Root cause: the summary `QLabel` has `setWordWrap(True)`, so its `minimumHeight` grows with the wrapped text. That minimum propagates through `QVBoxLayout` → `NodeDocPanel` → enclosing `QDockWidget`, and Qt's dock layout has no choice but to grow the dock to honour the minimum.

## Fix

- **Wrap the body in a `QScrollArea`** (`setWidgetResizable=True`). Long content now produces a vertical scroll bar inside the panel instead of growing it.
- **Override `sizeHint()` / `minimumSizeHint()`** on `NodeDocPanel` to fixed defaults (280×360 / 180×80) so a content-driven `updateGeometry()` can no longer push the dock taller.
- **Bound the details `QTextBrowser`** with `QSizePolicy.Ignored` (vertical) + 120-px minimum height so its content size doesn't leak into the body's `sizeHint` when the disclosure is open — the browser scrolls internally instead.

The dock now retains whatever height the user chose; overflow is handled by the inner scroll bar.

Bumps `APP_VERSION` to 0.2.42; CHANGELOG + welcome.html updated.

Closes #233.

## Test plan

- [ ] CI green on the new tests in `tests/test_node_doc_panel_widget.py`:
  - `test_size_hint_constant_across_show_class` — `sizeHint()` / `minimumSizeHint()` unchanged whether the panel is showing the empty state, a short-docstring built-in (`GaussianBlur`), or a synthetic `NodeBase` subclass with a 10-paragraph docstring.
  - `test_minimum_size_hint_below_default` — `minimumSizeHint` is strictly smaller than `sizeHint` so the user can shrink the dock.
- [ ] Manual: cycle through the palette clicking nodes with short and long docs; the Node List / Documentation split stays put.
- [ ] Manual: select `Hodogram`, expand *Details*; the dock height doesn't change, the panel scrolls internally.

https://claude.ai/code/session_01VeUsCbRo2t78AbT1gi3B7S

---
_Generated by [Claude Code](https://claude.ai/code/session_01VeUsCbRo2t78AbT1gi3B7S)_