### PR TITLE
Hodogram: two DATASET inputs (x, y) — drop column-name selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,22 @@ once a first tagged release is cut.
 
 ## [Unreleased]
 
+## [0.2.47] — 2026-04-29
+
+### Changed
+- **``Hodogram`` redesigned with two ``DATASET`` inputs.** Replaces the
+  single ``dataset`` input + ``x_column`` / ``y_column`` string params
+  with separate ``x`` and ``y`` ports. The first column of each input
+  is the signal, so two single-column producers (e.g. two
+  ``CsvSource`` nodes, one per axis) wire straight in — no
+  ``JoinDatasets`` step required. New optional ``x_label`` /
+  ``y_label`` override params keep axis labels readable when both
+  sources share a generic name like ``c0``; empty (default) falls
+  back to the column name. The bundled
+  ``data_display_time_series.flowjs`` demo flow drops the
+  ``JoinDatasets`` node and goes from 9 → 8 graph nodes.
+  Issue: #242.
+
 ## [0.2.46] — 2026-04-29
 
 ### Added

--- a/doc/welcome.html
+++ b/doc/welcome.html
@@ -180,7 +180,7 @@
   <main class="content-col">
 
     <header class="hero">
-      <h1>Welcome to Stjörnhorn <span class="version">v0.2.46</span></h1>
+      <h1>Welcome to Stjörnhorn <span class="version">v0.2.47</span></h1>
       <div class="tagline">A node-based image- and video-processing playground.</div>
     </header>
 
@@ -210,6 +210,13 @@
           <p>Write frames to image files or encode video (MP4V, XVID) with live preview via the Display node.</p>
         </div>
       </div>
+    </section>
+
+    <section>
+      <h2>What's new in v0.2.47</h2>
+      <ul class="tips">
+        <li><strong><code>Hodogram</code> now takes two <code>DATASET</code> inputs.</strong> Replaces the single <code>dataset</code> input + <code>x_column</code> / <code>y_column</code> string params with separate <code>x</code> and <code>y</code> ports — each consumes the first column of its input. Wire two <code>CsvSource</code> nodes (or any single-column producers) straight into the hodogram, no <code>JoinDatasets</code> step required. New <code>x_label</code> / <code>y_label</code> override params (default empty → use column name) keep axis labels readable when both sources share a generic name like <code>c0</code>. The bundled seismic demo flow drops to 9 nodes. Issue #242.</li>
+      </ul>
     </section>
 
     <section>

--- a/flow/data_display_time_series.flowjs
+++ b/flow/data_display_time_series.flowjs
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "app_version": "0.2.46",
+  "app_version": "0.2.47",
   "name": "data_display_time_series",
   "nodes": [
     {
@@ -79,18 +79,6 @@
     },
     {
       "id": 4,
-      "module": "nodes.filters.join_datasets",
-      "class": "JoinDatasets",
-      "position": [
-        -1600.0,
-        -100.0
-      ],
-      "port_defaults": {
-        "column_names": "N,E"
-      }
-    },
-    {
-      "id": 5,
       "module": "nodes.filters.hodogram",
       "class": "Hodogram",
       "position": [
@@ -98,8 +86,8 @@
         -227.60000000000002
       ],
       "port_defaults": {
-        "x_column": "N",
-        "y_column": "E",
+        "x_label": "N",
+        "y_label": "E",
         "width": 800,
         "height": 800,
         "color_by_time": true,
@@ -109,7 +97,7 @@
       }
     },
     {
-      "id": 6,
+      "id": 5,
       "module": "nodes.filters.merge",
       "class": "Merge",
       "position": [
@@ -119,7 +107,7 @@
       "port_defaults": {}
     },
     {
-      "id": 7,
+      "id": 6,
       "module": "nodes.filters.merge",
       "class": "Merge",
       "position": [
@@ -129,7 +117,7 @@
       "port_defaults": {}
     },
     {
-      "id": 8,
+      "id": 7,
       "module": "nodes.filters.display",
       "class": "Display",
       "position": [
@@ -143,7 +131,7 @@
       ]
     },
     {
-      "id": 9,
+      "id": 8,
       "module": "nodes.sinks.file_sink",
       "class": "FileSink",
       "position": [
@@ -181,22 +169,28 @@
       "dst_input": 1
     },
     {
-      "src_node": 4,
+      "src_node": 2,
       "src_output": 0,
       "dst_node": 5,
       "dst_input": 0
     },
     {
-      "src_node": 2,
+      "src_node": 3,
+      "src_output": 0,
+      "dst_node": 5,
+      "dst_input": 2
+    },
+    {
+      "src_node": 5,
       "src_output": 0,
       "dst_node": 6,
       "dst_input": 0
     },
     {
-      "src_node": 3,
+      "src_node": 4,
       "src_output": 0,
       "dst_node": 6,
-      "dst_input": 2
+      "dst_input": 1
     },
     {
       "src_node": 6,
@@ -205,21 +199,9 @@
       "dst_input": 0
     },
     {
-      "src_node": 5,
-      "src_output": 0,
-      "dst_node": 7,
-      "dst_input": 1
-    },
-    {
       "src_node": 7,
       "src_output": 0,
       "dst_node": 8,
-      "dst_input": 0
-    },
-    {
-      "src_node": 8,
-      "src_output": 0,
-      "dst_node": 9,
       "dst_input": 0
     }
   ],

--- a/flow/data_display_time_series.flowjs
+++ b/flow/data_display_time_series.flowjs
@@ -82,8 +82,8 @@
       "module": "nodes.filters.hodogram",
       "class": "Hodogram",
       "position": [
-        -1288.1999999999998,
-        -227.60000000000002
+        -1609.2012770503088,
+        -89.70508521078281
       ],
       "port_defaults": {
         "x_label": "N",
@@ -101,8 +101,8 @@
       "module": "nodes.filters.merge",
       "class": "Merge",
       "position": [
-        -1275.0,
-        -602.8000000000002
+        -1376.2028555675033,
+        -608.6838869515992
       ],
       "port_defaults": {}
     },
@@ -111,8 +111,8 @@
       "module": "nodes.filters.merge",
       "class": "Merge",
       "position": [
-        -949.7999999999998,
-        -556.5999999999999
+        -1229.8730188961135,
+        -413.03315838098365
       ],
       "port_defaults": {}
     },
@@ -121,8 +121,8 @@
       "module": "nodes.filters.display",
       "class": "Display",
       "position": [
-        -1376.8043478260863,
-        -1100.318695652174
+        -1268.8869256056792,
+        -195.46531082277914
       ],
       "port_defaults": {},
       "size": [
@@ -135,8 +135,8 @@
       "module": "nodes.sinks.file_sink",
       "class": "FileSink",
       "position": [
-        -916.0,
-        -151.39999999999998
+        -507.52829217252565,
+        262.1295940042186
       ],
       "port_defaults": {
         "output_path": "out.png"

--- a/src/constants.py
+++ b/src/constants.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 APP_NAME:         str = "Image-Inquest"
 APP_DISPLAY_NAME: str = "Stjörnhorn"
-APP_VERSION:      str = "0.2.46"
+APP_VERSION:      str = "0.2.47"
 API_URL:    str = "https://beltoforion.de"
 
 # Path resolution -----------------------------------------------------------

--- a/src/nodes/filters/hodogram.py
+++ b/src/nodes/filters/hodogram.py
@@ -21,6 +21,12 @@ from core.node_base import NodeBase
 from core.params import BoolParam, IntParam, StringParam
 from core.port import InputPort, OutputPort
 
+#: Names of the two DATASET input ports — also used as the default
+#: axis labels when the input dataset's first column is named with
+#: a generic placeholder (CsvSource emits ``c0``).
+_X_INPUT: str = "x"
+_Y_INPUT: str = "y"
+
 #: Render DPI used when sizing the matplotlib figure. Width / height in
 #: pixels are converted to inches via ``size_px / _RENDER_DPI``.
 _RENDER_DPI: int = 100
@@ -237,7 +243,7 @@ class HodogramRenderer:
 
 
 class Hodogram(NodeBase):
-    """Render two columns of a :data:`IoDataType.DATASET` as a hodogram.
+    """Render two single-column :data:`IoDataType.DATASET` inputs as a hodogram.
 
     A hodogram is a particle-motion plot — the trajectory of one signal
     against another instead of each one against time. The canonical use
@@ -245,6 +251,12 @@ class Hodogram(NodeBase):
     estimate back-azimuth from a P-wave's linear arrival), but the same
     view is generic enough for Lissajous figures, phase-space loops, or
     any pair of correlated signals.
+
+    Two ``DATASET`` inputs (``x`` and ``y``) carry the two channels.
+    The node uses the **first column** of each input as the signal,
+    so the natural pipeline is one ``CsvSource`` (or any single-column
+    producer) per axis, wired straight in. No ``JoinDatasets`` step
+    is needed.
 
     Three visual options on top of the basic trajectory:
 
@@ -259,32 +271,31 @@ class Hodogram(NodeBase):
       stays generic for non-seismic use.
 
     Parameters:
-      x_column          -- column name for X. Default ``"N"`` (the
-                           seismic convention); falls back to the
-                           first column when no ``"N"`` is present.
-      y_column          -- column name for Y. Default ``"E"``; falls
-                           back to the second column.
+      x_label / y_label -- override axis labels. Empty (default) uses
+                           the column name of the input's first column.
+                           Useful when both sources share a generic
+                           name like ``c0`` from ``CsvSource``.
       width / height    -- output image size in pixels (≥ 64).
       color_by_time     -- gradient-colour the trajectory.
       equal_aspect      -- force 1:1 axis scaling.
       show_polarization -- overlay the fitted PCA axis + readout.
+      title             -- optional plot title.
     """
 
-    x_column = StringParam(
-        "N",
-        placeholder="N",
+    x_label = StringParam(
+        "",
+        placeholder="(column name)",
         description=(
-            "Column name for the X axis. Default 'N' matches the "
-            "standard seismic Z/N/E ordering; falls back to the first "
-            "column when no 'N' is present."
+            "Override label for the X axis. Empty falls back to the "
+            "column name of the x input's first column."
         ),
     )
-    y_column = StringParam(
-        "E",
-        placeholder="E",
+    y_label = StringParam(
+        "",
+        placeholder="(column name)",
         description=(
-            "Column name for the Y axis. Default 'E'; falls back to "
-            "the second column when no 'E' is present."
+            "Override label for the Y axis. Empty falls back to the "
+            "column name of the y input's first column."
         ),
     )
     width = IntParam(
@@ -329,27 +340,36 @@ class Hodogram(NodeBase):
 
     def __init__(self) -> None:
         super().__init__("Hodogram", section="Visualization")
-        self._add_input(InputPort("dataset", {IoDataType.DATASET}))
+        # Explicit annotations so pyright sees the descriptor-backed attrs.
+        self._x_label: str
+        self._y_label: str
+        self._width: int
+        self._height: int
+        self._color_by_time: bool
+        self._equal_aspect: bool
+        self._show_polarization: bool
+        self._title: str
+        self._add_input(InputPort(_X_INPUT, {IoDataType.DATASET}, optional=False))
+        self._add_input(InputPort(_Y_INPUT, {IoDataType.DATASET}, optional=False))
         self._add_output(OutputPort("image", {IoDataType.IMAGE}))
         self._apply_default_params()
 
     @override
     def process_impl(self) -> None:
-        df: pd.DataFrame = self.inputs[0].data.payload
-        if len(df.columns) < 2:
-            raise KeyError(
-                f"Hodogram needs ≥ 2 columns; "
-                f"dataset has {len(df.columns)}: {list(df.columns)}"
-            )
-        x_col = self._resolve_column(df, self._x_column, default_index=0)
-        y_col = self._resolve_column(df, self._y_column, default_index=1)
+        x_df: pd.DataFrame = self.inputs[0].data.payload
+        y_df: pd.DataFrame = self.inputs[1].data.payload
+        if len(x_df.columns) == 0 or len(y_df.columns) == 0:
+            raise KeyError("Hodogram inputs must each have ≥ 1 column")
 
-        motion = ParticleMotion(df[x_col].to_numpy(), df[y_col].to_numpy())
+        x_col = str(x_df.columns[0])
+        y_col = str(y_df.columns[0])
+
+        motion = ParticleMotion(x_df[x_col].to_numpy(), y_df[y_col].to_numpy())
         renderer = HodogramRenderer()
         bgr = renderer.render(
             motion,
-            x_label=self._axis_label(df, x_col),
-            y_label=self._axis_label(df, y_col),
+            x_label=self._x_label or self._axis_label(x_df, x_col),
+            y_label=self._y_label or self._axis_label(y_df, y_col),
             width=self._width,
             height=self._height,
             color_by_time=self._color_by_time,
@@ -360,28 +380,6 @@ class Hodogram(NodeBase):
         self.outputs[0].send(IoData.from_image(bgr))
 
     # ── Pure helpers (testable without rendering) ────────────────────────────
-
-    @staticmethod
-    def _resolve_column(
-        df: pd.DataFrame, requested: str, *, default_index: int
-    ) -> str:
-        """Resolve a column name with a positional fallback.
-
-        Unlike :class:`PlotXY`, the empty-string case never arises here
-        (the descriptor seeds ``"N"``/``"E"`` defaults). When the
-        requested name *is* set but missing — typical for non-seismic
-        Datasets that don't use Z/N/E names — the positional fallback
-        kicks in instead of raising, so a default-configured Hodogram
-        on a generic 2-column Dataset still renders.
-        """
-        if requested and requested in df.columns:
-            return requested
-        if default_index >= len(df.columns):
-            raise KeyError(
-                f"Cannot resolve column {requested!r}: "
-                f"dataset has {len(df.columns)} column(s)"
-            )
-        return str(df.columns[default_index])
 
     @staticmethod
     def _axis_label(df: pd.DataFrame, column: str) -> str:

--- a/tests/test_hodogram.py
+++ b/tests/test_hodogram.py
@@ -92,20 +92,17 @@ def test_principal_axis_negative_slope_normalised() -> None:
 # ── Hodogram node — render output ────────────────────────────────────────────
 
 
-def _zne_df(n: int = 64) -> pd.DataFrame:
-    """A small Z/N/E DataFrame: linear N-vs-E motion at 30°."""
+def _ne_dfs(n: int = 64) -> tuple[pd.DataFrame, pd.DataFrame]:
+    """Two single-column DataFrames: linear N-vs-E motion at 30°."""
     t = np.linspace(0.0, 1.0, n)
-    return pd.DataFrame(
-        {
-            "Z": np.zeros(n),
-            "N": np.cos(np.deg2rad(30.0)) * t,
-            "E": np.sin(np.deg2rad(30.0)) * t,
-        }
-    )
+    n_df = pd.DataFrame({"N": np.cos(np.deg2rad(30.0)) * t})
+    e_df = pd.DataFrame({"E": np.sin(np.deg2rad(30.0)) * t})
+    return n_df, e_df
 
 
-def _run(node: Hodogram, df: pd.DataFrame) -> np.ndarray:
-    node.inputs[0].receive(IoData.from_dataset(df))
+def _run(node: Hodogram, x_df: pd.DataFrame, y_df: pd.DataFrame) -> np.ndarray:
+    node.inputs[0].receive(IoData.from_dataset(x_df))
+    node.inputs[1].receive(IoData.from_dataset(y_df))
     out = node.outputs[0].last_emitted
     assert out is not None, "Hodogram did not emit"
     assert out.type is IoDataType.IMAGE
@@ -116,34 +113,42 @@ def test_hodogram_emits_image_of_requested_shape() -> None:
     node = Hodogram()
     node.width = 200
     node.height = 200
-    img = _run(node, _zne_df())
+    x_df, y_df = _ne_dfs()
+    img = _run(node, x_df, y_df)
     assert img.dtype == np.uint8
     assert img.shape == (200, 200, 3)
 
 
-def test_hodogram_default_columns_pick_n_and_e() -> None:
-    """A Z/N/E dataset is the seismic happy path — defaults should
-    just work without the user typing column names."""
-    node = Hodogram()  # x="N", y="E"
-    img = _run(node, _zne_df())
+def test_hodogram_uses_first_column_of_each_input() -> None:
+    """The node always picks column 0 of each input — extra columns
+    are ignored. Mirrors the spec: one channel per input."""
+    n = 32
+    t = np.linspace(0.0, 1.0, n)
+    x_df = pd.DataFrame({"N": t, "extra": np.full(n, 999.0)})
+    y_df = pd.DataFrame({"E": 2 * t})
+    img = _run(Hodogram(), x_df, y_df)
     assert img.size > 0
 
 
-def test_hodogram_falls_back_to_positional_for_non_seismic_columns() -> None:
-    """When the Dataset doesn't use Z/N/E names, the seismic defaults
-    can't match — the positional fallback (first / second columns)
-    kicks in so a generic 2-column Dataset still renders."""
-    df = pd.DataFrame({"alpha": np.linspace(0, 1, 16), "beta": np.linspace(0, 0.5, 16)})
-    node = Hodogram()  # defaults still "N"/"E"
-    img = _run(node, df)
+def test_hodogram_renders_generic_column_names() -> None:
+    """Two ``c0`` inputs (the CsvSource default) render fine — column
+    names are not part of the hodogram pipeline any more."""
+    n = 16
+    x_df = pd.DataFrame({"c0": np.linspace(0, 1, n)})
+    y_df = pd.DataFrame({"c0": np.linspace(0, 0.5, n)})
+    img = _run(Hodogram(), x_df, y_df)
     assert img.size > 0
 
 
-def test_hodogram_raises_on_too_few_columns() -> None:
-    df = pd.DataFrame({"only": [1.0, 2.0, 3.0]})
-    node = Hodogram()
-    with pytest.raises(KeyError, match=r"≥ 2 columns"):
-        _run(node, df)
+def test_hodogram_raises_on_empty_input() -> None:
+    """A 0-column DataFrame on either input must raise — there's no
+    signal to plot."""
+    empty = pd.DataFrame()
+    full = pd.DataFrame({"c0": [1.0, 2.0]})
+    with pytest.raises(KeyError, match=r"≥ 1 column"):
+        _run(Hodogram(), empty, full)
+    with pytest.raises(KeyError, match=r"≥ 1 column"):
+        _run(Hodogram(), full, empty)
 
 
 def test_hodogram_color_by_time_off_uses_solid_line() -> None:
@@ -154,7 +159,8 @@ def test_hodogram_color_by_time_off_uses_solid_line() -> None:
     tracked via the unit test against a reference image, deferred."""
     node = Hodogram()
     node.color_by_time = False
-    img = _run(node, _zne_df())
+    x_df, y_df = _ne_dfs()
+    img = _run(node, x_df, y_df)
     assert img.dtype == np.uint8
     assert img.ndim == 3
 
@@ -165,7 +171,20 @@ def test_hodogram_show_polarization_smoke() -> None:
     doesn't crash on real data."""
     node = Hodogram()
     node.show_polarization = True
-    img = _run(node, _zne_df())
+    x_df, y_df = _ne_dfs()
+    img = _run(node, x_df, y_df)
+    assert img.size > 0
+
+
+def test_hodogram_label_overrides_take_precedence() -> None:
+    """``x_label`` / ``y_label`` overrides bypass the column-name
+    fallback. Useful when both inputs share a generic ``c0``."""
+    node = Hodogram()
+    node.x_label = "North"
+    node.y_label = "East"
+    x_df = pd.DataFrame({"c0": np.linspace(0, 1, 8)})
+    y_df = pd.DataFrame({"c0": np.linspace(0, 1, 8)})
+    img = _run(node, x_df, y_df)
     assert img.size > 0
 
 


### PR DESCRIPTION
## Summary

- `Hodogram` now exposes two `DATASET` inputs (`x`, `y`) instead of a single dataset + `x_column` / `y_column` string params. Each input contributes its first column as the signal.
- Adds optional `x_label` / `y_label` override params (default empty → use column name) so axis labels stay readable when both sources share a generic name like `c0`.
- Demo flow `data_display_time_series.flowjs` wires two `CsvSource` nodes straight into the hodogram; the `JoinDatasets` node is no longer needed there.
- `JoinDatasets` itself stays — generic dataset combiner, still useful.

## Why

A hodogram is semantically two independent time series plotted against each other. The single-DATASET design forced a `JoinDatasets` node in front of every hodogram just to merge two single-column DataFrames into one — a join with no conceptual meaning in the physics. Two inputs match how users think about the node.

## Test plan

- [x] `tests/test_hodogram.py` rewritten for two-input wiring (21 passed).
- [x] `tests/test_join_datasets.py`, `tests/test_plot_series.py` still pass.
- [x] Demo flow loads, every connection resolves to a valid port.
- [x] Smoke instantiation: two single-column DataFrames → 360×360×3 BGR image.

Fixes #242

https://claude.ai/code/session_01VeUsCbRo2t78AbT1gi3B7S

---
_Generated by [Claude Code](https://claude.ai/code/session_01VeUsCbRo2t78AbT1gi3B7S)_