### PR TITLE
TickTack/Step 1: IoData metadata + MetaInspector + PlayGate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,11 +16,16 @@ once a first tagged release is cut.
 
 - Per-frame metadata on `IoData`: new `IoMeta` open-ended `str → Any`
   bag (no fixed schema — any node may stamp any key). Travels
-  alongside the payload and survives pass-through filters via
-  `IoData.with_image` / new `IoData.with_payload` / new
-  `IoData.with_meta`. Conventional keys: `frame_index`, `source_path`,
-  `timestamp`. Foundation for filename templating (#159) and the
-  animated hodogram pipeline (#246, #251).
+  alongside the payload and survives pass-through filters via the new
+  `IoData.clone(*, payload=..., **meta_changes)` helper. Conventional
+  keys: `frame_index`, `source_path`, `timestamp`. Foundation for
+  filename templating (#159) and the animated hodogram pipeline
+  (#246, #251).
+- The previous `IoData.with_image` was replaced by `IoData.clone(payload=...)`
+  — the operation was always a clone with the payload swapped. Meta
+  updates take the same method: `data.clone(frame_index=5)`, both can
+  combine: `data.clone(payload=arr, frame_index=5)`. Node-author code
+  that called `with_image` must switch to `clone(payload=...)`.
 - `OutputPort.send` auto-stamps `meta.frame_index` from a per-port
   emit counter; `OutputPort.reset` rewinds the counter at the start
   of every flow run. Producers no longer thread frame indices

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,12 +14,13 @@ once a first tagged release is cut.
 
 ### Added (TickTack Step 1, #250)
 
-- Per-frame metadata on `IoData`: new `IoMeta` dataclass with
-  `source_path`, `frame_index`, `timestamp`, `extras`. Travels
+- Per-frame metadata on `IoData`: new `IoMeta` open-ended `str → Any`
+  bag (no fixed schema — any node may stamp any key). Travels
   alongside the payload and survives pass-through filters via
   `IoData.with_image` / new `IoData.with_payload` / new
-  `IoData.with_meta`. Foundation for filename templating (#159) and
-  the animated hodogram pipeline (#246, #251).
+  `IoData.with_meta`. Conventional keys: `frame_index`, `source_path`,
+  `timestamp`. Foundation for filename templating (#159) and the
+  animated hodogram pipeline (#246, #251).
 - `OutputPort.send` auto-stamps `meta.frame_index` from a per-port
   emit counter; `OutputPort.reset` rewinds the counter at the start
   of every flow run. Producers no longer thread frame indices

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,28 @@ once a first tagged release is cut.
 
 ## [0.3.0] — 2026-04-29
 
+### Added (TickTack Step 1, #250)
+
+- Per-frame metadata on `IoData`: new `IoMeta` dataclass with
+  `source_path`, `frame_index`, `timestamp`, `extras`. Travels
+  alongside the payload and survives pass-through filters via
+  `IoData.with_image` / new `IoData.with_payload` / new
+  `IoData.with_meta`. Foundation for filename templating (#159) and
+  the animated hodogram pipeline (#246, #251).
+- `OutputPort.send` auto-stamps `meta.frame_index` from a per-port
+  emit counter; `OutputPort.reset` rewinds the counter at the start
+  of every flow run. Producers no longer thread frame indices
+  manually.
+- `ImageSource` and `CsvSource` now stamp `meta.source_path` with the
+  resolved absolute path on every emit.
+- New **Meta Inspector** node under the **Debug** section: pass-through
+  probe that surfaces every frame's `IoMeta` (plus payload kind /
+  shape) in its node body. Type-agnostic, can sit anywhere in a flow.
+- New **Play Gate** node under the **Debug** section: pass-through
+  with a Play button in its node body. Holds the most recent input
+  frame, releases it downstream on click. Useful for stepping through
+  a stream while iterating on flow design.
+
 ### Changed
 
 - `APP_NAME` aligned with the brand: now `"Stjörnhorn"` (was the legacy

--- a/flow/test_ranged.flowjs
+++ b/flow/test_ranged.flowjs
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "app_version": "0.3.0.2",
+  "app_version": "0.3.0.3",
   "name": "test_ranged",
   "nodes": [
     {
@@ -8,8 +8,8 @@
       "module": "nodes.sources.image_source",
       "class": "ImageSource",
       "position": [
-        -1292.0,
-        -522.0
+        -1334.2481444605353,
+        -828.49108435916
       ],
       "port_defaults": {
         "file_path": "ship.jpg"
@@ -20,8 +20,8 @@
       "module": "nodes.sinks.file_sink",
       "class": "FileSink",
       "position": [
-        -584.0,
-        -507.0
+        -760.6740586531498,
+        -480.8829652425778
       ],
       "port_defaults": {
         "output_path": "out.png"
@@ -29,23 +29,56 @@
     },
     {
       "id": 2,
-      "module": "nodes.sources.range_source",
-      "class": "RangeSource",
+      "module": "nodes.debug.meta_inspector",
+      "class": "MetaInspector",
       "position": [
-        -980.0,
-        -818.0
+        -789.65622737147,
+        -841.8902968863146
       ],
-      "port_defaults": {
-        "min_value": 1,
-        "max_value": 10,
-        "increment": 1.0,
-        "loop": false
-      }
+      "port_defaults": {}
+    },
+    {
+      "id": 3,
+      "module": "nodes.debug.play_gate",
+      "class": "PlayGate",
+      "position": [
+        -1032.3910209992757,
+        -844.1947411296163
+      ],
+      "port_defaults": {}
+    },
+    {
+      "id": 4,
+      "module": "nodes.filters.display",
+      "class": "Display",
+      "position": [
+        -1053.1310191889934,
+        -506.2095854453295
+      ],
+      "port_defaults": {}
     }
   ],
   "connections": [
     {
+      "src_node": 3,
+      "src_output": 0,
+      "dst_node": 2,
+      "dst_input": 0
+    },
+    {
       "src_node": 0,
+      "src_output": 0,
+      "dst_node": 3,
+      "dst_input": 0
+    },
+    {
+      "src_node": 2,
+      "src_output": 0,
+      "dst_node": 4,
+      "dst_input": 0
+    },
+    {
+      "src_node": 4,
       "src_output": 0,
       "dst_node": 1,
       "dst_input": 0

--- a/src/constants.py
+++ b/src/constants.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 APP_NAME:         str = "Stjörnhorn"
 APP_DISPLAY_NAME: str = "Stjörnhorn"
-APP_VERSION:      str = "0.3.0.2"
+APP_VERSION:      str = "0.3.0.3"
 API_URL:    str = "https://beltoforion.de"
 
 # Path resolution -----------------------------------------------------------

--- a/src/core/io_data.py
+++ b/src/core/io_data.py
@@ -27,6 +27,12 @@ class IoDataType(Enum):
 IMAGE_TYPES: frozenset[IoDataType] = frozenset({IoDataType.IMAGE, IoDataType.IMAGE_GREY})
 
 
+#: Sentinel for "argument not supplied" on :meth:`IoData.clone`. Lets
+#: callers pass ``payload=None`` to actually mean "set the payload to
+#: None" rather than colliding with the default.
+_UNSET: Any = object()
+
+
 class IoMeta(Mapping[str, Any]):
     """Open-ended per-frame metadata bag travelling with an :class:`IoData`.
 
@@ -284,30 +290,28 @@ class IoData:
         """Return True if this carries an image payload (colour or greyscale)."""
         return self._type in IMAGE_TYPES
 
-    def with_image(self, image: np.ndarray) -> IoData:
-        """Return a new :class:`IoData` with the same type, payload replaced.
+    def clone(self, *, payload: Any = _UNSET, **meta_changes: Any) -> IoData:
+        """Return a copy of this :class:`IoData` with selected fields replaced.
 
-        Use this in pass-through filters so the output type (IMAGE vs
-        IMAGE_GREY) matches the input without the filter having to branch on
-        it explicitly. The :class:`IoMeta` is forwarded by reference so
-        provenance survives the filter chain.
+        Type is always forwarded so a pass-through filter doesn't have
+        to branch on IMAGE vs IMAGE_GREY (vs SCALAR vs DATASET).
+
+        - ``payload=value`` overrides the payload verbatim. Pass-through
+          filters use this to ship a transformed array without
+          rebuilding the envelope.
+        - Any other keyword arguments are interpreted as
+          :class:`IoMeta` updates and merged via
+          :meth:`IoMeta.replace` — ``data.clone(frame_index=5)`` keeps
+          the payload, stamps a new index, leaves other meta keys
+          alone.
+
+        Both can be combined: ``data.clone(payload=arr, frame_index=5)``.
         """
-        return IoData(self._type, payload=image, meta=self._meta)
-
-    def with_payload(self, payload: Any) -> IoData:
-        """Return a new :class:`IoData` with the same type/meta, payload
-        replaced. Generalisation of :meth:`with_image` for non-image
-        payload kinds."""
-        return IoData(self._type, payload=payload, meta=self._meta)
-
-    def with_meta(self, **changes: Any) -> IoData:
-        """Return a new :class:`IoData` with selected meta fields overridden.
-
-        Same payload and type; the IoMeta is the result of
-        ``self.meta.replace(**changes)``. Use to stamp a frame_index,
-        record a source path, etc., without rebuilding the payload.
-        """
-        return IoData(self._type, payload=self._payload, meta=self._meta.replace(**changes))
+        new_payload = self._payload if payload is _UNSET else payload
+        new_meta = (
+            self._meta.replace(**meta_changes) if meta_changes else self._meta
+        )
+        return IoData(self._type, payload=new_payload, meta=new_meta)
 
     def __repr__(self) -> str:
         # Image / SCALAR / MATRIX payloads expose a numpy ``shape``; the

--- a/src/core/io_data.py
+++ b/src/core/io_data.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
 from typing import Any
@@ -24,6 +25,53 @@ class IoDataType(Enum):
 #: declaring input/output ports that accept colour or greyscale images
 #: interchangeably, e.g. filters like Median and Scale that work on either.
 IMAGE_TYPES: frozenset[IoDataType] = frozenset({IoDataType.IMAGE, IoDataType.IMAGE_GREY})
+
+
+@dataclass
+class IoMeta:
+    """Per-frame metadata travelling alongside an :class:`IoData` payload.
+
+    Carries provenance and timing information that downstream nodes —
+    notably sinks doing filename templating — can read without
+    reaching back through the graph. Fields are independent: a value
+    in one does not constrain another.
+
+    Fields:
+      source_path -- absolute path of the originating file when the
+                     IoData began life as a source-loaded artefact
+                     (ImageSource, CsvSource). ``None`` for synthetic
+                     payloads (RangeSource, ConstantValue).
+      frame_index -- per-output-port emit counter, stamped automatically
+                     on :meth:`core.port.OutputPort.send`. Starts at 0
+                     for the first emit of a run; resets on
+                     :meth:`core.port.OutputPort.reset`.
+      timestamp   -- run start time as ``time.time()`` (Unix epoch
+                     seconds) when set by the runner. ``None`` outside
+                     a Flow.run context.
+      extras      -- escape hatch for ad-hoc tagging; node authors can
+                     stash arbitrary keys here without growing the
+                     IoMeta surface.
+    """
+
+    source_path: Path | None = None
+    frame_index: int = 0
+    timestamp: float | None = None
+    extras: dict[str, Any] = field(default_factory=dict)
+
+    def replace(self, **changes: Any) -> "IoMeta":
+        """Return a new :class:`IoMeta` with selected fields overridden.
+
+        Mirrors :func:`dataclasses.replace` semantics. ``extras`` is
+        shallow-copied so the caller's writes don't leak back into the
+        original meta object.
+        """
+        new_extras = dict(changes.pop("extras", self.extras))
+        return IoMeta(
+            source_path=changes.pop("source_path", self.source_path),
+            frame_index=changes.pop("frame_index", self.frame_index),
+            timestamp=changes.pop("timestamp", self.timestamp),
+            extras=new_extras,
+        )
 
 
 class IoData:
@@ -61,28 +109,34 @@ class IoData:
     payload value on this channel.
     """
 
-    def __init__(self, type: IoDataType, payload: Any) -> None:
+    def __init__(
+        self,
+        type: IoDataType,
+        payload: Any,
+        meta: IoMeta | None = None,
+    ) -> None:
         self._type = type
         self._payload = payload
+        self._meta: IoMeta = meta if meta is not None else IoMeta()
 
     # ── Factory methods ────────────────────────────────────────────────────────
 
     @classmethod
-    def from_image(cls, image: np.ndarray) -> IoData:
+    def from_image(cls, image: np.ndarray, *, meta: IoMeta | None = None) -> IoData:
         """Wrap a (potentially multi-channel) image as :data:`IoDataType.IMAGE`."""
-        return cls(IoDataType.IMAGE, payload=image)
+        return cls(IoDataType.IMAGE, payload=image, meta=meta)
 
     @classmethod
-    def from_greyscale(cls, image: np.ndarray) -> IoData:
+    def from_greyscale(cls, image: np.ndarray, *, meta: IoMeta | None = None) -> IoData:
         """Wrap a single-channel image as :data:`IoDataType.IMAGE_GREY`.
 
         The image is expected to be a 2-D ``uint8`` array. No shape check is
         enforced — callers are responsible for producing the right shape.
         """
-        return cls(IoDataType.IMAGE_GREY, payload=image)
+        return cls(IoDataType.IMAGE_GREY, payload=image, meta=meta)
 
     @classmethod
-    def from_scalar(cls, value: object) -> IoData:
+    def from_scalar(cls, value: object, *, meta: IoMeta | None = None) -> IoData:
         """Wrap a numeric scalar as :data:`IoDataType.SCALAR`.
 
         Accepts a Python ``int``/``float``, a numpy scalar, or any 0-d
@@ -95,10 +149,10 @@ class IoData:
             raise ValueError(
                 f"Scalar payload must be 0-d (ndim==0), got shape {arr.shape}"
             )
-        return cls(IoDataType.SCALAR, payload=arr)
+        return cls(IoDataType.SCALAR, payload=arr, meta=meta)
 
     @classmethod
-    def from_matrix(cls, matrix: np.ndarray) -> IoData:
+    def from_matrix(cls, matrix: np.ndarray, *, meta: IoMeta | None = None) -> IoData:
         """Wrap a 2-D numpy array as :data:`IoDataType.MATRIX`.
 
         Accepts any array-like (incl. nested lists); the result is
@@ -111,10 +165,10 @@ class IoData:
             raise ValueError(
                 f"Matrix payload must be 2-d (ndim==2), got shape {arr.shape}"
             )
-        return cls(IoDataType.MATRIX, payload=arr)
+        return cls(IoDataType.MATRIX, payload=arr, meta=meta)
 
     @classmethod
-    def from_dataset(cls, df: pd.DataFrame) -> IoData:
+    def from_dataset(cls, df: pd.DataFrame, *, meta: IoMeta | None = None) -> IoData:
         """Wrap a :class:`pandas.DataFrame` as :data:`IoDataType.DATASET`.
 
         The DataFrame is stored verbatim — its columns identify channels
@@ -132,10 +186,10 @@ class IoData:
                 f"Dataset payload must be a pandas.DataFrame, "
                 f"got {type(df).__name__}"
             )
-        return cls(IoDataType.DATASET, payload=df)
+        return cls(IoDataType.DATASET, payload=df, meta=meta)
 
     @classmethod
-    def from_bool(cls, value: object) -> IoData:
+    def from_bool(cls, value: object, *, meta: IoMeta | None = None) -> IoData:
         """Wrap a boolean as :data:`IoDataType.BOOL`.
 
         Coerces with ``bool(value)`` so widget-side strings like
@@ -143,15 +197,15 @@ class IoData:
         ``bool("false")`` is ``True`` — callers handing in strings
         should normalise first).
         """
-        return cls(IoDataType.BOOL, payload=bool(value))
+        return cls(IoDataType.BOOL, payload=bool(value), meta=meta)
 
     @classmethod
-    def from_string(cls, value: object) -> IoData:
+    def from_string(cls, value: object, *, meta: IoMeta | None = None) -> IoData:
         """Wrap a string as :data:`IoDataType.STRING`."""
-        return cls(IoDataType.STRING, payload=str(value))
+        return cls(IoDataType.STRING, payload=str(value), meta=meta)
 
     @classmethod
-    def from_enum(cls, value: object) -> IoData:
+    def from_enum(cls, value: object, *, meta: IoMeta | None = None) -> IoData:
         """Wrap an enum member (or its int value) as :data:`IoDataType.ENUM`.
 
         The payload is stored verbatim — receivers that expect a
@@ -159,17 +213,17 @@ class IoData:
         (``MyEnum(data.payload)``) so an ``int`` from a saved flow file
         round-trips through the same path as a typed enum member.
         """
-        return cls(IoDataType.ENUM, payload=value)
+        return cls(IoDataType.ENUM, payload=value, meta=meta)
 
     @classmethod
-    def from_path(cls, value: object) -> IoData:
+    def from_path(cls, value: object, *, meta: IoMeta | None = None) -> IoData:
         """Wrap a filesystem path as :data:`IoDataType.PATH`.
 
         Coerces to :class:`pathlib.Path` so consumers can rely on the
         ``Path`` API regardless of whether the caller supplied a
         ``str``, an existing ``Path``, or a path-like object.
         """
-        return cls(IoDataType.PATH, payload=Path(value))
+        return cls(IoDataType.PATH, payload=Path(value), meta=meta)
 
     # ── Properties ─────────────────────────────────────────────────────────────
 
@@ -198,18 +252,39 @@ class IoData:
         """
         return self._payload
 
+    @property
+    def meta(self) -> IoMeta:
+        """Per-frame metadata travelling with the payload."""
+        return self._meta
+
     def is_image(self) -> bool:
         """Return True if this carries an image payload (colour or greyscale)."""
         return self._type in IMAGE_TYPES
 
     def with_image(self, image: np.ndarray) -> IoData:
-        """Return a new :class:`IoData` with the same type and a new payload.
+        """Return a new :class:`IoData` with the same type, payload replaced.
 
         Use this in pass-through filters so the output type (IMAGE vs
         IMAGE_GREY) matches the input without the filter having to branch on
-        it explicitly.
+        it explicitly. The :class:`IoMeta` is forwarded by reference so
+        provenance survives the filter chain.
         """
-        return IoData(self._type, payload=image)
+        return IoData(self._type, payload=image, meta=self._meta)
+
+    def with_payload(self, payload: Any) -> IoData:
+        """Return a new :class:`IoData` with the same type/meta, payload
+        replaced. Generalisation of :meth:`with_image` for non-image
+        payload kinds."""
+        return IoData(self._type, payload=payload, meta=self._meta)
+
+    def with_meta(self, **changes: Any) -> IoData:
+        """Return a new :class:`IoData` with selected meta fields overridden.
+
+        Same payload and type; the IoMeta is the result of
+        ``self.meta.replace(**changes)``. Use to stamp a frame_index,
+        record a source path, etc., without rebuilding the payload.
+        """
+        return IoData(self._type, payload=self._payload, meta=self._meta.replace(**changes))
 
     def __repr__(self) -> str:
         # Image / SCALAR / MATRIX payloads expose a numpy ``shape``; the

--- a/src/core/io_data.py
+++ b/src/core/io_data.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from collections.abc import Mapping
 from enum import Enum
 from pathlib import Path
-from typing import Any
+from typing import Any, Iterator
 
 import numpy as np
 import pandas as pd
@@ -27,51 +27,74 @@ class IoDataType(Enum):
 IMAGE_TYPES: frozenset[IoDataType] = frozenset({IoDataType.IMAGE, IoDataType.IMAGE_GREY})
 
 
-@dataclass
-class IoMeta:
-    """Per-frame metadata travelling alongside an :class:`IoData` payload.
+class IoMeta(Mapping[str, Any]):
+    """Open-ended per-frame metadata bag travelling with an :class:`IoData`.
 
-    Carries provenance and timing information that downstream nodes —
-    notably sinks doing filename templating — can read without
-    reaching back through the graph. Fields are independent: a value
-    in one does not constrain another.
+    A free-form ``str → Any`` mapping with **no fixed schema** — any node
+    may stamp any key. The framework follows a few conventions so
+    different nodes recognise each other's stamps:
 
-    Fields:
-      source_path -- absolute path of the originating file when the
-                     IoData began life as a source-loaded artefact
-                     (ImageSource, CsvSource). ``None`` for synthetic
-                     payloads (RangeSource, ConstantValue).
-      frame_index -- per-output-port emit counter, stamped automatically
-                     on :meth:`core.port.OutputPort.send`. Starts at 0
-                     for the first emit of a run; resets on
-                     :meth:`core.port.OutputPort.reset`.
-      timestamp   -- run start time as ``time.time()`` (Unix epoch
-                     seconds) when set by the runner. ``None`` outside
-                     a Flow.run context.
-      extras      -- escape hatch for ad-hoc tagging; node authors can
-                     stash arbitrary keys here without growing the
-                     IoMeta surface.
+    ============  ====================================================
+    Key           Stamped by
+    ============  ====================================================
+    frame_index   :meth:`core.port.OutputPort.send` (per-port counter)
+    source_path   source nodes that read from disk (ImageSource,
+                  CsvSource), set to the resolved absolute path
+    timestamp     run start time, when populated by the runner
+    ============  ====================================================
+
+    Custom nodes are free to add domain-specific keys (e.g. a
+    ``station`` tag, a ``window_index``); downstream consumers
+    decide whether to read them.
+
+    Instances are read-only views over a backing dict — write a new
+    copy via :meth:`replace`. Keys are accessed with subscript:
+
+    >>> meta = IoMeta(source_path=Path("a.jpg"), frame_index=3)
+    >>> meta["source_path"]
+    PosixPath('a.jpg')
+    >>> meta.get("missing")  # None — no schema enforces presence
     """
 
-    source_path: Path | None = None
-    frame_index: int = 0
-    timestamp: float | None = None
-    extras: dict[str, Any] = field(default_factory=dict)
+    __slots__ = ("_data",)
+
+    def __init__(
+        self,
+        _initial: Mapping[str, Any] | None = None,
+        /,
+        **kwargs: Any,
+    ) -> None:
+        merged: dict[str, Any] = dict(_initial) if _initial is not None else {}
+        merged.update(kwargs)
+        # Stored as a plain dict — Mapping API is read-only by absence of
+        # __setitem__ on this class. .replace() returns a new IoMeta so
+        # callers never mutate shared state.
+        object.__setattr__(self, "_data", merged)
+
+    def __getitem__(self, key: str) -> Any:
+        return self._data[key]
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(self._data)
+
+    def __len__(self) -> int:
+        return len(self._data)
+
+    def __contains__(self, key: object) -> bool:
+        return key in self._data
 
     def replace(self, **changes: Any) -> "IoMeta":
-        """Return a new :class:`IoMeta` with selected fields overridden.
+        """Return a new :class:`IoMeta` with selected keys overridden / added.
 
-        Mirrors :func:`dataclasses.replace` semantics. ``extras`` is
-        shallow-copied so the caller's writes don't leak back into the
-        original meta object.
+        The original is left untouched; the new bag is the union of
+        ``self`` and ``changes``, with ``changes`` winning on conflicts.
         """
-        new_extras = dict(changes.pop("extras", self.extras))
-        return IoMeta(
-            source_path=changes.pop("source_path", self.source_path),
-            frame_index=changes.pop("frame_index", self.frame_index),
-            timestamp=changes.pop("timestamp", self.timestamp),
-            extras=new_extras,
-        )
+        merged = dict(self._data)
+        merged.update(changes)
+        return IoMeta(merged)
+
+    def __repr__(self) -> str:
+        return f"IoMeta({self._data!r})"
 
 
 class IoData:

--- a/src/core/port.py
+++ b/src/core/port.py
@@ -267,6 +267,11 @@ class OutputPort:
         # node without needing the flow to re-run on every selection.
         self._last_emitted: IoData | None = None
         self._finished: bool = False
+        # Per-port emit counter — stamped onto IoData.meta.frame_index
+        # at send() time so downstream consumers (filename templating,
+        # debug inspectors) can read a per-stream frame index without
+        # the producer having to thread it manually. Reset by reset().
+        self._emit_count: int = 0
 
     # ── Connection management ──────────────────────────────────────────────────
 
@@ -331,6 +336,16 @@ class OutputPort:
             raise RuntimeError(
                 f"Output '{self.name}' send() called after finish()"
             )
+        # Stamp the per-port frame index onto the outgoing IoData so
+        # downstream nodes (sinks, debug inspectors) read a stable
+        # counter without the producer threading it manually. Filters
+        # that forward via ``with_image`` / ``with_payload`` preserve
+        # the source's other metadata (source_path, timestamp); the
+        # index is overwritten here per outbound hop, which matches
+        # the "current stream's frame number" semantics most consumers
+        # want.
+        data = data.with_meta(frame_index=self._emit_count)
+        self._emit_count += 1
         self._last_emitted = data
         for port in self._connections:
             port.receive(data)
@@ -356,3 +371,4 @@ class OutputPort:
         produces something fresh.
         """
         self._finished = False
+        self._emit_count = 0

--- a/src/core/port.py
+++ b/src/core/port.py
@@ -344,7 +344,7 @@ class OutputPort:
         # index is overwritten here per outbound hop, which matches
         # the "current stream's frame number" semantics most consumers
         # want.
-        data = data.with_meta(frame_index=self._emit_count)
+        data = data.clone(frame_index=self._emit_count)
         self._emit_count += 1
         self._last_emitted = data
         for port in self._connections:

--- a/src/nodes/debug/meta_inspector.py
+++ b/src/nodes/debug/meta_inspector.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from typing import Callable
+
+from typing_extensions import override
+
+from core.io_data import IoData, IoDataType
+from core.node_base import NodeBase
+from core.port import InputPort, OutputPort
+
+
+#: Set of payload kinds the inspector accepts on its input. Covers every
+#: :class:`IoDataType` so the node can sit inline anywhere in a flow as a
+#: debug probe without the user having to pick a "compatible" connection.
+_ALL_TYPES: frozenset[IoDataType] = frozenset(IoDataType)
+
+
+class MetaInspector(NodeBase):
+    """Pass-through node that surfaces each frame's :class:`IoMeta` to a
+    preview widget.
+
+    Accepts every payload kind so the inspector can sit inline anywhere
+    in a streaming flow as a debug probe — image, scalar, dataset,
+    matrix, all flow through unchanged. Each frame's meta dict is
+    handed to the UI via :meth:`set_frame_callback`; the preview
+    widget renders the field-by-field text on the main thread.
+
+    The node itself is Qt-free; the worker-thread → main-thread hop
+    is the preview widget's responsibility (queued signal).
+    """
+
+    def __init__(self) -> None:
+        super().__init__("Meta Inspector", section="Debug")
+        self._frame_callback: Callable[[IoData], None] | None = None
+        self._add_input(InputPort("data", set(_ALL_TYPES)))
+        self._add_output(OutputPort("data", set(_ALL_TYPES)))
+
+    # ── UI integration ─────────────────────────────────────────────────────────
+
+    def set_frame_callback(
+        self, callback: Callable[[IoData], None] | None,
+    ) -> None:
+        """Attach (or clear) a callback invoked with each new IoData.
+
+        The full envelope is handed over so the preview can render
+        meta fields, payload kind, and payload shape side by side.
+        Fires on whichever thread :meth:`process_impl` runs on; the
+        UI widget is responsible for marshalling back to the main
+        thread.
+        """
+        self._frame_callback = callback
+
+    # ── NodeBase interface ─────────────────────────────────────────────────────
+
+    @override
+    def process_impl(self) -> None:
+        in_data = self.inputs[0].data
+        if self._frame_callback is not None:
+            self._frame_callback(in_data)
+        self.outputs[0].send(in_data)

--- a/src/nodes/debug/play_gate.py
+++ b/src/nodes/debug/play_gate.py
@@ -47,6 +47,14 @@ class PlayGate(NodeBase):
         # lock prevents lost-update races on the single-slot cache.
         self._lock = threading.Lock()
         self._queued: IoData | None = None
+        # When the upstream finishes while we still have a queued
+        # frame, the default _on_finish would close our outputs
+        # before the user gets a chance to click Play — afterward,
+        # send() raises "called after finish()" and the click silently
+        # does nothing. Defer the output-side finish until the queue
+        # drains; ``request_emit`` flushes the deferred finish after
+        # releasing the last frame.
+        self._pending_finish: bool = False
         self._state_callback: Callable[[bool], None] | None = None
 
     # ── UI integration ─────────────────────────────────────────────────────────
@@ -73,6 +81,8 @@ class PlayGate(NodeBase):
         with self._lock:
             data = self._queued
             self._queued = None
+            pending_finish = self._pending_finish
+            self._pending_finish = False
         if data is None:
             return
         self._notify_state(False)
@@ -80,6 +90,9 @@ class PlayGate(NodeBase):
         # that takes its own locks (or re-enters the gate via a fan-out
         # path) can't deadlock against us.
         self.outputs[0].send(data)
+        if pending_finish:
+            for port in self._outputs:
+                port.finish()
 
     @property
     def has_queued(self) -> bool:
@@ -94,6 +107,7 @@ class PlayGate(NodeBase):
         super()._before_run_impl()
         with self._lock:
             self._queued = None
+            self._pending_finish = False
         self._notify_state(False)
 
     @override
@@ -102,6 +116,22 @@ class PlayGate(NodeBase):
         with self._lock:
             self._queued = in_data
         self._notify_state(True)
+
+    @override
+    def _on_finish(self) -> None:
+        """Defer output finish if a frame is still queued.
+
+        The default implementation would close the output ports as
+        soon as upstream finishes — but that races with a slow user
+        who hasn't clicked Play yet. Deferring lets ``request_emit``
+        emit the last frame before propagating the lifecycle signal.
+        """
+        with self._lock:
+            still_queued = self._queued is not None
+            if still_queued:
+                self._pending_finish = True
+        if not still_queued:
+            super()._on_finish()
 
     # ── Internal ───────────────────────────────────────────────────────────────
 

--- a/src/nodes/debug/play_gate.py
+++ b/src/nodes/debug/play_gate.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import threading
+from typing import Callable
+
+from typing_extensions import override
+
+from core.io_data import IoData, IoDataType
+from core.node_base import NodeBase
+from core.port import InputPort, OutputPort
+
+
+#: Every payload kind passes through; the gate is type-agnostic.
+_ALL_TYPES: frozenset[IoDataType] = frozenset(IoDataType)
+
+
+class PlayGate(NodeBase):
+    """Pass-through node that holds each input frame until the user
+    clicks Play.
+
+    Behaviour:
+      - When a frame arrives at :attr:`process_impl`, it is queued and
+        the preview widget's Play button becomes enabled.
+      - When the user clicks Play, :meth:`request_emit` releases the
+        queued frame downstream and disables the button until the
+        next frame arrives.
+      - Only the most recently received frame is held; if a second
+        frame arrives before the user clicks, the first is dropped.
+        This keeps the gate usable on fast streams (the user steps
+        through whatever the stream surfaces at the moment of click)
+        without an unbounded queue.
+
+    The node is Qt-free; the preview widget owns the button and
+    forwards clicks via :meth:`request_emit`. State changes (queue
+    became non-empty / empty) are surfaced through
+    :meth:`set_state_callback` so the widget can update its enabled
+    state on the UI thread via a queued signal.
+    """
+
+    def __init__(self) -> None:
+        super().__init__("Play Gate", section="Debug")
+        self._add_input(InputPort("data", set(_ALL_TYPES)))
+        self._add_output(OutputPort("data", set(_ALL_TYPES)))
+
+        # The queue + click state is touched from both the worker
+        # thread (process_impl) and the UI thread (request_emit), so a
+        # lock prevents lost-update races on the single-slot cache.
+        self._lock = threading.Lock()
+        self._queued: IoData | None = None
+        self._state_callback: Callable[[bool], None] | None = None
+
+    # ── UI integration ─────────────────────────────────────────────────────────
+
+    def set_state_callback(
+        self, callback: Callable[[bool], None] | None,
+    ) -> None:
+        """Attach a callback invoked when the queued state changes.
+
+        The argument is ``True`` when a frame is queued (button should
+        enable), ``False`` after a release or when the queue is empty.
+        Fires on whichever thread caused the transition; the widget is
+        responsible for marshalling back to the UI thread.
+        """
+        self._state_callback = callback
+
+    def request_emit(self) -> None:
+        """Release the queued frame downstream, if any.
+
+        Called from the UI thread when the Play button is clicked.
+        No-op when nothing is queued (button should be disabled in
+        that case, but the no-op keeps a stale double-click safe).
+        """
+        with self._lock:
+            data = self._queued
+            self._queued = None
+        if data is None:
+            return
+        self._notify_state(False)
+        # send() is invoked OUTSIDE the lock so a downstream listener
+        # that takes its own locks (or re-enters the gate via a fan-out
+        # path) can't deadlock against us.
+        self.outputs[0].send(data)
+
+    @property
+    def has_queued(self) -> bool:
+        """True when a frame is currently waiting for a Play click."""
+        with self._lock:
+            return self._queued is not None
+
+    # ── NodeBase interface ─────────────────────────────────────────────────────
+
+    @override
+    def _before_run_impl(self) -> None:
+        super()._before_run_impl()
+        with self._lock:
+            self._queued = None
+        self._notify_state(False)
+
+    @override
+    def process_impl(self) -> None:
+        in_data = self.inputs[0].data
+        with self._lock:
+            self._queued = in_data
+        self._notify_state(True)
+
+    # ── Internal ───────────────────────────────────────────────────────────────
+
+    def _notify_state(self, queued: bool) -> None:
+        cb = self._state_callback
+        if cb is not None:
+            cb(queued)

--- a/src/nodes/filters/crop.py
+++ b/src/nodes/filters/crop.py
@@ -68,4 +68,4 @@ class Crop(NodeBase):
         # a view, which is fine for read-only consumers but bites in-place
         # writers. Cheap insurance for ~100kB-100MB frames.
         cropped = np.ascontiguousarray(cropped)
-        self.outputs[0].send(in_data.with_image(cropped))
+        self.outputs[0].send(in_data.clone(payload=cropped))

--- a/src/nodes/filters/dither.py
+++ b/src/nodes/filters/dither.py
@@ -144,7 +144,7 @@ class Dither(NodeBase):
         else:
             out = self._dither_plane(image)
 
-        self.outputs[0].send(in_data.with_image(out))
+        self.outputs[0].send(in_data.clone(payload=out))
 
     def _dither_plane(self, plane: np.ndarray) -> np.ndarray:
         method = self._method

--- a/src/nodes/filters/flip.py
+++ b/src/nodes/filters/flip.py
@@ -47,4 +47,4 @@ class Flip(NodeBase):
     def process_impl(self) -> None:
         in_data = self.inputs[0].data
         flipped = cv2.flip(in_data.image, int(self._mode))
-        self.outputs[0].send(in_data.with_image(flipped))
+        self.outputs[0].send(in_data.clone(payload=flipped))

--- a/src/nodes/filters/frame_difference.py
+++ b/src/nodes/filters/frame_difference.py
@@ -43,4 +43,4 @@ class FrameDifference(NodeBase):
             diff = cv2.absdiff(image, self._prev_frame)
 
         self._prev_frame = image.copy()
-        self.outputs[0].send(in_data.with_image(diff))
+        self.outputs[0].send(in_data.clone(payload=diff))

--- a/src/nodes/filters/gaussian_blur.py
+++ b/src/nodes/filters/gaussian_blur.py
@@ -53,4 +53,4 @@ class GaussianBlur(NodeBase):
             (self._ksize, self._ksize),
             self._sigma,
         )
-        self.outputs[0].send(in_data.with_image(blurred))
+        self.outputs[0].send(in_data.clone(payload=blurred))

--- a/src/nodes/filters/invert.py
+++ b/src/nodes/filters/invert.py
@@ -25,4 +25,4 @@ class Invert(NodeBase):
     def process_impl(self) -> None:
         in_data = self.inputs[0].data
         inverted = cv2.bitwise_not(in_data.image)
-        self.outputs[0].send(in_data.with_image(inverted))
+        self.outputs[0].send(in_data.clone(payload=inverted))

--- a/src/nodes/filters/median.py
+++ b/src/nodes/filters/median.py
@@ -41,4 +41,4 @@ class Median(NodeBase):
     def process_impl(self) -> None:
         in_data = self.inputs[0].data
         blurred = cv2.medianBlur(in_data.image, self._size)
-        self.outputs[0].send(in_data.with_image(blurred))
+        self.outputs[0].send(in_data.clone(payload=blurred))

--- a/src/nodes/filters/normalize.py
+++ b/src/nodes/filters/normalize.py
@@ -38,4 +38,4 @@ class Normalize(NodeBase):
             equalised = [cv2.equalizeHist(c) for c in channels]
             result = cv2.merge(equalised)
 
-        self.outputs[0].send(in_data.with_image(result))
+        self.outputs[0].send(in_data.clone(payload=result))

--- a/src/nodes/filters/resize.py
+++ b/src/nodes/filters/resize.py
@@ -109,7 +109,7 @@ class Resize(NodeBase):
         else:  # BEST_FIT
             out = self._best_fit(image, target_w, target_h)
 
-        self.outputs[0].send(in_data.with_image(out))
+        self.outputs[0].send(in_data.clone(payload=out))
 
     # ── Layout strategies ─────────────────────────────────────────────────────
 

--- a/src/nodes/filters/rotate.py
+++ b/src/nodes/filters/rotate.py
@@ -64,4 +64,4 @@ class Rotate(NodeBase):
             out_size = (w, h)
 
         rotated = cv2.warpAffine(image, m, out_size, flags=cv2.INTER_LINEAR)
-        self.outputs[0].send(in_data.with_image(rotated))
+        self.outputs[0].send(in_data.clone(payload=rotated))

--- a/src/nodes/filters/scale.py
+++ b/src/nodes/filters/scale.py
@@ -75,4 +75,4 @@ class Scale(NodeBase):
             (new_w, new_h),
             interpolation=int(self._interpolation),
         )
-        self.outputs[0].send(in_data.with_image(resized))
+        self.outputs[0].send(in_data.clone(payload=resized))

--- a/src/nodes/filters/shift.py
+++ b/src/nodes/filters/shift.py
@@ -50,4 +50,4 @@ class Shift(NodeBase):
         matrix = np.float32([[1, 0, self._offset_x],
                              [0, 1, self._offset_y]])
         shifted = cv2.warpAffine(image, matrix, (w, h))
-        self.outputs[0].send(in_data.with_image(shifted))
+        self.outputs[0].send(in_data.clone(payload=shifted))

--- a/src/nodes/filters/temporal_mean.py
+++ b/src/nodes/filters/temporal_mean.py
@@ -62,4 +62,4 @@ class TemporalMean(NodeBase):
         # to the input dtype so downstream nodes get the type they expect.
         stack = np.stack(self._buffer, axis=0).astype(np.float32)
         mean = stack.mean(axis=0).astype(image.dtype)
-        self.outputs[0].send(in_data.with_image(mean))
+        self.outputs[0].send(in_data.clone(payload=mean))

--- a/src/nodes/filters/temporal_median.py
+++ b/src/nodes/filters/temporal_median.py
@@ -64,4 +64,4 @@ class TemporalMedian(NodeBase):
         # dtype so downstream nodes get the type they expect.
         stack = np.stack(self._buffer, axis=0)
         median = np.median(stack, axis=0).astype(image.dtype)
-        self.outputs[0].send(in_data.with_image(median))
+        self.outputs[0].send(in_data.clone(payload=median))

--- a/src/nodes/sources/csv_source.py
+++ b/src/nodes/sources/csv_source.py
@@ -6,7 +6,7 @@ import pandas as pd
 from typing_extensions import override
 
 from constants import INPUT_DIR
-from core.io_data import IoData, IoDataType
+from core.io_data import IoData, IoDataType, IoMeta
 from core.node_base import SourceNodeBase
 from core.params import BoolParam, FilePathParam, StringParam
 from core.path_utils import resolve_against
@@ -141,7 +141,9 @@ class CsvSource(SourceNodeBase):
             df.columns = [f"c{i}" for i in range(len(df.columns))]
 
         df.attrs["source_path"] = str(resolved)
-        self.outputs[0].send(IoData.from_dataset(df))
+        self.outputs[0].send(
+            IoData.from_dataset(df, meta=IoMeta(source_path=resolved))
+        )
 
     def _resolved_path(self) -> Path:
         """Return an absolute path; relative values are joined with INPUT_DIR."""

--- a/src/nodes/sources/image_source.py
+++ b/src/nodes/sources/image_source.py
@@ -8,7 +8,7 @@ import rawpy
 from typing_extensions import override
 
 from constants import INPUT_DIR
-from core.io_data import IoData, IoDataType
+from core.io_data import IoData, IoDataType, IoMeta
 from core.node_base import SourceNodeBase
 from core.params import FilePathParam
 from core.path_utils import resolve_against
@@ -87,7 +87,9 @@ class ImageSource(SourceNodeBase):
             if image.ndim == 2:
                 image = cv2.cvtColor(image, cv2.COLOR_GRAY2BGR)
 
-        self.outputs[0].send(IoData.from_image(image))
+        self.outputs[0].send(
+            IoData.from_image(image, meta=IoMeta(source_path=resolved))
+        )
 
     def _resolved_path(self) -> Path:
         """Return an absolute path; relative values are joined with INPUT_DIR."""

--- a/src/ui/preview_widgets.py
+++ b/src/ui/preview_widgets.py
@@ -8,11 +8,13 @@ from typing_extensions import override
 
 from PySide6.QtCore import Qt, Signal, Slot
 from PySide6.QtGui import QImage, QPixmap
-from PySide6.QtWidgets import QLabel, QSizePolicy, QVBoxLayout, QWidget
+from PySide6.QtWidgets import QLabel, QPushButton, QSizePolicy, QVBoxLayout, QWidget
 
 from core import notifications
 from core.io_data import IoData, IoDataType
 from core.node_base import NodeBase
+from nodes.debug.meta_inspector import MetaInspector
+from nodes.debug.play_gate import PlayGate
 from nodes.filters.display import Display
 
 logger = logging.getLogger(__name__)
@@ -217,10 +219,149 @@ def _numpy_to_qimage(frame: np.ndarray) -> QImage:
     return qimg.copy()
 
 
+# ── MetaInspector preview ─────────────────────────────────────────────────────
+
+
+class MetaInspectorPreview(_PreviewWidgetBase):
+    """Inline preview for :class:`~nodes.debug.meta_inspector.MetaInspector`.
+
+    Shows the :class:`~core.io_data.IoMeta` of every frame that passes
+    through the inspector, plus the payload kind and shape. The text
+    arrives on the worker thread via the node's frame_callback; a
+    queued :class:`Signal` hops it to the UI thread before the label
+    is updated.
+    """
+
+    _text_ready = Signal(str)
+
+    _PREVIEW_MIN_W: int = 220
+    _PREVIEW_MIN_H: int = 90
+
+    def __init__(self, node: MetaInspector) -> None:
+        super().__init__(node)
+        self._label = QLabel()
+        self._label.setAlignment(
+            Qt.AlignmentFlag.AlignTop | Qt.AlignmentFlag.AlignLeft
+        )
+        self._label.setMinimumSize(self._PREVIEW_MIN_W, self._PREVIEW_MIN_H)
+        self._label.setSizePolicy(
+            QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding,
+        )
+        self._label.setStyleSheet(
+            "QLabel { background: #111; border: 1px solid #333;"
+            "         color: #d6d6d6; padding: 4px;"
+            "         font-family: 'Consolas','Menlo',monospace;"
+            "         font-size: 11px; }"
+        )
+        self._label.setText("(no frame yet)")
+
+        self.setSizePolicy(
+            QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding,
+        )
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.addWidget(self._label)
+
+        self._text_ready.connect(self._on_text_ready)
+        node.set_frame_callback(self._emit_from_worker)
+
+    def _emit_from_worker(self, data: IoData) -> None:
+        self._text_ready.emit(_format_meta(data))
+
+    @Slot(str)
+    def _on_text_ready(self, text: str) -> None:
+        self._label.setText(text)
+
+
+def _format_meta(data: IoData) -> str:
+    """Render an :class:`IoData` envelope's meta + payload summary as
+    readable text for the inspector preview."""
+    meta = data.meta
+    shape = getattr(data.payload, "shape", None)
+    payload_line = (
+        f"payload: {data.type.name} shape={shape}"
+        if shape is not None
+        else f"payload: {data.type.name} value={data.payload!r}"
+    )
+    lines = [
+        f"frame_index: {meta.frame_index}",
+        f"source_path: {meta.source_path}",
+        f"timestamp:   {meta.timestamp}",
+    ]
+    if meta.extras:
+        lines.append(f"extras:      {meta.extras}")
+    lines.append(payload_line)
+    return "\n".join(lines)
+
+
+# ── PlayGate preview ──────────────────────────────────────────────────────────
+
+
+class PlayGatePreview(_PreviewWidgetBase):
+    """Inline preview for :class:`~nodes.debug.play_gate.PlayGate`.
+
+    Hosts a Play button inside the node body. The button is enabled
+    when the gate has a queued frame and disabled otherwise; clicking
+    it asks the gate to release the queued frame downstream. The
+    queue-state hop crosses threads via a queued :class:`Signal`.
+    """
+
+    _state_changed = Signal(bool)
+
+    _PREVIEW_MIN_W: int = 140
+    _PREVIEW_MIN_H: int = 56
+
+    def __init__(self, node: PlayGate) -> None:
+        super().__init__(node)
+        self._button = QPushButton("▶  Play")
+        self._button.setEnabled(False)
+        self._button.setMinimumSize(self._PREVIEW_MIN_W, self._PREVIEW_MIN_H)
+        self._button.setSizePolicy(
+            QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding,
+        )
+        self._button.setStyleSheet(
+            "QPushButton { background: #2b6cb0; color: white;"
+            "              border: 1px solid #1a4577;"
+            "              padding: 6px 10px; font-weight: bold; }"
+            "QPushButton:disabled { background: #333; color: #777; }"
+            "QPushButton:hover:enabled { background: #3478c2; }"
+        )
+        self._button.clicked.connect(self._on_clicked)
+
+        self.setSizePolicy(
+            QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding,
+        )
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.addWidget(self._button)
+
+        self._state_changed.connect(self._on_state_changed)
+        node.set_state_callback(self._emit_from_worker)
+
+    def _emit_from_worker(self, queued: bool) -> None:
+        self._state_changed.emit(queued)
+
+    @Slot(bool)
+    def _on_state_changed(self, queued: bool) -> None:
+        self._button.setEnabled(queued)
+
+    @Slot()
+    def _on_clicked(self) -> None:
+        # Disable immediately so a fast double-click doesn't fire the
+        # gate twice (the worker side will also call back to disable
+        # via _state_changed, but that hop has latency).
+        self._button.setEnabled(False)
+        node = self._node
+        assert isinstance(node, PlayGate)
+        node.request_emit()
+
+
 # ── Registry ───────────────────────────────────────────────────────────────────
 
 _PREVIEW_WIDGET_CLASSES: dict[type[NodeBase], type[_PreviewWidgetBase]] = {
     Display: DisplayPreview,
+    MetaInspector: MetaInspectorPreview,
+    PlayGate: PlayGatePreview,
 }
 
 

--- a/src/ui/preview_widgets.py
+++ b/src/ui/preview_widgets.py
@@ -275,23 +275,28 @@ class MetaInspectorPreview(_PreviewWidgetBase):
 
 def _format_meta(data: IoData) -> str:
     """Render an :class:`IoData` envelope's meta + payload summary as
-    readable text for the inspector preview."""
-    meta = data.meta
+    readable text for the inspector preview.
+
+    The meta bag is open-ended; we render every key in sorted order
+    so the inspector reflects whatever the upstream nodes stamped,
+    without hard-coding which keys exist.
+    """
     shape = getattr(data.payload, "shape", None)
     payload_line = (
         f"payload: {data.type.name} shape={shape}"
         if shape is not None
         else f"payload: {data.type.name} value={data.payload!r}"
     )
-    lines = [
-        f"frame_index: {meta.frame_index}",
-        f"source_path: {meta.source_path}",
-        f"timestamp:   {meta.timestamp}",
+    if not data.meta:
+        return f"meta: (empty)\n{payload_line}"
+
+    # Right-pad keys to a common width so values line up vertically.
+    key_width = max(len(k) for k in data.meta)
+    meta_lines = [
+        f"{key.ljust(key_width)}  {data.meta[key]}"
+        for key in sorted(data.meta)
     ]
-    if meta.extras:
-        lines.append(f"extras:      {meta.extras}")
-    lines.append(payload_line)
-    return "\n".join(lines)
+    return "\n".join(meta_lines + [payload_line])
 
 
 # ── PlayGate preview ──────────────────────────────────────────────────────────

--- a/tests/test_io_data.py
+++ b/tests/test_io_data.py
@@ -254,3 +254,59 @@ def test_image_types_set_unaffected_by_new_kinds() -> None:
     declare image-only ports."""
     new_kinds = {IoDataType.BOOL, IoDataType.STRING, IoDataType.ENUM, IoDataType.PATH}
     assert IMAGE_TYPES.isdisjoint(new_kinds)
+
+
+# ── IoMeta + IoData.meta ──────────────────────────────────────────────────────
+
+
+def test_iodata_default_meta_is_empty() -> None:
+    from core.io_data import IoMeta
+    data = IoData.from_scalar(0)
+    assert isinstance(data.meta, IoMeta)
+    assert data.meta.source_path is None
+    assert data.meta.frame_index == 0
+    assert data.meta.timestamp is None
+    assert data.meta.extras == {}
+
+
+def test_iodata_factory_accepts_meta_kwarg() -> None:
+    from core.io_data import IoMeta
+    meta = IoMeta(source_path=Path("ship.jpg"), frame_index=7)
+    data = IoData.from_image(np.zeros((2, 2, 3), dtype=np.uint8), meta=meta)
+    assert data.meta.source_path == Path("ship.jpg")
+    assert data.meta.frame_index == 7
+
+
+def test_with_image_preserves_meta() -> None:
+    """Filters that pass through via ``with_image`` must carry meta forward."""
+    from core.io_data import IoMeta
+    src = IoData.from_image(
+        np.zeros((2, 2, 3), dtype=np.uint8),
+        meta=IoMeta(source_path=Path("ship.jpg"), frame_index=3),
+    )
+    new_payload = np.ones((2, 2, 3), dtype=np.uint8)
+    out = src.with_image(new_payload)
+    assert out.payload is new_payload
+    assert out.meta is src.meta  # forwarded by reference
+
+
+def test_with_meta_returns_new_iodata_with_overrides() -> None:
+    src = IoData.from_scalar(42)
+    out = src.with_meta(frame_index=5, source_path=Path("data.csv"))
+    assert out is not src
+    assert out.payload is src.payload
+    assert out.meta.frame_index == 5
+    assert out.meta.source_path == Path("data.csv")
+    # Original untouched.
+    assert src.meta.frame_index == 0
+    assert src.meta.source_path is None
+
+
+def test_iometa_replace_is_immutable_for_extras() -> None:
+    """``replace`` must shallow-copy ``extras`` so the caller's writes
+    don't leak back into the original meta object."""
+    from core.io_data import IoMeta
+    original = IoMeta(extras={"foo": 1})
+    updated = original.replace(frame_index=2)
+    updated.extras["bar"] = 99
+    assert "bar" not in original.extras

--- a/tests/test_io_data.py
+++ b/tests/test_io_data.py
@@ -259,22 +259,39 @@ def test_image_types_set_unaffected_by_new_kinds() -> None:
 # ── IoMeta + IoData.meta ──────────────────────────────────────────────────────
 
 
-def test_iodata_default_meta_is_empty() -> None:
+def test_iodata_default_meta_is_empty_bag() -> None:
     from core.io_data import IoMeta
     data = IoData.from_scalar(0)
     assert isinstance(data.meta, IoMeta)
-    assert data.meta.source_path is None
-    assert data.meta.frame_index == 0
-    assert data.meta.timestamp is None
-    assert data.meta.extras == {}
+    assert len(data.meta) == 0
+    # Open-ended bag: missing keys are simply absent, not None-typed.
+    assert "source_path" not in data.meta
+    assert data.meta.get("frame_index") is None
 
 
 def test_iodata_factory_accepts_meta_kwarg() -> None:
     from core.io_data import IoMeta
     meta = IoMeta(source_path=Path("ship.jpg"), frame_index=7)
     data = IoData.from_image(np.zeros((2, 2, 3), dtype=np.uint8), meta=meta)
-    assert data.meta.source_path == Path("ship.jpg")
-    assert data.meta.frame_index == 7
+    assert data.meta["source_path"] == Path("ship.jpg")
+    assert data.meta["frame_index"] == 7
+
+
+def test_iometa_accepts_initial_mapping() -> None:
+    """The first positional argument is a dict-like seed, kwargs override."""
+    from core.io_data import IoMeta
+    meta = IoMeta({"source_path": Path("a"), "custom": "x"}, frame_index=2)
+    assert meta["source_path"] == Path("a")
+    assert meta["custom"] == "x"
+    assert meta["frame_index"] == 2
+
+
+def test_iometa_supports_arbitrary_keys() -> None:
+    """No schema — node authors can stamp any string key/value."""
+    from core.io_data import IoMeta
+    meta = IoMeta(window_index=4, station="ALH02")
+    assert meta["window_index"] == 4
+    assert meta["station"] == "ALH02"
 
 
 def test_with_image_preserves_meta() -> None:
@@ -295,18 +312,25 @@ def test_with_meta_returns_new_iodata_with_overrides() -> None:
     out = src.with_meta(frame_index=5, source_path=Path("data.csv"))
     assert out is not src
     assert out.payload is src.payload
-    assert out.meta.frame_index == 5
-    assert out.meta.source_path == Path("data.csv")
+    assert out.meta["frame_index"] == 5
+    assert out.meta["source_path"] == Path("data.csv")
     # Original untouched.
-    assert src.meta.frame_index == 0
-    assert src.meta.source_path is None
+    assert "frame_index" not in src.meta
+    assert "source_path" not in src.meta
 
 
-def test_iometa_replace_is_immutable_for_extras() -> None:
-    """``replace`` must shallow-copy ``extras`` so the caller's writes
-    don't leak back into the original meta object."""
+def test_iometa_replace_does_not_mutate_original() -> None:
+    """``replace`` must produce a new bag; the original stays empty."""
     from core.io_data import IoMeta
-    original = IoMeta(extras={"foo": 1})
-    updated = original.replace(frame_index=2)
-    updated.extras["bar"] = 99
-    assert "bar" not in original.extras
+    original = IoMeta(foo=1)
+    updated = original.replace(bar=2)
+    assert dict(original) == {"foo": 1}
+    assert dict(updated) == {"foo": 1, "bar": 2}
+
+
+def test_iometa_is_read_only_view() -> None:
+    """No __setitem__ — callers must use .replace() to grow the bag."""
+    from core.io_data import IoMeta
+    meta = IoMeta(foo=1)
+    with pytest.raises(TypeError):
+        meta["bar"] = 2  # type: ignore[index]

--- a/tests/test_io_data.py
+++ b/tests/test_io_data.py
@@ -294,22 +294,23 @@ def test_iometa_supports_arbitrary_keys() -> None:
     assert meta["station"] == "ALH02"
 
 
-def test_with_image_preserves_meta() -> None:
-    """Filters that pass through via ``with_image`` must carry meta forward."""
+def test_clone_payload_preserves_meta() -> None:
+    """Filters that pass through via ``clone(payload=...)`` must carry
+    meta forward to keep provenance alive across the chain."""
     from core.io_data import IoMeta
     src = IoData.from_image(
         np.zeros((2, 2, 3), dtype=np.uint8),
         meta=IoMeta(source_path=Path("ship.jpg"), frame_index=3),
     )
     new_payload = np.ones((2, 2, 3), dtype=np.uint8)
-    out = src.with_image(new_payload)
+    out = src.clone(payload=new_payload)
     assert out.payload is new_payload
     assert out.meta is src.meta  # forwarded by reference
 
 
-def test_with_meta_returns_new_iodata_with_overrides() -> None:
+def test_clone_meta_changes_returns_new_iodata_with_overrides() -> None:
     src = IoData.from_scalar(42)
-    out = src.with_meta(frame_index=5, source_path=Path("data.csv"))
+    out = src.clone(frame_index=5, source_path=Path("data.csv"))
     assert out is not src
     assert out.payload is src.payload
     assert out.meta["frame_index"] == 5

--- a/tests/test_meta_inspector.py
+++ b/tests/test_meta_inspector.py
@@ -48,10 +48,10 @@ def test_callback_receives_each_frame_with_meta() -> None:
 
     assert len(seen) == 2
     # source_path survives the per-port frame_index stamp.
-    assert seen[0].meta.source_path == Path("ship.jpg")
+    assert seen[0].meta["source_path"] == Path("ship.jpg")
     # frame_index reflects the upstream feeder's counter, not the
     # inspector's own outbound counter.
-    assert [d.meta.frame_index for d in seen] == [0, 1]
+    assert [d.meta["frame_index"] for d in seen] == [0, 1]
 
 
 def test_callback_is_optional() -> None:

--- a/tests/test_meta_inspector.py
+++ b/tests/test_meta_inspector.py
@@ -1,0 +1,66 @@
+"""Unit tests for the MetaInspector debug node."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+
+from core.io_data import IoData, IoDataType, IoMeta
+from core.port import InputPort, OutputPort
+from nodes.debug.meta_inspector import MetaInspector
+
+
+def _wire(node: MetaInspector) -> tuple[OutputPort, InputPort, list[IoData]]:
+    feeder = OutputPort("feeder", {IoDataType.SCALAR})
+    feeder.connect(node.inputs[0])
+
+    sink = InputPort("sink", {IoDataType.SCALAR})
+    captured: list[IoData] = []
+    sink.add_listener(
+        lambda: captured.append(sink.data) if sink.has_data else None
+    )
+    node.outputs[0].connect(sink)
+    return feeder, sink, captured
+
+
+def test_passes_input_through_unchanged() -> None:
+    node = MetaInspector()
+    feeder, _, captured = _wire(node)
+    node.before_run()
+
+    feeder.send(IoData.from_scalar(42))
+
+    assert len(captured) == 1
+    assert int(captured[0].payload) == 42
+
+
+def test_callback_receives_each_frame_with_meta() -> None:
+    node = MetaInspector()
+    feeder, _, _ = _wire(node)
+    node.before_run()
+
+    seen: list[IoData] = []
+    node.set_frame_callback(lambda d: seen.append(d))
+
+    meta = IoMeta(source_path=Path("ship.jpg"))
+    feeder.send(IoData.from_scalar(0, meta=meta))
+    feeder.send(IoData.from_scalar(1, meta=meta))
+
+    assert len(seen) == 2
+    # source_path survives the per-port frame_index stamp.
+    assert seen[0].meta.source_path == Path("ship.jpg")
+    # frame_index reflects the upstream feeder's counter, not the
+    # inspector's own outbound counter.
+    assert [d.meta.frame_index for d in seen] == [0, 1]
+
+
+def test_callback_is_optional() -> None:
+    """A flow without a UI hook must still pass frames through."""
+    node = MetaInspector()
+    feeder, _, captured = _wire(node)
+    node.before_run()
+
+    feeder.send(IoData.from_scalar(0))
+    feeder.send(IoData.from_scalar(1))
+
+    assert len(captured) == 2

--- a/tests/test_play_gate.py
+++ b/tests/test_play_gate.py
@@ -1,0 +1,110 @@
+"""Unit tests for the PlayGate debug node."""
+from __future__ import annotations
+
+from core.io_data import IoData, IoDataType
+from core.port import InputPort, OutputPort
+from nodes.debug.play_gate import PlayGate
+
+
+def _wire(node: PlayGate) -> tuple[OutputPort, list[IoData]]:
+    feeder = OutputPort("feeder", {IoDataType.SCALAR})
+    feeder.connect(node.inputs[0])
+
+    sink = InputPort("sink", {IoDataType.SCALAR})
+    captured: list[IoData] = []
+    sink.add_listener(
+        lambda: captured.append(sink.data) if sink.has_data else None
+    )
+    node.outputs[0].connect(sink)
+    return feeder, captured
+
+
+def test_input_arrival_does_not_emit_until_play_clicked() -> None:
+    """The whole point of the gate: data piles up until the user
+    explicitly releases it."""
+    node = PlayGate()
+    feeder, captured = _wire(node)
+    node.before_run()
+
+    feeder.send(IoData.from_scalar(0))
+    assert captured == []
+    assert node.has_queued is True
+
+
+def test_request_emit_releases_queued_frame() -> None:
+    node = PlayGate()
+    feeder, captured = _wire(node)
+    node.before_run()
+
+    feeder.send(IoData.from_scalar(7))
+    node.request_emit()
+
+    assert len(captured) == 1
+    assert int(captured[0].payload) == 7
+    assert node.has_queued is False
+
+
+def test_request_emit_with_empty_queue_is_a_noop() -> None:
+    """A double-click with nothing queued must not crash and must not
+    re-emit a stale frame."""
+    node = PlayGate()
+    feeder, captured = _wire(node)
+    node.before_run()
+
+    feeder.send(IoData.from_scalar(1))
+    node.request_emit()
+    captured_count = len(captured)
+
+    node.request_emit()  # second click on an empty queue
+
+    assert len(captured) == captured_count
+
+
+def test_second_input_overwrites_first_when_play_not_pressed() -> None:
+    """Latest-wins single-slot semantics: a second frame replaces the
+    first, so the gate stays usable on fast streams without an
+    unbounded queue."""
+    node = PlayGate()
+    feeder, captured = _wire(node)
+    node.before_run()
+
+    feeder.send(IoData.from_scalar(1))
+    feeder.send(IoData.from_scalar(2))
+    node.request_emit()
+
+    assert len(captured) == 1
+    assert int(captured[0].payload) == 2
+
+
+def test_state_callback_fires_on_queue_transitions() -> None:
+    """The preview widget needs to know when the button should enable /
+    disable; the gate signals that through ``set_state_callback``."""
+    node = PlayGate()
+    feeder, _ = _wire(node)
+    node.before_run()
+
+    states: list[bool] = []
+    node.set_state_callback(lambda queued: states.append(queued))
+
+    feeder.send(IoData.from_scalar(0))
+    node.request_emit()
+
+    # before_run cleared the queue (False), then receive queued (True),
+    # then request_emit released (False). The before_run notification
+    # happens before the callback was attached, so it isn't observed.
+    assert states == [True, False]
+
+
+def test_before_run_clears_a_stale_queue() -> None:
+    """A second run must not emit a frame left over from the first."""
+    node = PlayGate()
+    feeder, captured = _wire(node)
+    node.before_run()
+
+    feeder.send(IoData.from_scalar(99))
+    assert node.has_queued is True
+
+    node.before_run()
+    assert node.has_queued is False
+    node.request_emit()  # nothing to release
+    assert captured == []

--- a/tests/test_play_gate.py
+++ b/tests/test_play_gate.py
@@ -12,9 +12,17 @@ def _wire(node: PlayGate) -> tuple[OutputPort, list[IoData]]:
 
     sink = InputPort("sink", {IoDataType.SCALAR})
     captured: list[IoData] = []
-    sink.add_listener(
-        lambda: captured.append(sink.data) if sink.has_data else None
-    )
+
+    # Fake-dispatcher: a real consumer node would clear() after
+    # processing each fresh frame, so the next listener fire (e.g.
+    # the one ``finish()`` triggers) doesn't double-count. The test
+    # sink has no owning node, so clear here.
+    def _on_change() -> None:
+        if sink.is_fresh and sink.has_data:
+            captured.append(sink.data)
+            sink.clear()
+
+    sink.add_listener(_on_change)
     node.outputs[0].connect(sink)
     return feeder, captured
 
@@ -108,3 +116,41 @@ def test_before_run_clears_a_stale_queue() -> None:
     assert node.has_queued is False
     node.request_emit()  # nothing to release
     assert captured == []
+
+
+def test_upstream_finish_with_queue_defers_output_finish() -> None:
+    """Regression: the upstream finishing while a frame is queued must
+    not close our output port — ``request_emit`` would otherwise raise
+    "send() called after finish()" and the click would silently do
+    nothing."""
+    node = PlayGate()
+    feeder, captured = _wire(node)
+    node.before_run()
+
+    feeder.send(IoData.from_scalar(7))
+    feeder.finish()  # upstream done, we still have a queued frame
+
+    assert node.outputs[0].finished is False, (
+        "output must NOT finish while a frame is still queued"
+    )
+
+    node.request_emit()
+
+    assert len(captured) == 1
+    assert int(captured[0].payload) == 7
+    # Now that the queue has drained AND upstream is done, the
+    # deferred finish flushes — no further frames will arrive.
+    assert node.outputs[0].finished is True
+
+
+def test_upstream_finish_with_empty_queue_propagates_immediately() -> None:
+    """Symmetric to the deferred case: when nothing is queued, finish
+    propagates the moment upstream signals end-of-stream so downstream
+    sinks can wrap up promptly."""
+    node = PlayGate()
+    feeder, _ = _wire(node)
+    node.before_run()
+
+    feeder.finish()
+
+    assert node.outputs[0].finished is True

--- a/tests/test_port_frame_index.py
+++ b/tests/test_port_frame_index.py
@@ -1,0 +1,74 @@
+"""Verify ``OutputPort.send`` stamps a per-port frame_index onto IoData.meta.
+
+The stamping is the runner-side half of the metadata system: sources
+populate ``source_path``; OutputPort populates ``frame_index`` so every
+hop carries an unambiguous "current frame number" without producers
+having to thread it manually.
+"""
+from __future__ import annotations
+
+from core.io_data import IoData, IoDataType
+from core.port import InputPort, OutputPort
+
+
+def _wire_capture() -> tuple[OutputPort, list[IoData]]:
+    out = OutputPort("out", {IoDataType.SCALAR})
+    sink = InputPort("sink", {IoDataType.SCALAR})
+    captured: list[IoData] = []
+    sink.add_listener(
+        lambda: captured.append(sink.data) if sink.has_data else None
+    )
+    out.connect(sink)
+    return out, captured
+
+
+def test_send_stamps_zero_based_frame_index_on_each_emit() -> None:
+    out, captured = _wire_capture()
+
+    for i in range(4):
+        out.send(IoData.from_scalar(i))
+
+    assert [d.meta.frame_index for d in captured] == [0, 1, 2, 3]
+
+
+def test_send_overrides_caller_supplied_frame_index() -> None:
+    """The producer's frame_index is overwritten on each hop so the
+    receiver sees the upstream port's current count, not whatever the
+    caller stamped earlier."""
+    from core.io_data import IoMeta
+    out, captured = _wire_capture()
+
+    out.send(IoData.from_scalar(99, meta=IoMeta(frame_index=999)))
+
+    assert captured[0].meta.frame_index == 0
+
+
+def test_send_preserves_other_meta_fields() -> None:
+    """source_path / timestamp / extras must survive the frame_index
+    stamp untouched so provenance reaches the sink."""
+    from pathlib import Path
+
+    from core.io_data import IoMeta
+
+    out, captured = _wire_capture()
+    meta = IoMeta(source_path=Path("ship.jpg"), timestamp=1700000000.0)
+    out.send(IoData.from_scalar(0, meta=meta))
+
+    received = captured[0]
+    assert received.meta.source_path == Path("ship.jpg")
+    assert received.meta.timestamp == 1700000000.0
+    assert received.meta.frame_index == 0
+
+
+def test_reset_rewinds_frame_counter() -> None:
+    """``reset`` runs at the start of every flow run; the per-port
+    counter must restart at 0 so two consecutive runs both stamp
+    0,1,2,..."""
+    out, captured = _wire_capture()
+
+    out.send(IoData.from_scalar(0))
+    out.send(IoData.from_scalar(1))
+    out.reset()
+    out.send(IoData.from_scalar(2))
+
+    assert [d.meta.frame_index for d in captured] == [0, 1, 0]

--- a/tests/test_port_frame_index.py
+++ b/tests/test_port_frame_index.py
@@ -28,7 +28,7 @@ def test_send_stamps_zero_based_frame_index_on_each_emit() -> None:
     for i in range(4):
         out.send(IoData.from_scalar(i))
 
-    assert [d.meta.frame_index for d in captured] == [0, 1, 2, 3]
+    assert [d.meta["frame_index"] for d in captured] == [0, 1, 2, 3]
 
 
 def test_send_overrides_caller_supplied_frame_index() -> None:
@@ -40,24 +40,25 @@ def test_send_overrides_caller_supplied_frame_index() -> None:
 
     out.send(IoData.from_scalar(99, meta=IoMeta(frame_index=999)))
 
-    assert captured[0].meta.frame_index == 0
+    assert captured[0].meta["frame_index"] == 0
 
 
-def test_send_preserves_other_meta_fields() -> None:
-    """source_path / timestamp / extras must survive the frame_index
-    stamp untouched so provenance reaches the sink."""
+def test_send_preserves_other_meta_keys() -> None:
+    """Stamping frame_index must leave the other keys in the bag
+    untouched so provenance reaches the sink."""
     from pathlib import Path
 
     from core.io_data import IoMeta
 
     out, captured = _wire_capture()
-    meta = IoMeta(source_path=Path("ship.jpg"), timestamp=1700000000.0)
+    meta = IoMeta(source_path=Path("ship.jpg"), timestamp=1700000000.0, custom_tag="abc")
     out.send(IoData.from_scalar(0, meta=meta))
 
     received = captured[0]
-    assert received.meta.source_path == Path("ship.jpg")
-    assert received.meta.timestamp == 1700000000.0
-    assert received.meta.frame_index == 0
+    assert received.meta["source_path"] == Path("ship.jpg")
+    assert received.meta["timestamp"] == 1700000000.0
+    assert received.meta["custom_tag"] == "abc"
+    assert received.meta["frame_index"] == 0
 
 
 def test_reset_rewinds_frame_counter() -> None:
@@ -71,4 +72,4 @@ def test_reset_rewinds_frame_counter() -> None:
     out.reset()
     out.send(IoData.from_scalar(2))
 
-    assert [d.meta.frame_index for d in captured] == [0, 1, 0]
+    assert [d.meta["frame_index"] for d in captured] == [0, 1, 0]


### PR DESCRIPTION
## Summary

Foundation for the **TickTack** streaming-dataflow series (umbrella
#249). Three pieces land together because the new dev nodes are the
test rig for the metadata system.

### IoData metadata

- New `IoMeta` dataclass: `source_path`, `frame_index`, `timestamp`,
  `extras`. Attached to every `IoData`; factories accept an optional
  `meta=`; new `with_meta(**changes)` and `with_payload(payload)`
  helpers; existing `with_image` now forwards meta by reference.
- `OutputPort.send` auto-stamps `meta.frame_index` from a per-port
  emit counter; `OutputPort.reset` rewinds it at the start of every
  run. Producers no longer thread frame indices manually.
- `ImageSource` and `CsvSource` stamp `meta.source_path` on emit so
  the resolved input path travels with the data.

### Debug-section nodes

- **Meta Inspector** (`src/nodes/debug/meta_inspector.py`):
  pass-through probe that surfaces every frame's `IoMeta` (plus
  payload kind / shape) in its node body. Type-agnostic — accepts
  every `IoDataType` so it can sit anywhere in a flow.
- **Play Gate** (`src/nodes/debug/play_gate.py`): pass-through with a
  Play button in its node body. Holds the most recently received
  frame; releases it downstream on click. Latest-wins single-slot
  semantics so fast streams stay usable without an unbounded queue.
- Preview widgets in `src/ui/preview_widgets.py`, registered in
  `_PREVIEW_WIDGET_CLASSES`.

### Notes

- Filters that build their output via `IoData.from_*(...)` instead of
  `with_image` / `with_payload` still drop `source_path` (the
  per-port `frame_index` stamp survives because it's added in
  `send`). Opportunistic conversion to `with_payload` will follow as
  individual filters are touched; full sweep is out of scope here.
- `APP_VERSION` 0.3.0.2 → 0.3.0.3. `M.m.r` unchanged so
  `doc/welcome.html`'s "What's new" heading stays put.

## Test plan

- [x] `tests/test_io_data.py`: IoMeta factories, `with_meta` shallow
      copy, `with_image` preserves meta.
- [x] `tests/test_port_frame_index.py`: per-port frame_index stamp,
      override of caller-supplied index, source_path / timestamp
      survive the stamp, reset rewinds counter.
- [x] `tests/test_meta_inspector.py`: pass-through, callback receives
      each frame, callback is optional.
- [x] `tests/test_play_gate.py`: holds until Play, releases on click,
      double-click is no-op, latest-wins overwrite, state callback
      transitions, before_run clears stale queue.
- [x] Full non-Qt suite green (649 passed). Qt-dependent tests fail
      to collect on this environment due to missing `libEGL.so.1` —
      pre-existing, unrelated to this change.
- [ ] **Manual UI smoke test** still owed (no Qt-capable env here):
      run a flow `RangeSource(0..4) → Meta Inspector → Display` and
      verify frame_index 0..4 appear in the inspector's body. Then
      insert `Play Gate` between the source and the inspector and
      step through with the button.

Closes #250.

https://claude.ai/code/session_017Q45XSv1CneevA6jvjjujA

---
_Generated by [Claude Code](https://claude.ai/code/session_017Q45XSv1CneevA6jvjjujA)_