### PR TITLE
Align APP_NAME with brand identity to "Stjörnhorn"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ once a first tagged release is cut.
 
 ## [0.3.0] — 2026-04-29
 
+### Changed
+
+- `APP_NAME` aligned with the brand: now `"Stjörnhorn"` (was the legacy
+  `"Image-Inquest"`). Affects the Qt application name and the startup
+  log line; user-visible captions are unchanged because they already
+  use `APP_DISPLAY_NAME`, which read `"Stjörnhorn"` before.
+
 ### Versioning reset
 
 The 0.2.x line — 98 micro-bumps tracking individual PRs — has been

--- a/src/constants.py
+++ b/src/constants.py
@@ -2,9 +2,9 @@ import os
 import sys
 from pathlib import Path
 
-APP_NAME:         str = "Image-Inquest"
+APP_NAME:         str = "Stjörnhorn"
 APP_DISPLAY_NAME: str = "Stjörnhorn"
-APP_VERSION:      str = "0.3.0.0"
+APP_VERSION:      str = "0.3.0.1"
 API_URL:    str = "https://beltoforion.de"
 
 # Path resolution -----------------------------------------------------------


### PR DESCRIPTION
## Summary
Updated the application's internal name constant to match the established brand identity, changing `APP_NAME` from the legacy `"Image-Inquest"` to `"Stjörnhorn"`.

## Changes
- **APP_NAME constant**: Changed from `"Image-Inquest"` to `"Stjörnhorn"` in `src/constants.py`
  - This affects the Qt application name and startup log output
  - User-visible captions remain unchanged as they already use `APP_DISPLAY_NAME`
- **Version bump**: Incremented `APP_VERSION` from `0.3.0.0` to `0.3.0.1` to reflect this change

## Details
The `APP_DISPLAY_NAME` constant was already set to `"Stjörnhorn"`, so this change brings the internal `APP_NAME` into alignment with the brand. Since user-facing UI elements already reference `APP_DISPLAY_NAME`, this change primarily affects the application's internal identity as seen in Qt window titles and startup logs.

https://claude.ai/code/session_017Q45XSv1CneevA6jvjjujA