### PR TITLE
Add PolarSpectrum node: directional FFT heatmap on a polar plot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,27 @@ once a first tagged release is cut.
 
 ## [0.3.0] — 2026-04-29
 
+### Added (PolarSpectrum node)
+
+- **New `PolarSpectrum` filter (section "Visualization").** For each
+  azimuth θ ∈ [0, 2π), rotates the input pair (x, y) into a single
+  trace ``r_θ(t) = x cos θ + y sin θ``, takes the magnitude FFT, and
+  renders the result as a polar heatmap (angular axis = azimuth,
+  radial axis = frequency, colour = amplitude). Pairs with
+  `SlidingWindow` upstream so each window produces one polar-spectrum
+  frame — particle-motion analytics for two-component sensor data
+  (seismology N + E channels, etc.).
+- Defaults follow the geographic / seismic convention: θ = 0 at the
+  top, angles increase clockwise, dB amplitude scaling, viridis
+  colormap. Configurable: `n_angles` (azimuth resolution), `n_fft`
+  inferred from the input length with a Hann window, `freq_max`
+  (clip the radial axis), `db_scale`, `colormap`, `width`/`height`,
+  optional title.
+- Tests cover: rotated-FFT math (synthetic motion along the x-axis,
+  y-axis, and 45° diagonal each peaks at the corresponding azimuth),
+  dB floor relative to the spectrum peak, output shape, no-figure-
+  leak, column-resolution errors.
+
 ### Changed (PlotXY / PlotSeries config-only params)
 
 - **`title`, `grid`, `width`, and `height` on `PlotXY` and

--- a/src/constants.py
+++ b/src/constants.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 APP_NAME:         str = "Stjörnhorn"
 APP_DISPLAY_NAME: str = "Stjörnhorn"
-APP_VERSION:      str = "0.3.0.25"
+APP_VERSION:      str = "0.3.0.26"
 API_URL:    str = "https://beltoforion.de"
 
 # Path resolution -----------------------------------------------------------

--- a/src/nodes/filters/polar_spectrum.py
+++ b/src/nodes/filters/polar_spectrum.py
@@ -1,0 +1,327 @@
+from __future__ import annotations
+
+# Switch matplotlib to the off-screen Agg backend BEFORE pyplot is
+# imported anywhere — keeps figure rendering self-contained and
+# prevents matplotlib from claiming the host editor's Qt backend.
+import matplotlib
+
+matplotlib.use("Agg")
+
+from enum import IntEnum
+
+import cv2
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+from typing_extensions import override
+
+from core.io_data import IoData, IoDataType
+from core.node_base import NodeBase
+from core.params import BoolParam, EnumParam, FloatParam, IntParam, StringParam
+from core.port import InputPort, OutputPort
+
+#: Render DPI, matched to PlotXY / PlotSeries so multi-panel mosaics
+#: don't pick up scaling discontinuities between plot types.
+_RENDER_DPI: int = 100
+
+#: Tiny floor under the dB conversion so a silent angle/freq cell
+#: doesn't blow up to ``-inf``. Scaled relative to the spectrum's
+#: peak so the dynamic range stays meaningful regardless of input
+#: magnitude.
+_DB_FLOOR_REL: float = 1e-6
+
+
+class Colormap(IntEnum):
+    """Matplotlib colormap selection for :class:`PolarSpectrum`."""
+    VIRIDIS = 0
+    PLASMA  = 1
+    INFERNO = 2
+    MAGMA   = 3
+    TURBO   = 4
+    JET     = 5
+    HOT     = 6
+
+
+_CMAP_NAME: dict[Colormap, str] = {
+    Colormap.VIRIDIS: "viridis",
+    Colormap.PLASMA:  "plasma",
+    Colormap.INFERNO: "inferno",
+    Colormap.MAGMA:   "magma",
+    Colormap.TURBO:   "turbo",
+    Colormap.JET:     "jet",
+    Colormap.HOT:     "hot",
+}
+
+
+class PolarSpectrum(NodeBase):
+    """Directional / polarisation spectrum of two-component data.
+
+    For each azimuth θ ∈ [0, 2π), rotate the input pair (x, y) into a
+    single trace ``r_θ(t) = x cos θ + y sin θ``, take the magnitude
+    FFT, and plot the resulting (angle, frequency, amplitude) as a
+    polar heatmap. Useful for seeing which directions of motion carry
+    which frequency content — particle-motion analytics for
+    seismology and similar two-component sensor data.
+
+    Pairs naturally with :class:`SlidingWindow` upstream: each window
+    produces one polar-spectrum frame, animating alongside a
+    :class:`PlotXY`-rendered hodogram and the source waveforms.
+
+    Convention:
+
+    * ``x_column`` / ``y_column`` default to the first / second
+      columns of the input dataset (the typical
+      ``JoinDatasets(N, E)`` shape).
+    * ``θ = 0`` points up (sets ``set_theta_zero_location("N")``)
+      and angles increase clockwise — the geographic / seismic
+      convention. Different communities prefer different
+      conventions; revisit if a real consumer fights this.
+    * ``sample_rate`` is in Hz; ``freq_max = 0`` shows the full
+      Nyquist range, otherwise clips the radial axis.
+    * ``db_scale = True`` plots ``20 log10(|F|)`` so wide-dynamic-range
+      spectra read cleanly; linear is available for cases where the
+      raw amplitude matters.
+    """
+
+    x_column = StringParam(
+        "",
+        placeholder="(first column)",
+        description=(
+            "Column name for the first component (x). Empty → first "
+            "column of the input dataset."
+        ),
+    )
+    y_column = StringParam(
+        "",
+        placeholder="(second column)",
+        description=(
+            "Column name for the second component (y). Empty → second "
+            "column of the input dataset."
+        ),
+    )
+    sample_rate = FloatParam(
+        8.0,
+        min=0.0,
+        min_exclusive=True,
+        constant=True,
+        unit="Hz",
+        description=(
+            "Sample rate of the input signal, used to label the "
+            "frequency axis and set the Nyquist limit."
+        ),
+    )
+    n_angles = IntParam(
+        72,
+        min=4,
+        constant=True,
+        description=(
+            "Azimuth resolution: number of angles the (x, y) pair is "
+            "rotated through. 72 = 5° steps; 360 = 1° steps. Cost "
+            "scales linearly per frame."
+        ),
+    )
+    freq_max = FloatParam(
+        0.0,
+        min=0.0,
+        constant=True,
+        unit="Hz",
+        description=(
+            "Upper frequency on the radial axis. ``0`` shows the full "
+            "Nyquist range; lower values zoom into the band of interest."
+        ),
+    )
+    db_scale = BoolParam(
+        True,
+        constant=True,
+        description=(
+            "When True, plot ``20 log10(|F|)`` for wide-dynamic-range "
+            "spectra. Linear amplitude when False."
+        ),
+    )
+    colormap = EnumParam(
+        Colormap,
+        Colormap.VIRIDIS,
+        constant=True,
+        description="Heatmap palette.",
+    )
+    width = IntParam(
+        640,
+        min=64,
+        unit="px",
+        constant=True,
+        description="Output image width in pixels.",
+    )
+    height = IntParam(
+        640,
+        min=64,
+        unit="px",
+        constant=True,
+        description="Output image height in pixels.",
+    )
+    title = StringParam(
+        "",
+        placeholder="(no title)",
+        constant=True,
+        description="Optional plot title rendered above the polar axes.",
+    )
+
+    def __init__(self) -> None:
+        super().__init__("Polar Spectrum", section="Visualization")
+        # Explicit annotations so pyright sees the descriptor-backed attrs.
+        self._x_column:    str
+        self._y_column:    str
+        self._sample_rate: float
+        self._n_angles:    int
+        self._freq_max:    float
+        self._db_scale:    bool
+        self._colormap:    Colormap
+        self._width:       int
+        self._height:      int
+        self._title:       str
+        self._add_input(InputPort("dataset", {IoDataType.DATASET}))
+        self._add_output(OutputPort("image", {IoDataType.IMAGE}))
+        self._apply_default_params()
+
+    @override
+    def process_impl(self) -> None:
+        df: pd.DataFrame = self.inputs[0].data.payload
+        x_col = self._resolve_column(df, self._x_column, default_index=0)
+        y_col = self._resolve_column(df, self._y_column, default_index=1)
+        x = df[x_col].to_numpy(dtype=np.float64)
+        y = df[y_col].to_numpy(dtype=np.float64)
+        n = min(len(x), len(y))
+        if n < 4:
+            # Too few samples to produce a meaningful FFT — emit a
+            # blank canvas of the right dimensions so downstream
+            # mosaic / video sinks don't see a frame-shape change.
+            self.outputs[0].send(
+                IoData.from_image(self._blank_image()),
+            )
+            return
+
+        thetas, freqs, spec = self._compute_spectrum(
+            x[:n], y[:n], self._sample_rate, self._n_angles,
+        )
+        freq_max = self._freq_max if self._freq_max > 0.0 else float(freqs[-1])
+        mask = freqs <= freq_max
+        freqs_show = freqs[mask]
+        spec_show  = spec[:, mask]
+        if self._db_scale:
+            spec_show = self._to_db(spec_show)
+
+        bgr = self._render(
+            thetas, freqs_show, spec_show,
+            db_scale=self._db_scale,
+            cmap_name=_CMAP_NAME[self._colormap],
+            width=self._width, height=self._height,
+            title=self._title,
+        )
+        self.outputs[0].send(IoData.from_image(bgr))
+
+    # ── Pure helpers (testable without rendering) ─────────────────────────────
+
+    @staticmethod
+    def _resolve_column(
+        df: pd.DataFrame, requested: str, *, default_index: int,
+    ) -> str:
+        """Return the column name to use, raising on miss.
+
+        Empty ``requested`` falls back to ``default_index``; a typo
+        raises :class:`KeyError` with the available columns listed.
+        """
+        if requested:
+            if requested not in df.columns:
+                raise KeyError(
+                    f"Column {requested!r} not in dataset; "
+                    f"available: {list(df.columns)}",
+                )
+            return requested
+        if default_index >= len(df.columns):
+            raise KeyError(
+                f"Dataset has only {len(df.columns)} column(s); need at "
+                f"least {default_index + 1} for a polar spectrum.",
+            )
+        return str(df.columns[default_index])
+
+    @staticmethod
+    def _compute_spectrum(
+        x: np.ndarray, y: np.ndarray, sample_rate: float, n_angles: int,
+    ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+        """Return ``(thetas, freqs, spec)`` for the rotated FFT stack.
+
+        ``thetas`` shape ``(n_angles,)`` (radians), ``freqs`` shape
+        ``(n_freq,)`` (Hz), ``spec`` shape ``(n_angles, n_freq)``
+        (linear magnitude). A Hann window is applied per rotation to
+        suppress spectral leakage on short windows — the typical
+        SlidingWindow consumer.
+        """
+        n = len(x)
+        window = np.hanning(n)
+        x_w = x * window
+        y_w = y * window
+        thetas = np.linspace(0.0, 2.0 * np.pi, n_angles, endpoint=False)
+        cos_t = np.cos(thetas)[:, None]
+        sin_t = np.sin(thetas)[:, None]
+        rotated = cos_t * x_w + sin_t * y_w
+        spec = np.abs(np.fft.rfft(rotated, axis=1))
+        freqs = np.fft.rfftfreq(n, d=1.0 / sample_rate)
+        return thetas, freqs, spec
+
+    @staticmethod
+    def _to_db(spec: np.ndarray) -> np.ndarray:
+        """Convert a linear-magnitude spectrum to dB with a floor
+        scaled relative to the peak so silent cells don't go to
+        ``-inf`` while the dynamic range stays meaningful."""
+        peak = float(np.max(spec))
+        floor = max(peak * _DB_FLOOR_REL, 1e-12)
+        return 20.0 * np.log10(np.maximum(spec, floor))
+
+    def _blank_image(self) -> np.ndarray:
+        """White canvas matching the configured dimensions, used when
+        the input is too short to FFT meaningfully."""
+        return np.full((self._height, self._width, 3), 255, dtype=np.uint8)
+
+    # ── Rendering (off-screen) ────────────────────────────────────────────────
+
+    @staticmethod
+    def _render(
+        thetas: np.ndarray,
+        freqs:  np.ndarray,
+        spec:   np.ndarray,
+        *,
+        db_scale: bool,
+        cmap_name: str,
+        width:    int,
+        height:   int,
+        title:    str,
+    ) -> np.ndarray:
+        """Render the polar heatmap to a BGR ``uint8`` array.
+
+        Closes the figure in the ``finally`` block so a long-running
+        flow doesn't leak figures across frames (parity with the
+        rest of the matplotlib-based viz nodes).
+        """
+        fig = plt.figure(
+            figsize=(width / _RENDER_DPI, height / _RENDER_DPI),
+            dpi=_RENDER_DPI,
+        )
+        try:
+            ax = fig.add_subplot(111, projection="polar")
+            # Wrap angles + spectrum so the polar plot closes back to
+            # 2π without a visible seam at θ = 0.
+            theta_closed = np.concatenate([thetas, [2.0 * np.pi]])
+            spec_closed  = np.vstack([spec, spec[:1]])
+            T, R = np.meshgrid(theta_closed, freqs, indexing="xy")
+            mesh = ax.pcolormesh(T, R, spec_closed.T, cmap=cmap_name, shading="auto")
+            ax.set_theta_zero_location("N")
+            ax.set_theta_direction(-1)
+            if title:
+                ax.set_title(title)
+            cbar = fig.colorbar(mesh, ax=ax, pad=0.1, shrink=0.8)
+            cbar.set_label("dB" if db_scale else "amplitude")
+            fig.tight_layout(pad=0.4)
+            fig.canvas.draw()
+            rgba = np.asarray(fig.canvas.buffer_rgba())
+            return cv2.cvtColor(rgba, cv2.COLOR_RGBA2BGR)
+        finally:
+            plt.close(fig)

--- a/tests/test_polar_spectrum.py
+++ b/tests/test_polar_spectrum.py
@@ -1,0 +1,251 @@
+"""Tests for :class:`~nodes.filters.polar_spectrum.PolarSpectrum`.
+
+Focused on:
+
+* the FFT / rotation math (``_compute_spectrum``, pure helper —
+  testable without matplotlib);
+* the dB conversion floor;
+* the rendering pipeline emits an image of the requested shape and
+  doesn't leak figures.
+
+The visual correctness of the polar heatmap (cell layout, theta=N
+convention) is verified indirectly: synthetic data with motion along
+a known azimuth must produce its peak power at that azimuth.
+"""
+from __future__ import annotations
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import pytest
+
+from core.io_data import IoData, IoDataType
+from nodes.filters.polar_spectrum import PolarSpectrum
+
+
+def _two_channel_df(x: np.ndarray, y: np.ndarray) -> pd.DataFrame:
+    return pd.DataFrame({"N": x, "E": y})
+
+
+def _run(node: PolarSpectrum, df: pd.DataFrame) -> np.ndarray:
+    """Feed *df* into the node and return the emitted BGR image."""
+    node.inputs[0].receive(IoData.from_dataset(df))
+    out = node.outputs[0].last_emitted
+    assert out is not None, "PolarSpectrum did not emit"
+    assert out.type is IoDataType.IMAGE
+    return out.image
+
+
+# ── Output shape & lifecycle ─────────────────────────────────────────────────
+
+
+def test_emits_image_of_requested_shape() -> None:
+    node = PolarSpectrum()
+    node.width = 200
+    node.height = 200
+    n = 64
+    t = np.arange(n) / 8.0
+    img = _run(node, _two_channel_df(np.sin(2 * np.pi * t), np.zeros(n)))
+
+    assert img.dtype == np.uint8
+    assert img.ndim == 3
+    assert img.shape[:2] == (200, 200)
+
+
+def test_no_open_figures_after_render() -> None:
+    plt.close("all")
+    node = PolarSpectrum()
+    node.width = 200
+    node.height = 200
+    n = 64
+    t = np.arange(n) / 8.0
+    for _ in range(3):
+        _run(node, _two_channel_df(np.sin(2 * np.pi * t), np.zeros(n)))
+    assert plt.get_fignums() == [], "PolarSpectrum left matplotlib figures open"
+
+
+def test_too_short_input_emits_blank_canvas() -> None:
+    """An FFT of < 4 samples is meaningless; the node emits a blank
+    canvas of the configured size so a downstream Mosaic or VideoSink
+    doesn't see a frame-shape change between empty and populated
+    windows."""
+    node = PolarSpectrum()
+    node.width = 100
+    node.height = 100
+    img = _run(node, _two_channel_df(np.array([1.0, 2.0]), np.array([0.5, 0.7])))
+    assert img.shape[:2] == (100, 100)
+
+
+# ── Pure spectrum math ───────────────────────────────────────────────────────
+
+
+def test_compute_spectrum_shape_matches_n_angles_and_rfft_size() -> None:
+    """``spec`` shape is ``(n_angles, n_freq)`` with
+    ``n_freq = n // 2 + 1`` for an even-length input."""
+    n = 128
+    n_angles = 36
+    x = np.zeros(n)
+    y = np.zeros(n)
+    thetas, freqs, spec = PolarSpectrum._compute_spectrum(x, y, 8.0, n_angles)
+    assert thetas.shape == (n_angles,)
+    assert freqs.shape  == (n // 2 + 1,)
+    assert spec.shape   == (n_angles, n // 2 + 1)
+
+
+def test_motion_along_x_axis_peaks_at_theta_zero_and_pi() -> None:
+    """Pure x-axis motion (y = 0) projects fully onto θ=0 and θ=π
+    (the rotation ``cos θ`` is ±1 there); orthogonal angles project to
+    zero. The polar spectrum's peak power at the signal's frequency
+    must therefore land on θ ∈ {0, π} and be near-zero at θ = π/2,
+    3π/2."""
+    fs   = 8.0
+    n    = 128
+    f0   = 1.0
+    t    = np.arange(n) / fs
+    x    = np.sin(2 * np.pi * f0 * t)
+    y    = np.zeros(n)
+    n_angles = 72  # 5° resolution → cardinal angles fall on bins
+    thetas, freqs, spec = PolarSpectrum._compute_spectrum(x, y, fs, n_angles)
+
+    # Frequency bin closest to f0
+    k = int(np.argmin(np.abs(freqs - f0)))
+    power_at_f0 = spec[:, k]
+
+    angle_step = 2 * np.pi / n_angles
+
+    def angle_idx(theta: float) -> int:
+        return int(round(theta / angle_step)) % n_angles
+
+    east_west = max(power_at_f0[angle_idx(0.0)], power_at_f0[angle_idx(np.pi)])
+    north_south = max(
+        power_at_f0[angle_idx(np.pi / 2)],
+        power_at_f0[angle_idx(3 * np.pi / 2)],
+    )
+    assert east_west > 10 * north_south, (
+        f"x-axis motion should concentrate at θ ∈ {{0, π}}: "
+        f"east_west={east_west:.3f}, north_south={north_south:.3f}"
+    )
+
+
+def test_motion_along_y_axis_peaks_at_theta_pi_over_2_and_3pi_over_2() -> None:
+    """Symmetric to the x-axis test: pure y-axis motion peaks at the
+    perpendicular azimuths."""
+    fs   = 8.0
+    n    = 128
+    f0   = 1.0
+    t    = np.arange(n) / fs
+    x    = np.zeros(n)
+    y    = np.sin(2 * np.pi * f0 * t)
+    n_angles = 72
+    thetas, freqs, spec = PolarSpectrum._compute_spectrum(x, y, fs, n_angles)
+
+    k = int(np.argmin(np.abs(freqs - f0)))
+    power_at_f0 = spec[:, k]
+    angle_step = 2 * np.pi / n_angles
+    def angle_idx(theta: float) -> int:
+        return int(round(theta / angle_step)) % n_angles
+
+    north_south = max(
+        power_at_f0[angle_idx(np.pi / 2)],
+        power_at_f0[angle_idx(3 * np.pi / 2)],
+    )
+    east_west = max(power_at_f0[angle_idx(0.0)], power_at_f0[angle_idx(np.pi)])
+    assert north_south > 10 * east_west
+
+
+def test_diagonal_motion_peaks_at_45_degree_azimuths() -> None:
+    """Motion along the 45° / 225° diagonal (x = y) should peak at
+    those azimuths and be near-zero at 135° / 315°."""
+    fs = 8.0
+    n  = 128
+    f0 = 1.0
+    t  = np.arange(n) / fs
+    s  = np.sin(2 * np.pi * f0 * t)
+    n_angles = 72
+    thetas, freqs, spec = PolarSpectrum._compute_spectrum(s, s, fs, n_angles)
+
+    k = int(np.argmin(np.abs(freqs - f0)))
+    power_at_f0 = spec[:, k]
+    angle_step = 2 * np.pi / n_angles
+    def angle_idx(theta: float) -> int:
+        return int(round(theta / angle_step)) % n_angles
+
+    forty_five = max(
+        power_at_f0[angle_idx(np.pi / 4)],
+        power_at_f0[angle_idx(5 * np.pi / 4)],
+    )
+    one_thirty_five = max(
+        power_at_f0[angle_idx(3 * np.pi / 4)],
+        power_at_f0[angle_idx(7 * np.pi / 4)],
+    )
+    assert forty_five > 10 * one_thirty_five
+
+
+# ── dB conversion ────────────────────────────────────────────────────────────
+
+
+def test_db_floor_keeps_silent_cells_finite() -> None:
+    """A spectrum cell that's zero in the linear domain becomes
+    ``20 * log10(floor)`` rather than ``-inf`` — colormaps don't
+    render ``-inf`` cleanly."""
+    spec = np.array([[1.0, 0.0, 0.5], [0.0, 0.0, 0.0]])
+    db = PolarSpectrum._to_db(spec)
+    assert np.all(np.isfinite(db))
+    # The peak in linear → 0 dB in our convention is `20 log10(1)`.
+    assert db[0, 0] == pytest.approx(0.0, abs=1e-9)
+
+
+def test_db_floor_is_relative_to_peak() -> None:
+    """Scaling the input by a factor shifts the dB output by the
+    same multiplier in dB (i.e. all cells get +20 log10(scale))
+    EXCEPT the floored ones, which clip to peak * 1e-6 — so peak-to-
+    floor distance stays at ``120 dB`` regardless of input scale."""
+    spec = np.array([[2.5, 0.0]])
+    db = PolarSpectrum._to_db(spec)
+    spread = float(db[0, 0] - db[0, 1])
+    assert spread == pytest.approx(120.0, abs=1e-6)
+
+
+# ── Column resolution ───────────────────────────────────────────────────────
+
+
+def test_explicit_column_names_are_used_when_provided() -> None:
+    """A 3-column input with named overrides plots the named pair, not
+    the first two."""
+    node = PolarSpectrum()
+    node.x_column = "ch_a"
+    node.y_column = "ch_c"
+    node.width = 100
+    node.height = 100
+    n = 64
+    t = np.arange(n) / 8.0
+    df = pd.DataFrame({
+        "ch_a": np.sin(2 * np.pi * t),
+        "ch_b": np.zeros(n),
+        "ch_c": np.cos(2 * np.pi * t),
+    })
+    img = _run(node, df)
+    # Just verifies the pair was resolved without raising; numerical
+    # check belongs to ``_compute_spectrum`` tests above.
+    assert img is not None
+
+
+def test_unknown_column_raises_keyerror() -> None:
+    node = PolarSpectrum()
+    node.x_column = "missing"
+    df = pd.DataFrame({"N": np.zeros(64), "E": np.zeros(64)})
+    with pytest.raises(KeyError, match="missing"):
+        node.inputs[0].receive(IoData.from_dataset(df))
+
+
+def test_single_column_input_raises_keyerror() -> None:
+    """Default y_column resolution falls through to ``default_index=1``;
+    a one-column input can't supply that, so the node raises with a
+    clear message rather than silently plotting nonsense."""
+    node = PolarSpectrum()
+    df = pd.DataFrame({"N": np.zeros(64)})
+    with pytest.raises(KeyError, match="at least 2"):
+        node.inputs[0].receive(IoData.from_dataset(df))


### PR DESCRIPTION
## Summary

New `PolarSpectrum` filter (section "Visualization"). For each azimuth θ ∈ [0, 2π), rotates the input pair (x, y) into a single trace `r_θ(t) = x cos θ + y sin θ`, takes the magnitude FFT, and renders the result as a polar heatmap — angular axis = azimuth, radial axis = frequency, colour = amplitude.

Pairs with `SlidingWindow` upstream so each window produces one polar-spectrum frame, animating alongside the existing PlotXY hodogram view. Particle-motion analytics for two-component sensor data — seismology N + E channels are the canonical use case.

## Conventions

- **θ = 0 at the top**, angles increase **clockwise** (geographic / seismic).
- **Hann window per rotation** to suppress spectral leakage on short windows (the typical SlidingWindow consumer).
- **dB scaling by default** with a floor at `peak * 1e-6` so silent cells don't go to `-inf`.
- **Default colormap**: viridis. JET, TURBO, INFERNO etc. available.

## Params

| Name | Default | Notes |
|------|---------|-------|
| `x_column`, `y_column` | empty | First / second column by default |
| `sample_rate` | 8.0 Hz | Used to label frequency axis + Nyquist limit |
| `n_angles` | 72 | 5° resolution; cost scales linearly |
| `freq_max` | 0 (Nyquist) | Clip the radial axis to a band of interest |
| `db_scale` | True | `20 log10(|F|)` vs linear |
| `colormap` | VIRIDIS | 7 palettes |
| `width`, `height` | 640 × 640 | Output image dimensions |
| `title` | empty | Optional |

## Test plan

- [x] **FFT math** — pure-helper `_compute_spectrum` returns `(thetas, freqs, spec)` with the right shapes and Nyquist-bin count
- [x] **Directional correctness** — synthetic motion along the x-axis peaks at θ ∈ {0, π} and is at least 10× attenuated at perpendicular azimuths; same for y-axis (peaks at π/2, 3π/2) and 45° diagonal (peaks at π/4, 5π/4)
- [x] **dB floor** — silent cells become `peak * 1e-6` ≈ -120 dB rather than `-inf`; peak-to-floor distance stays at 120 dB regardless of input scale
- [x] **Render lifecycle** — image of requested shape, no leaked matplotlib figures across multiple frames
- [x] **Column resolution** — explicit names work; typo and too-few-columns raise `KeyError`
- [x] **Too-short input** — < 4 samples emits a blank canvas of the configured size (no frame-shape change downstream)

12 new tests; full suite 858 passed.

`APP_VERSION` → `0.3.0.26`.

https://claude.ai/code/session_019kbkJFq2zqKh7CwVzFtvCh

---
_Generated by [Claude Code](https://claude.ai/code/session_019kbkJFq2zqKh7CwVzFtvCh)_