### PR TITLE
feat(filters): AddIndexColumn node + revert PlotXY row-index fallback (Datenkrake #235)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,35 @@ once a first tagged release is cut.
 
 ## [Unreleased]
 
+## [0.2.43] — 2026-04-29
+
+### Added
+- **Datenkrake: ``AddIndexColumn`` node.** Prepends a synthetic
+  numeric column to a ``DATASET`` so a one-column trace gets an
+  explicit X axis instead of relying on a renderer-side row-index
+  fallback. Parameters: ``name`` (default ``"index"``), ``start``
+  (default ``0.0``), ``step`` (default ``1.0``, strictly positive).
+  Setting ``step = 1 / sample_rate`` produces a time axis in
+  seconds. Inserts the new column at position 0 so it becomes the
+  default X for ``PlotXY``. Preserves ``df.attrs``. Issue: #235.
+
+### Changed
+- **``PlotXY`` no longer falls back to the row index for
+  single-column inputs** (revert of #231). The renderer now always
+  plots two named columns; a 1-column input raises a ``KeyError``
+  pointing the user at ``AddIndexColumn``. The split is cleaner
+  SRP-wise: ``AddIndexColumn`` synthesises the X axis, ``PlotXY``
+  renders. The ``x_column = "_index"`` sentinel and the
+  ``"sample"`` axis label are gone with it. Saved flows that
+  relied on the implicit fallback need an ``AddIndexColumn``
+  inserted upstream — per the new ``CLAUDE.md`` rule, no migration
+  shim is provided. Bundled
+  ``flow/data_display_time_series.flowjs`` updated to insert
+  ``AddIndexColumn`` and use ``step = 0.125`` (1/8 s for the 8 Hz
+  quake sample). Also corrects the second ``CsvSource``'s
+  ``has_header`` from ``true`` to ``false`` so both branches load
+  the full 5652-sample trace. Issue: #235.
+
 ## [0.2.42] — 2026-04-29
 
 ### Fixed

--- a/doc/welcome.html
+++ b/doc/welcome.html
@@ -180,7 +180,7 @@
   <main class="content-col">
 
     <header class="hero">
-      <h1>Welcome to Stjörnhorn <span class="version">v0.2.42</span></h1>
+      <h1>Welcome to Stjörnhorn <span class="version">v0.2.43</span></h1>
       <div class="tagline">A node-based image- and video-processing playground.</div>
     </header>
 
@@ -210,6 +210,14 @@
           <p>Write frames to image files or encode video (MP4V, XVID) with live preview via the Display node.</p>
         </div>
       </div>
+    </section>
+
+    <section>
+      <h2>What's new in v0.2.43</h2>
+      <ul class="tips">
+        <li><strong>Datenkrake: <code>AddIndexColumn</code> node.</strong> Prepends a synthetic numeric column to a <code>DATASET</code> so a one-column trace gets an explicit X axis instead of relying on a renderer-side fallback. Parameters: <code>name</code>, <code>start</code>, <code>step</code>; set <code>step = 1 / sample_rate</code> for a time axis in seconds. Preserves <code>df.attrs</code>. Issue #235.</li>
+        <li><strong><code>PlotXY</code> no longer auto-falls-back to the row index for single-column inputs</strong> (revert of #231). Always plots two named columns; a 1-column input now raises with a hint to insert <code>AddIndexColumn</code> upstream. Cleaner separation of concerns — the index node synthesises the axis, the plot node renders. Saved flows that relied on the fallback need an <code>AddIndexColumn</code> in front of <code>PlotXY</code>. The bundled <code>data_display_time_series.flowjs</code> demo flow has been updated. Issue #235.</li>
+      </ul>
     </section>
 
     <section>

--- a/flow/data_display_time_series.flowjs
+++ b/flow/data_display_time_series.flowjs
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "app_version": "0.2.42",
+  "app_version": "0.2.43",
   "name": "data_display_time_series",
   "nodes": [
     {
@@ -31,8 +31,8 @@
         -981.0091861138433
       ],
       "port_defaults": {
-        "x_column": "",
-        "y_column": "",
+        "x_column": "t",
+        "y_column": "c0",
         "width": 800,
         "height": 300,
         "title": "Earthquake Data",
@@ -54,7 +54,7 @@
       "port_defaults": {
         "file_path": "quakedata/quake_eib_20000908_1139.002",
         "delimiter": ",",
-        "has_header": true,
+        "has_header": false,
         "decimal": "."
       },
       "size": [
@@ -71,8 +71,8 @@
         -249.30663539509987
       ],
       "port_defaults": {
-        "x_column": "",
-        "y_column": "",
+        "x_column": "t",
+        "y_column": "c0",
         "width": 800,
         "height": 300,
         "title": "",
@@ -148,17 +148,57 @@
       "port_defaults": {
         "value": 200.0
       }
+    },
+    {
+      "id": 9,
+      "module": "nodes.filters.add_index_column",
+      "class": "AddIndexColumn",
+      "position": [
+        -1610.0,
+        -870.0
+      ],
+      "port_defaults": {
+        "name": "t",
+        "start": 0.0,
+        "step": 0.125
+      }
+    },
+    {
+      "id": 10,
+      "module": "nodes.filters.add_index_column",
+      "class": "AddIndexColumn",
+      "position": [
+        -1610.0,
+        -360.0
+      ],
+      "port_defaults": {
+        "name": "t",
+        "start": 0.0,
+        "step": 0.125
+      }
     }
   ],
   "connections": [
     {
       "src_node": 0,
       "src_output": 0,
+      "dst_node": 9,
+      "dst_input": 0
+    },
+    {
+      "src_node": 9,
+      "src_output": 0,
       "dst_node": 1,
       "dst_input": 0
     },
     {
       "src_node": 2,
+      "src_output": 0,
+      "dst_node": 10,
+      "dst_input": 0
+    },
+    {
+      "src_node": 10,
       "src_output": 0,
       "dst_node": 3,
       "dst_input": 0

--- a/flow/data_display_time_series.flowjs
+++ b/flow/data_display_time_series.flowjs
@@ -8,8 +8,8 @@
       "module": "nodes.sources.csv_source",
       "class": "CsvSource",
       "position": [
-        -1704.702004370738,
-        -671.8739355218556
+        -2223.548680321199,
+        -757.1955810616265
       ],
       "port_defaults": {
         "file_path": "quakedata/quake_eib_20000908_1139.001",
@@ -27,8 +27,8 @@
       "module": "nodes.filters.plot_xy",
       "class": "PlotXY",
       "position": [
-        -1491.402219884505,
-        -981.0091861138433
+        -1359.5541519340327,
+        -629.4143382459176
       ],
       "port_defaults": {
         "x_column": "t",
@@ -48,8 +48,8 @@
       "module": "nodes.sources.csv_source",
       "class": "CsvSource",
       "position": [
-        -1698.9970102118364,
-        -471.8356137921535
+        -2221.3261109294363,
+        -545.5261771821298
       ],
       "port_defaults": {
         "file_path": "quakedata/quake_eib_20000908_1139.002",
@@ -67,8 +67,8 @@
       "module": "nodes.filters.plot_xy",
       "class": "PlotXY",
       "position": [
-        -1489.1502285083752,
-        -249.30663539509987
+        -1381.913799908658,
+        -251.0646096344395
       ],
       "port_defaults": {
         "x_column": "t",
@@ -88,8 +88,8 @@
       "module": "nodes.filters.merge",
       "class": "Merge",
       "position": [
-        -1116.2068496356228,
-        -649.4483846239268
+        -1024.0832775012009,
+        -540.8323519763024
       ],
       "port_defaults": {}
     },
@@ -98,8 +98,8 @@
       "module": "nodes.filters.display",
       "class": "Display",
       "position": [
-        -938.6891716313074,
-        -805.0744372620011
+        -835.9507066377673,
+        -754.050051245123
       ],
       "port_defaults": {},
       "size": [
@@ -112,8 +112,8 @@
       "module": "nodes.filters.hodogram",
       "class": "Hodogram",
       "position": [
-        -1193.8289902596696,
-        -182.85619979410012
+        -726.2078425953284,
+        -110.77925598117542
       ],
       "port_defaults": {
         "x_column": "N",
@@ -154,8 +154,8 @@
       "module": "nodes.filters.add_index_column",
       "class": "AddIndexColumn",
       "position": [
-        -1610.0,
-        -870.0
+        -1748.4861803211988,
+        -757.1955810616265
       ],
       "port_defaults": {
         "name": "t",
@@ -168,8 +168,8 @@
       "module": "nodes.filters.add_index_column",
       "class": "AddIndexColumn",
       "position": [
-        -1610.0,
-        -360.0
+        -1753.0355623608866,
+        -545.5261771821298
       ],
       "port_defaults": {
         "name": "t",
@@ -246,5 +246,23 @@
       "dst_input": 4
     }
   ],
-  "backdrops": []
+  "backdrops": [
+    {
+      "position": [
+        -2249.548680321199,
+        -805.1955810616265
+      ],
+      "size": [
+        689.671875,
+        461.6694038794967
+      ],
+      "title": "Input",
+      "color": [
+        70,
+        60,
+        40,
+        140
+      ]
+    }
+  ]
 }

--- a/src/constants.py
+++ b/src/constants.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 APP_NAME:         str = "Image-Inquest"
 APP_DISPLAY_NAME: str = "Stjörnhorn"
-APP_VERSION:      str = "0.2.42"
+APP_VERSION:      str = "0.2.43"
 API_URL:    str = "https://beltoforion.de"
 
 # Path resolution -----------------------------------------------------------

--- a/src/nodes/filters/add_index_column.py
+++ b/src/nodes/filters/add_index_column.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+from typing_extensions import override
+
+from core.io_data import IoData, IoDataType
+from core.node_base import NodeBase
+from core.params import FloatParam, StringParam
+from core.port import InputPort, OutputPort
+
+
+class AddIndexColumn(NodeBase):
+    """Prepend a synthetic numeric column to a :data:`IoDataType.DATASET`.
+
+    Single-responsibility companion to nodes that need an explicit X axis
+    (``PlotXY``, ``Hodogram``) but receive a DATASET with no natural one
+    — typical for ``CsvSource`` reading a one-column trace where the
+    sample number / time has to be synthesised. Slotting this node
+    upstream means the X axis is a *real, named column* every
+    downstream node can address by name, instead of an implicit
+    "row index" baked into the renderer.
+
+    The new column is inserted at position 0 so it becomes the default
+    X for ``PlotXY`` (whose empty-``x_column`` falls back to the first
+    column). ``df.attrs`` is preserved so upstream metadata
+    (``sample_rate``, ``source_path``, …) survives the transform.
+
+    Set ``step = 1 / sample_rate`` to produce a time axis in seconds
+    instead of a bare sample index. The node is intentionally generic
+    — sample-rate awareness lives upstream (or in a future
+    ``AddTimeAxis`` thin wrapper) so this node stays domain-free.
+
+    Parameters:
+      name  -- column name for the new index. Default ``"index"``.
+               Raises if a column with the same name already exists.
+      start -- first value of the index. Default ``0.0``.
+      step  -- increment per row. Default ``1.0`` (sample numbers).
+               Strictly positive — a non-positive step would produce a
+               flat or descending axis that no downstream renderer
+               currently expects.
+    """
+
+    name = StringParam(
+        "index",
+        max_length=64,
+        description=(
+            "Name for the new index column. Inserted at position 0 "
+            "so it becomes the default X axis downstream."
+        ),
+    )
+    start = FloatParam(
+        0.0,
+        description="First value of the index.",
+    )
+    step = FloatParam(
+        1.0,
+        min=0.0,
+        min_exclusive=True,
+        description=(
+            "Increment per row. Use 1.0 for sample numbers, "
+            "1/sample_rate for a time axis in seconds."
+        ),
+    )
+
+    def __init__(self) -> None:
+        super().__init__("Add Index Column", section="Data")
+        self._add_input(InputPort("dataset", {IoDataType.DATASET}))
+        self._add_output(OutputPort("dataset", {IoDataType.DATASET}))
+        self._apply_default_params()
+
+    @override
+    def process_impl(self) -> None:
+        df: pd.DataFrame = self.inputs[0].data.payload
+
+        if self._name in df.columns:
+            raise ValueError(
+                f"Cannot add index column {self._name!r}: "
+                f"a column with that name already exists "
+                f"in the input dataset (columns: {list(df.columns)})"
+            )
+
+        n = len(df)
+        index_values = self._start + np.arange(n) * self._step
+
+        new_df = df.copy()
+        new_df.insert(0, self._name, index_values)
+        # ``DataFrame.copy`` preserves ``.attrs`` in modern pandas, but
+        # be explicit about it — the metadata channel is the whole
+        # reason ``DATASET`` exists as a typed payload, and a regression
+        # here would silently strip ``sample_rate`` and friends.
+        new_df.attrs = dict(df.attrs)
+        self.outputs[0].send(IoData.from_dataset(new_df))

--- a/src/nodes/filters/plot_xy.py
+++ b/src/nodes/filters/plot_xy.py
@@ -25,18 +25,6 @@ from core.port import InputPort, OutputPort
 #: text-readable plots at typical pixel sizes.
 _RENDER_DPI: int = 100
 
-#: Sentinel value for ``x_column`` that forces the X axis to be the
-#: row index regardless of the input Dataset's column count. Useful
-#: when a multi-column Dataset should be plotted against position
-#: (e.g. a single recording where the time axis isn't a stored
-#: column). The ``"sample"`` label below is the matching display name.
-_INDEX_SENTINEL: str = "_index"
-
-#: Axis label used whenever the X axis is the row index rather than a
-#: stored column. ``"sample"`` reads correctly for time-series
-#: (sample number) and stays domain-agnostic for non-temporal data.
-_INDEX_LABEL: str = "sample"
-
 
 class PlotXY(NodeBase):
     """Render two columns of a :data:`IoDataType.DATASET` as an XY line plot.
@@ -52,6 +40,12 @@ class PlotXY(NodeBase):
     off-screen ``Agg`` backend is used for rendering; no GUI thread
     is touched.
 
+    The node always plots two named columns. A one-column input is
+    rejected with a clear error; insert
+    :class:`~nodes.filters.add_index_column.AddIndexColumn` upstream
+    to add an explicit X axis (sample number, or time in seconds via
+    ``step = 1 / sample_rate``).
+
     Axis labels come from the column names. If ``df.attrs["units"]``
     is set (a ``{column: unit_string}`` dict, populated by upstream
     nodes like ``SetUnits`` or by a domain-aware source), the unit is
@@ -59,14 +53,9 @@ class PlotXY(NodeBase):
 
     Parameters:
       x_column -- column name for the X axis. Empty (default) picks the
-                  first column when the Dataset has ≥ 2 columns; with a
-                  single-column Dataset it falls back to the row index
-                  so a one-channel trace plots out of the box. Set to
-                  ``"_index"`` to force row-index X regardless of the
-                  Dataset's column count.
-      y_column -- column name for Y. Empty (default) → second column on
-                  multi-column Datasets, first (only) column on
-                  single-column Datasets.
+                  first column of the input dataset.
+      y_column -- column name for Y. Empty (default) picks the second
+                  column.
       width    -- output image width in pixels (≥ 64).
       height   -- output image height in pixels (≥ 64).
       title    -- overlay title; empty (default) shows none.
@@ -75,20 +64,18 @@ class PlotXY(NodeBase):
 
     x_column = StringParam(
         "",
-        placeholder="(first column / index for 1-col)",
+        placeholder="(first column)",
         description=(
-            "Column name for the X axis. Leave empty to auto-pick: "
-            "first column for multi-column Datasets, row index for "
-            "single-column. Set to '_index' to force row-index X."
+            "Column name for the X axis. Leave empty to use the first "
+            "column of the input dataset."
         ),
     )
     y_column = StringParam(
         "",
-        placeholder="(second column / first for 1-col)",
+        placeholder="(second column)",
         description=(
-            "Column name for the Y axis. Leave empty to auto-pick: "
-            "second column for multi-column Datasets, the only column "
-            "for single-column."
+            "Column name for the Y axis. Leave empty to use the second "
+            "column of the input dataset."
         ),
     )
     width = IntParam(
@@ -122,15 +109,14 @@ class PlotXY(NodeBase):
     @override
     def process_impl(self) -> None:
         df: pd.DataFrame = self.inputs[0].data.payload
-        x, x_label, y, y_label = self._resolve_xy(
-            df, self._x_column, self._y_column
-        )
+        x_col = self._resolve_column(df, self._x_column, default_index=0)
+        y_col = self._resolve_column(df, self._y_column, default_index=1)
 
         bgr = self._render(
-            x,
-            y,
-            x_label=x_label,
-            y_label=y_label,
+            df[x_col].to_numpy(),
+            df[y_col].to_numpy(),
+            x_label=self._axis_label(df, x_col),
+            y_label=self._axis_label(df, y_col),
             width=self._width,
             height=self._height,
             title=self._title,
@@ -139,53 +125,6 @@ class PlotXY(NodeBase):
         self.outputs[0].send(IoData.from_image(bgr))
 
     # ── Pure helpers (testable without rendering) ─────────────────────────────
-
-    @classmethod
-    def _resolve_xy(
-        cls,
-        df: pd.DataFrame,
-        x_column: str,
-        y_column: str,
-    ) -> tuple[np.ndarray, str, np.ndarray, str]:
-        """Pick the X / Y arrays and their axis labels.
-
-        Three paths share this helper:
-
-        1. ``x_column == "_index"`` — X is the row index regardless of
-           how many columns the Dataset has. Y resolves normally
-           (defaulting to the first column).
-
-        2. Single-column Dataset with empty ``x_column`` — same
-           row-index treatment, so a one-column trace (a seismic
-           recording, a one-channel sensor log) plots out of the box
-           without the user having to type a column name. Issue: #231.
-
-        3. Multi-column Dataset — empty ``x_column`` picks the first
-           column for X, empty ``y_column`` picks the second.
-
-        Raises :class:`KeyError` on a non-empty miss or when there
-        aren't enough columns for the chosen defaults.
-        """
-        n_cols = len(df.columns)
-        if n_cols == 0:
-            raise KeyError("Dataset has no columns to plot")
-
-        use_index = x_column == _INDEX_SENTINEL or (not x_column and n_cols == 1)
-
-        if use_index:
-            y_default = 0
-            y_col = cls._resolve_column(df, y_column, default_index=y_default)
-            x_arr = np.arange(len(df))
-            x_label = _INDEX_LABEL
-        else:
-            x_col = cls._resolve_column(df, x_column, default_index=0)
-            y_col = cls._resolve_column(df, y_column, default_index=1)
-            x_arr = df[x_col].to_numpy()
-            x_label = cls._axis_label(df, x_col)
-
-        y_arr = df[y_col].to_numpy()
-        y_label = cls._axis_label(df, y_col)
-        return x_arr, x_label, y_arr, y_label
 
     @staticmethod
     def _resolve_column(
@@ -196,7 +135,10 @@ class PlotXY(NodeBase):
         An empty ``requested`` falls back to the column at
         ``default_index`` so a freshly-dropped node renders without
         the user having to type column names. A non-empty miss raises
-        :class:`KeyError` with the available columns listed.
+        :class:`KeyError` with the available columns listed; an empty
+        request with too few columns points the user at
+        :class:`~nodes.filters.add_index_column.AddIndexColumn`, which
+        is the supported way to add a synthetic X axis.
         """
         if requested:
             if requested not in df.columns:
@@ -208,7 +150,8 @@ class PlotXY(NodeBase):
         if default_index >= len(df.columns):
             raise KeyError(
                 f"Dataset has only {len(df.columns)} column(s); "
-                f"need at least {default_index + 1} to plot"
+                f"need at least {default_index + 1} to plot. "
+                f"Insert an AddIndexColumn node upstream to add an X axis."
             )
         return str(df.columns[default_index])
 

--- a/tests/test_add_index_column.py
+++ b/tests/test_add_index_column.py
@@ -1,0 +1,134 @@
+"""Tests for the :class:`~nodes.filters.add_index_column.AddIndexColumn` node."""
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from core.io_data import IoData, IoDataType
+from nodes.filters.add_index_column import AddIndexColumn
+
+
+def _run(node: AddIndexColumn, df: pd.DataFrame) -> pd.DataFrame:
+    """Drive the node once and return the emitted DataFrame."""
+    node.inputs[0].receive(IoData.from_dataset(df))
+    out = node.outputs[0].last_emitted
+    assert out is not None, "AddIndexColumn did not emit"
+    assert out.type is IoDataType.DATASET
+    return out.payload
+
+
+# ── Defaults ──────────────────────────────────────────────────────────────────
+
+def test_default_index_is_zero_based_step_one() -> None:
+    df = pd.DataFrame({"v": [10.0, 20.0, 30.0]})
+    out = _run(AddIndexColumn(), df)
+    assert list(out.columns) == ["index", "v"]
+    np.testing.assert_array_equal(out["index"].to_numpy(), [0.0, 1.0, 2.0])
+    np.testing.assert_array_equal(out["v"].to_numpy(), [10.0, 20.0, 30.0])
+
+
+def test_index_is_inserted_at_position_zero() -> None:
+    """PlotXY's default x_column='' picks the first column, so the
+    new index has to be at index 0 for the renderer to find it
+    automatically."""
+    df = pd.DataFrame({"a": [1, 2], "b": [3, 4]})
+    out = _run(AddIndexColumn(), df)
+    assert out.columns[0] == "index"
+
+
+# ── Custom name / start / step ────────────────────────────────────────────────
+
+def test_custom_name() -> None:
+    df = pd.DataFrame({"v": [1.0, 2.0]})
+    node = AddIndexColumn()
+    node.name = "t"
+    out = _run(node, df)
+    assert list(out.columns) == ["t", "v"]
+
+
+def test_custom_start_and_step_produce_time_axis() -> None:
+    """Setting step = 1 / sample_rate produces a time axis in seconds —
+    the seismic use case."""
+    df = pd.DataFrame({"amplitude": [0.0, 0.0, 0.0, 0.0]})
+    node = AddIndexColumn()
+    node.name = "t"
+    node.start = 0.0
+    node.step = 0.125  # 8 Hz sampling
+    out = _run(node, df)
+    np.testing.assert_allclose(out["t"].to_numpy(), [0.0, 0.125, 0.250, 0.375])
+
+
+def test_nonzero_start_offset() -> None:
+    df = pd.DataFrame({"v": [0, 0, 0]})
+    node = AddIndexColumn()
+    node.start = 100.0
+    out = _run(node, df)
+    np.testing.assert_array_equal(out["index"].to_numpy(), [100.0, 101.0, 102.0])
+
+
+# ── attrs preservation ───────────────────────────────────────────────────────
+
+def test_preserves_dataset_attrs() -> None:
+    """The whole point of the DATASET payload is that metadata travels
+    with the data. Filters must not silently strip ``df.attrs``."""
+    df = pd.DataFrame({"v": [1.0, 2.0]})
+    df.attrs["sample_rate"] = 8.0
+    df.attrs["station"] = "EIB"
+    df.attrs["source_path"] = "/tmp/something.csv"
+
+    out = _run(AddIndexColumn(), df)
+
+    assert out.attrs["sample_rate"] == 8.0
+    assert out.attrs["station"] == "EIB"
+    assert out.attrs["source_path"] == "/tmp/something.csv"
+
+
+# ── Error paths ───────────────────────────────────────────────────────────────
+
+def test_collision_with_existing_column_raises() -> None:
+    df = pd.DataFrame({"index": [0, 1, 2], "v": [10.0, 20.0, 30.0]})
+    node = AddIndexColumn()
+    with pytest.raises(ValueError, match="already exists"):
+        _run(node, df)
+
+
+def test_zero_step_rejected_at_param_set() -> None:
+    """``step`` is strictly positive — set on the descriptor, not at
+    process time, so a misconfigured flow fails at edit time rather
+    than mid-run."""
+    node = AddIndexColumn()
+    with pytest.raises(ValueError, match=r"step must be > 0"):
+        node.step = 0.0
+
+
+def test_negative_step_rejected() -> None:
+    node = AddIndexColumn()
+    with pytest.raises(ValueError, match=r"step must be > 0"):
+        node.step = -1.0
+
+
+# ── Edge cases ────────────────────────────────────────────────────────────────
+
+def test_empty_dataframe_produces_empty_index() -> None:
+    """An empty DataFrame still has columns; the new index column has
+    zero rows. Doesn't crash; downstream renderers will handle the
+    no-data case (or raise their own clear error)."""
+    df = pd.DataFrame({"v": pd.Series([], dtype=float)})
+    out = _run(AddIndexColumn(), df)
+    assert list(out.columns) == ["index", "v"]
+    assert len(out) == 0
+
+
+def test_does_not_mutate_input_dataframe() -> None:
+    """The node copies before inserting, so the upstream's DataFrame
+    keeps its original shape — important when the same upstream feeds
+    multiple downstream branches."""
+    df = pd.DataFrame({"v": [1.0, 2.0, 3.0]})
+    df.attrs["original"] = True
+    original_columns = list(df.columns)
+
+    _run(AddIndexColumn(), df)
+
+    assert list(df.columns) == original_columns
+    assert "index" not in df.columns

--- a/tests/test_plot_xy.py
+++ b/tests/test_plot_xy.py
@@ -76,59 +76,18 @@ def test_missing_column_raises_keyerror() -> None:
 def test_empty_dataset_raises() -> None:
     df = pd.DataFrame()
     node = PlotXY()
-    with pytest.raises(KeyError, match="no columns"):
+    with pytest.raises(KeyError):
         _run(node, df)
 
 
-# ── Single-column Datasets (issue #231) ──────────────────────────────────────
-
-def test_single_column_default_plots_against_row_index() -> None:
-    """A one-column DataFrame (e.g. a seismic ASCII trace loaded by
-    CsvSource with has_header=False) plots out of the box: row index
-    on X, the column on Y. Default x_column / y_column are empty."""
+def test_single_column_input_raises_with_hint_to_add_index_column() -> None:
+    """A 1-column DATASET no longer auto-falls-back to a row index.
+    The error message points the user at the AddIndexColumn node so
+    the fix path is discoverable."""
     df = pd.DataFrame({"velocity": np.linspace(0.0, 1.0, 8)})
-    node = PlotXY()  # all defaults
-    img = _run(node, df)
-    assert img.size > 0
-
-
-def test_single_column_uses_sample_label_for_x() -> None:
-    df = pd.DataFrame({"v": [0.0, 1.0, 2.0]})
-    x_arr, x_label, y_arr, y_label = PlotXY._resolve_xy(df, "", "")
-    assert x_label == "sample"
-    assert y_label == "v"
-    np.testing.assert_array_equal(x_arr, np.array([0, 1, 2]))
-    np.testing.assert_array_equal(y_arr, np.array([0.0, 1.0, 2.0]))
-
-
-def test_index_sentinel_forces_row_index_on_multi_column_data() -> None:
-    """An explicit x_column='_index' plots Y against position even
-    when the Dataset has multiple columns — useful for picking a
-    single column out of a wide DF and viewing it against position."""
-    df = pd.DataFrame({"V": [0.0, 1.0, 2.0], "I": [10.0, 20.0, 30.0]})
-    x_arr, x_label, y_arr, y_label = PlotXY._resolve_xy(df, "_index", "I")
-    assert x_label == "sample"
-    assert y_label == "I"
-    np.testing.assert_array_equal(x_arr, np.array([0, 1, 2]))
-    np.testing.assert_array_equal(y_arr, np.array([10.0, 20.0, 30.0]))
-
-
-def test_index_sentinel_with_empty_y_picks_first_column() -> None:
-    df = pd.DataFrame({"a": [1.0, 2.0], "b": [3.0, 4.0]})
-    _, _, y_arr, y_label = PlotXY._resolve_xy(df, "_index", "")
-    assert y_label == "a"
-    np.testing.assert_array_equal(y_arr, np.array([1.0, 2.0]))
-
-
-def test_multi_column_default_unchanged() -> None:
-    """The original "first vs second" default still applies for any
-    Dataset with ≥ 2 columns, so existing CV / I-V flows are unaffected."""
-    df = pd.DataFrame({"V": [0.0, 1.0], "I": [0.0, 1e-3], "T": [300.0, 300.0]})
-    x_arr, x_label, y_arr, y_label = PlotXY._resolve_xy(df, "", "")
-    assert x_label == "V"
-    assert y_label == "I"
-    np.testing.assert_array_equal(x_arr, np.array([0.0, 1.0]))
-    np.testing.assert_array_equal(y_arr, np.array([0.0, 1e-3]))
+    node = PlotXY()
+    with pytest.raises(KeyError, match="AddIndexColumn"):
+        _run(node, df)
 
 
 # ── Pure helpers ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Splits the "synthesise an X axis" responsibility out of `PlotXY` into a dedicated **`AddIndexColumn`** node. Cleaner SRP, and the X axis becomes a real named column that any downstream node can address — instead of an implicit, renderer-only "row index" hack.

## What changes

### New: `AddIndexColumn` (`src/nodes/filters/add_index_column.py`, palette section `Data`)

Prepends a numeric column at position 0 of a `DATASET`. Parameters:

- `name` (default `"index"`) — the new column's name; raises on collision with an existing column.
- `start` (default `0.0`) — first value.
- `step` (default `1.0`, strictly positive) — increment per row. Set `step = 1 / sample_rate` for a time axis in seconds (the seismic use case).

Preserves `df.attrs` explicitly so upstream metadata survives.

### Reverted: `PlotXY` row-index fallback (#231)

`PlotXY` always plots two named columns again. A 1-column input raises a `KeyError` whose message points the user at `AddIndexColumn`. Drops `_resolve_xy`, `_INDEX_SENTINEL`, `_INDEX_LABEL`, and the related tests.

### Updated demo flow

`flow/data_display_time_series.flowjs` gets two `AddIndexColumn` nodes inserted between each `CsvSource` and `PlotXY`, with `step = 0.125` so the X axis reads as time in seconds for the 8 Hz quake sample. Also corrects the second `CsvSource`'s `has_header` from `true` to `false` so both branches load the full 5652-sample trace.

Per the new `CLAUDE.md` rule (saved flows are not a backwards-compatibility constraint), no migration shim is provided. Bundled flows are updated in the same PR that breaks them.

Bumps `APP_VERSION` to 0.2.43; CHANGELOG + welcome.html updated.

Closes #235.

## Test plan

- [ ] CI green on `tests/test_add_index_column.py`:
  - default index is `0, 1, 2, …` at column position 0
  - custom name / start / step honoured
  - step = `1/sample_rate` produces correct time axis
  - `df.attrs` preserved (sample_rate, station, source_path)
  - column-name collision raises `ValueError`
  - `step = 0` and `step < 0` rejected at param-set time (descriptor enforces)
  - empty DataFrame produces empty index column without crash
  - input DataFrame is not mutated (multi-branch flows stay safe)
- [ ] CI green on the updated `tests/test_plot_xy.py` — single-column input now raises with `"AddIndexColumn"` in the error message; old row-index tests removed.
- [ ] Visual: open `flow/data_display_time_series.flowjs`, run; both `PlotXY` panes render with a `t` (seconds) X axis, no errors.

https://claude.ai/code/session_01VeUsCbRo2t78AbT1gi3B7S

---
_Generated by [Claude Code](https://claude.ai/code/session_01VeUsCbRo2t78AbT1gi3B7S)_