### PR TITLE
Redesign port visuals with type-coloured rings and direction glyphs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,27 @@ once a first tagged release is cut.
 
 ## [0.3.0] — 2026-04-29
 
+### Changed (port visuals: type-coloured rings + output direction glyph)
+
+- **Ports now encode their `IoDataType` set as colour.** Each port
+  renders as a pie of one arc per accepted (input) or emitted
+  (output) type, drawn from a new `PORT_TYPE_COLORS` palette in
+  `ui/theme.py` (image=blue, scalar=orange, dataset=green,
+  bool=red, …). Multi-type ports (e.g. `IMAGE_TYPES`) read as
+  multi-coloured rings without any "primary type" heuristic; the
+  connected-state fill uses the same pie. Previously every input
+  was grey and every output yellow, with the type only readable by
+  hovering over the node's source.
+- **Output ports get a small right-pointing triangle glyph** beside
+  the dot so flow direction stays obvious now that the ring colour
+  is no longer carrying it. Inputs stay plain — their position on
+  the left edge of the node already disambiguates.
+- **Required / optional / held semantics moved to ring style** —
+  required and outputs use a thicker solid ring, optional inputs a
+  thinner solid ring, held inputs a dashed ring. Three orthogonal
+  visual axes (type=colour, direction=glyph, semantics=stroke
+  style) replace the previous overloaded colour scheme.
+
 ### Removed (Output Inspector dock + toolbar-mirroring menu entries)
 
 - **Output Inspector** — the dockable panel that previewed the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ once a first tagged release is cut.
   the left edge of the node already disambiguates.
 - **Required / optional / held semantics moved to ring style** —
   required and outputs use a thicker solid ring, optional inputs a
-  thinner solid ring, held inputs a dashed ring. Three orthogonal
+  thinner solid ring, held inputs a dotted ring. Three orthogonal
   visual axes (type=colour, direction=glyph, semantics=stroke
   style) replace the previous overloaded colour scheme.
 

--- a/src/constants.py
+++ b/src/constants.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 APP_NAME:         str = "Stjörnhorn"
 APP_DISPLAY_NAME: str = "Stjörnhorn"
-APP_VERSION:      str = "0.3.0.31"
+APP_VERSION:      str = "0.3.0.32"
 API_URL:    str = "https://beltoforion.de"
 
 # Path resolution -----------------------------------------------------------

--- a/src/constants.py
+++ b/src/constants.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 APP_NAME:         str = "Stjörnhorn"
 APP_DISPLAY_NAME: str = "Stjörnhorn"
-APP_VERSION:      str = "0.3.0.33"
+APP_VERSION:      str = "0.3.0.34"
 API_URL:    str = "https://beltoforion.de"
 
 # Path resolution -----------------------------------------------------------

--- a/src/constants.py
+++ b/src/constants.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 APP_NAME:         str = "Stjörnhorn"
 APP_DISPLAY_NAME: str = "Stjörnhorn"
-APP_VERSION:      str = "0.3.0.30"
+APP_VERSION:      str = "0.3.0.31"
 API_URL:    str = "https://beltoforion.de"
 
 # Path resolution -----------------------------------------------------------

--- a/src/constants.py
+++ b/src/constants.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 APP_NAME:         str = "Stjörnhorn"
 APP_DISPLAY_NAME: str = "Stjörnhorn"
-APP_VERSION:      str = "0.3.0.32"
+APP_VERSION:      str = "0.3.0.33"
 API_URL:    str = "https://beltoforion.de"
 
 # Path resolution -----------------------------------------------------------

--- a/src/ui/port_item.py
+++ b/src/ui/port_item.py
@@ -1,20 +1,22 @@
 from __future__ import annotations
 
-from enum import Enum
 from typing import TYPE_CHECKING, Literal
 
 from PySide6.QtCore import QRectF, Qt
-from PySide6.QtGui import QBrush, QPen
-from PySide6.QtWidgets import QGraphicsEllipseItem, QGraphicsItem
+from PySide6.QtGui import QBrush, QPainterPath, QPen
+from PySide6.QtWidgets import QGraphicsEllipseItem
 
+from core.io_data import IoDataType
 from ui.theme import (
-    NODE_BORDER_COLOR,
+    PORT_DIRECTION_GLYPH_COLOR,
     PORT_HOVER_COLOR,
-    PORT_INPUT_COLOR,
-    PORT_OUTPUT_COLOR,
+    PORT_TYPE_COLORS,
+    PORT_TYPE_DEFAULT_COLOR,
 )
 
 if TYPE_CHECKING:
+    from PySide6.QtGui import QColor
+
     from core.port import InputPort, OutputPort
 
     from ui.link_item import LinkItem
@@ -22,6 +24,12 @@ if TYPE_CHECKING:
 
 
 PortKind = Literal["input", "output"]
+
+
+# Qt's drawArc / drawPie work in 1/16-degree units; one full turn is
+# 360 * 16. Stored as a constant so the geometry helpers don't sprinkle
+# the magic 5760 inline.
+_FULL_CIRCLE_16THS: int = 360 * 16
 
 
 class PortItem(QGraphicsEllipseItem):
@@ -33,6 +41,19 @@ class PortItem(QGraphicsEllipseItem):
 
     Link creation is initiated by pressing the mouse on a port; the scene
     takes over from there (see :class:`FlowScene`).
+
+    Visual encoding (three orthogonal axes):
+
+    * **Type** — ring (and connected-state fill) is a pie of one arc per
+      :class:`IoDataType` in the port's accepted/emitted set, coloured
+      from :data:`ui.theme.PORT_TYPE_COLORS`. Multi-type ports therefore
+      read as multi-coloured rings without any "primary type" heuristic.
+    * **Semantics** — ring style differentiates required (thick solid),
+      optional input (thin solid) and held input (dashed). Outputs are
+      always thick solid.
+    * **Direction** — output ports get a small right-pointing triangle
+      glyph beside the dot. Input ports stay plain — the position on the
+      left edge of the node already disambiguates.
     """
 
     RADIUS: float = 5.0
@@ -43,6 +64,21 @@ class PortItem(QGraphicsEllipseItem):
     #: leave the label text overlapping the dot.
     LABEL_OFFSET: float = 11.0  # = RADIUS + 6 px breathing room
     Z_VALUE = 2
+
+    # Ring widths by port semantics. Required inputs and all outputs
+    # use the thicker stroke so the type colour stays visible at the
+    # default zoom level; optional inputs read as a thinner ring to
+    # signal "OK to leave unconnected" without a separate colour axis.
+    _RING_WIDTH_DEFAULT: float = 1.4
+    _RING_WIDTH_OPTIONAL: float = 1.0
+
+    # Direction glyph (output-only triangle) geometry, in port-local
+    # coords. The base sits flush with the right edge of the dot and
+    # the tip extends ``_GLYPH_LENGTH`` further out so the arrow reads
+    # at typical zoom levels without crowding adjacent ports.
+    _GLYPH_BASE_OFFSET: float = 1.0
+    _GLYPH_LENGTH: float = 4.5
+    _GLYPH_HALF_HEIGHT: float = 3.0
 
     def __init__(
         self,
@@ -58,34 +94,16 @@ class PortItem(QGraphicsEllipseItem):
         self._index = index
         self._model = model
         self._links: list[LinkItem] = []
+        self._hovered: bool = False
 
         self.setZValue(self.Z_VALUE)
         self.setAcceptHoverEvents(True)
         self.setCursor(Qt.CursorShape.CrossCursor)
-        # Pen (outline) by port kind:
-        #   * Output          → bright PORT_OUTPUT_COLOR ring so the
-        #     unconnected fill (set by ``_apply_default_brush``) is
-        #     visibly haloed in yellow, mirroring the optional-input
-        #     ring on the opposite side of the node.
-        #   * Held input      → bright PORT_INPUT_COLOR ring with a
-        #     dashed pen, signalling "this port latches its last
-        #     value — it's a parameter, not a per-tick clock".
-        #   * Optional input  → bright PORT_INPUT_COLOR ring (the
-        #     pre-existing "OK to leave unconnected" affordance).
-        #   * Required input  → subtle dark NODE_BORDER_COLOR.
-        # The pen stays put for the lifetime of the port; brush is
-        # what tracks connection state via ``_apply_default_brush``.
-        if self._kind == "output":
-            self.setPen(QPen(PORT_OUTPUT_COLOR, 1.4))
-        elif self._is_held():
-            held_pen = QPen(PORT_INPUT_COLOR, 1.4)
-            held_pen.setStyle(Qt.PenStyle.DashLine)
-            self.setPen(held_pen)
-        elif self._is_optional():
-            self.setPen(QPen(PORT_INPUT_COLOR, 1.4))
-        else:
-            self.setPen(QPen(NODE_BORDER_COLOR, 1))
-        self._apply_default_brush()
+        # All visuals are drawn in :meth:`paint`; suppress the default
+        # ellipse pen/brush so Qt doesn't paint a stray outline under
+        # our pie-arc ring.
+        self.setPen(QPen(Qt.PenStyle.NoPen))
+        self.setBrush(QBrush(Qt.BrushStyle.NoBrush))
 
     # ── Identity ───────────────────────────────────────────────────────────────
 
@@ -118,12 +136,12 @@ class PortItem(QGraphicsEllipseItem):
     def add_link(self, link: LinkItem) -> None:
         if link not in self._links:
             self._links.append(link)
-            self._apply_default_brush()
+            self.update()
 
     def remove_link(self, link: LinkItem) -> None:
         if link in self._links:
             self._links.remove(link)
-            self._apply_default_brush()
+            self.update()
 
     def refresh_links(self) -> None:
         """Called by NodeItem when the node moves so link paths stay glued."""
@@ -133,24 +151,32 @@ class PortItem(QGraphicsEllipseItem):
     # ── Hover feedback ─────────────────────────────────────────────────────────
 
     def hoverEnterEvent(self, event) -> None:  # type: ignore[override]
-        self.setBrush(QBrush(PORT_HOVER_COLOR))
+        self._hovered = True
+        self.update()
         super().hoverEnterEvent(event)
 
     def hoverLeaveEvent(self, event) -> None:  # type: ignore[override]
-        self._apply_default_brush()
+        self._hovered = False
+        self.update()
         super().hoverLeaveEvent(event)
 
-    def _apply_default_brush(self) -> None:
-        # Connection state drives the fill: an unconnected port reads
-        # as a "ready to receive" affordance with a black interior; a
-        # connected port turns solid in its kind colour to signal the
-        # link is live. The pen / outline keeps the port-kind colour
-        # in both states so the dot stays identifiable at a glance.
-        if self._is_connected():
-            color = PORT_OUTPUT_COLOR if self._kind == "output" else PORT_INPUT_COLOR
-            self.setBrush(QBrush(color))
+    # ── Type / semantics introspection ─────────────────────────────────────────
+
+    def _types(self) -> list[IoDataType]:
+        """Return the port's accepted/emitted types in a stable order.
+
+        Sorted by enum-name so a port's ring colours stay put across
+        runs and across calls — frozenset iteration order is unspecified.
+        """
+        if self._kind == "input":
+            raw = getattr(self._model, "accepted_types", frozenset())
         else:
-            self.setBrush(QBrush(Qt.black))
+            raw = getattr(self._model, "emits", frozenset())
+        return sorted(raw, key=lambda t: t.name)
+
+    @staticmethod
+    def _type_color(t: IoDataType) -> QColor:
+        return PORT_TYPE_COLORS.get(t, PORT_TYPE_DEFAULT_COLOR)
 
     def _is_connected(self) -> bool:
         """True if this port currently has at least one link.
@@ -163,24 +189,101 @@ class PortItem(QGraphicsEllipseItem):
         return bool(self._links)
 
     def _is_optional(self) -> bool:
-        """True if this port is an input marked ``optional=True``.
-
-        Output ports are never optional — only the receiver side can
-        choose to run without an incoming payload.
-        """
         if self._kind != "input":
             return False
         return bool(getattr(self._model, "optional", False))
 
     def _is_held(self) -> bool:
-        """True if this port is an input marked ``hold_last=True``.
-
-        Held inputs latch their last received value; outputs don't
-        have the concept (they push, they don't hold).
-        """
         if self._kind != "input":
             return False
         return bool(getattr(self._model, "hold_last", False))
+
+    def _ring_width(self) -> float:
+        return self._RING_WIDTH_OPTIONAL if self._is_optional() else self._RING_WIDTH_DEFAULT
+
+    def _ring_style(self) -> Qt.PenStyle:
+        return Qt.PenStyle.DashLine if self._is_held() else Qt.PenStyle.SolidLine
+
+    # ── Painting ───────────────────────────────────────────────────────────────
+
+    def paint(self, painter, option, widget=None) -> None:  # type: ignore[override]
+        painter.setRenderHint(painter.RenderHint.Antialiasing, True)
+
+        types = self._types()
+        rect = self.rect()
+
+        # Interior fill — connection state.
+        # Hover wins over everything so the user always gets the same
+        # "you're about to grab this dot" feedback.
+        if self._hovered:
+            painter.setPen(QPen(Qt.PenStyle.NoPen))
+            painter.setBrush(QBrush(PORT_HOVER_COLOR))
+            painter.drawEllipse(rect)
+        elif self._is_connected() and types:
+            self._paint_pie(painter, rect, types)
+        else:
+            painter.setPen(QPen(Qt.PenStyle.NoPen))
+            painter.setBrush(QBrush(Qt.GlobalColor.black))
+            painter.drawEllipse(rect)
+
+        # Ring — type-coloured arcs on top of the fill.
+        self._paint_ring(painter, rect, types)
+
+        # Output direction glyph — drawn last so it sits above any
+        # neighbouring ring stroke.
+        if self._kind == "output":
+            self._paint_direction_glyph(painter)
+
+    def _paint_pie(self, painter, rect: QRectF, types: list[IoDataType]) -> None:
+        painter.setPen(QPen(Qt.PenStyle.NoPen))
+        if len(types) == 1:
+            painter.setBrush(QBrush(self._type_color(types[0])))
+            painter.drawEllipse(rect)
+            return
+        span = _FULL_CIRCLE_16THS // len(types)
+        # Distribute any rounding remainder onto the last slice so the
+        # pie always closes cleanly with no thin background sliver.
+        for i, t in enumerate(types):
+            start = i * span
+            slice_span = span if i < len(types) - 1 else _FULL_CIRCLE_16THS - start
+            painter.setBrush(QBrush(self._type_color(t)))
+            painter.drawPie(rect, start, slice_span)
+
+    def _paint_ring(self, painter, rect: QRectF, types: list[IoDataType]) -> None:
+        painter.setBrush(QBrush(Qt.BrushStyle.NoBrush))
+        width = self._ring_width()
+        style = self._ring_style()
+        if not types:
+            pen = QPen(PORT_TYPE_DEFAULT_COLOR, width, style)
+            painter.setPen(pen)
+            painter.drawEllipse(rect)
+            return
+        if len(types) == 1:
+            pen = QPen(self._type_color(types[0]), width, style)
+            painter.setPen(pen)
+            painter.drawEllipse(rect)
+            return
+        span = _FULL_CIRCLE_16THS // len(types)
+        for i, t in enumerate(types):
+            start = i * span
+            arc_span = span if i < len(types) - 1 else _FULL_CIRCLE_16THS - start
+            pen = QPen(self._type_color(t), width, style)
+            pen.setCapStyle(Qt.PenCapStyle.FlatCap)
+            painter.setPen(pen)
+            painter.drawArc(rect, start, arc_span)
+
+    def _paint_direction_glyph(self, painter) -> None:
+        path = QPainterPath()
+        base_x = self.RADIUS + self._GLYPH_BASE_OFFSET
+        tip_x = base_x + self._GLYPH_LENGTH
+        h = self._GLYPH_HALF_HEIGHT
+        path.moveTo(base_x, -h)
+        path.lineTo(tip_x, 0.0)
+        path.lineTo(base_x, h)
+        path.closeSubpath()
+        painter.setPen(QPen(Qt.PenStyle.NoPen))
+        painter.setBrush(QBrush(PORT_DIRECTION_GLYPH_COLOR))
+        painter.drawPath(path)
 
     # Press handling is intentionally left to the scene: if PortItem grabs
     # the mouse here, Qt routes subsequent move/release events to the item
@@ -188,6 +291,12 @@ class PortItem(QGraphicsEllipseItem):
     # code path needs to consume. See FlowScene.mousePressEvent.
 
     def boundingRect(self) -> QRectF:  # type: ignore[override]
-        # Slightly larger than the visible ellipse so hit-testing is forgiving.
+        # Slightly larger than the visible ellipse so hit-testing is
+        # forgiving. Outputs extend further to the right to cover the
+        # direction glyph; without it the arrow would clip when scrolled
+        # near the viewport edge.
         r = self.RADIUS + 2
+        if self._kind == "output":
+            extra = self._GLYPH_BASE_OFFSET + self._GLYPH_LENGTH + 1.0
+            return QRectF(-r, -r, 2 * r + extra, 2 * r)
         return QRectF(-r, -r, 2 * r, 2 * r)

--- a/src/ui/port_item.py
+++ b/src/ui/port_item.py
@@ -56,7 +56,7 @@ class PortItem(QGraphicsEllipseItem):
       from :data:`ui.theme.PORT_TYPE_COLORS`. Multi-type ports therefore
       read as multi-coloured rings without any "primary type" heuristic.
     * **Semantics** — ring style differentiates required (thick solid),
-      optional input (thin solid) and held input (dashed). Outputs are
+      optional input (thin solid) and held input (dotted). Outputs are
       always thick solid.
     * **Direction** — output ports get a small right-pointing triangle
       glyph beside the dot. Input ports stay plain — the position on the
@@ -209,7 +209,10 @@ class PortItem(QGraphicsEllipseItem):
         return self._RING_WIDTH_OPTIONAL if self._is_optional() else self._RING_WIDTH_DEFAULT
 
     def _ring_style(self) -> Qt.PenStyle:
-        return Qt.PenStyle.DashLine if self._is_held() else Qt.PenStyle.SolidLine
+        # DotLine gives ~10 fine dots around the small port ring,
+        # which reads as "intermittent" much better than the four
+        # chunky dashes DashLine produces at this radius.
+        return Qt.PenStyle.DotLine if self._is_held() else Qt.PenStyle.SolidLine
 
     # ── Painting ───────────────────────────────────────────────────────────────
 

--- a/src/ui/port_item.py
+++ b/src/ui/port_item.py
@@ -31,6 +31,13 @@ PortKind = Literal["input", "output"]
 # the magic 5760 inline.
 _FULL_CIRCLE_16THS: int = 360 * 16
 
+# Connected-state fill darkening factor passed to ``QColor.darker``.
+# 100 = unchanged, >100 = darker. The ring keeps the full type colour;
+# the interior is rendered noticeably darker so the bright ring stays
+# visible against its own type-coloured fill (otherwise ring and fill
+# merge into a single flat blob and the connection state is lost).
+_CONNECTED_FILL_DARKEN: int = 200
+
 
 class PortItem(QGraphicsEllipseItem):
     """Small clickable dot at the edge of a node that represents one port.
@@ -237,7 +244,7 @@ class PortItem(QGraphicsEllipseItem):
     def _paint_pie(self, painter, rect: QRectF, types: list[IoDataType]) -> None:
         painter.setPen(QPen(Qt.PenStyle.NoPen))
         if len(types) == 1:
-            painter.setBrush(QBrush(self._type_color(types[0])))
+            painter.setBrush(QBrush(self._fill_color(types[0])))
             painter.drawEllipse(rect)
             return
         span = _FULL_CIRCLE_16THS // len(types)
@@ -246,8 +253,12 @@ class PortItem(QGraphicsEllipseItem):
         for i, t in enumerate(types):
             start = i * span
             slice_span = span if i < len(types) - 1 else _FULL_CIRCLE_16THS - start
-            painter.setBrush(QBrush(self._type_color(t)))
+            painter.setBrush(QBrush(self._fill_color(t)))
             painter.drawPie(rect, start, slice_span)
+
+    @classmethod
+    def _fill_color(cls, t: IoDataType) -> QColor:
+        return cls._type_color(t).darker(_CONNECTED_FILL_DARKEN)
 
     def _paint_ring(self, painter, rect: QRectF, types: list[IoDataType]) -> None:
         painter.setBrush(QBrush(Qt.BrushStyle.NoBrush))

--- a/src/ui/port_item.py
+++ b/src/ui/port_item.py
@@ -56,13 +56,13 @@ class PortItem(QGraphicsEllipseItem):
       left edge of the node already disambiguates.
     """
 
-    RADIUS: float = 5.0
+    RADIUS: float = 6.0
     #: Horizontal distance from a port's centre to where its label text
     #: starts. Defined here (rather than as a per-call literal in
     #: :mod:`ui.node_item`) so the relationship between dot radius and
     #: label inset stays in one place — bumping ``RADIUS`` shouldn't
     #: leave the label text overlapping the dot.
-    LABEL_OFFSET: float = 11.0  # = RADIUS + 6 px breathing room
+    LABEL_OFFSET: float = 12.0  # = RADIUS + 6 px breathing room
     Z_VALUE = 2
 
     # Ring widths by port semantics. Required inputs and all outputs

--- a/src/ui/theme.py
+++ b/src/ui/theme.py
@@ -4,6 +4,7 @@ from PySide6.QtGui import QColor, QPalette
 from PySide6.QtWidgets import QApplication
 
 from constants import ASSETS_DIR
+from core.io_data import IoDataType
 
 # ── Node header colours by category ────────────────────────────────────────────
 # RGBA tuples; kept separate from the QSS sheet so node-drawing code can
@@ -27,6 +28,42 @@ NODE_PARAM_LABEL_COLOR    = QColor(210, 210, 210)
 PORT_INPUT_COLOR          = QColor(210, 210, 210)
 PORT_OUTPUT_COLOR         = QColor(220, 180,   0)
 PORT_HOVER_COLOR          = QColor(255, 255, 255)
+
+#: Per-:class:`~core.io_data.IoDataType` ring/fill colour for ports.
+#:
+#: A port whose ``accepted_types`` (input) or ``emits`` (output) set
+#: contains *N* types is rendered as *N* equal arcs around the port
+#: ring, each picking its colour from this map. The same palette
+#: drives the connected-state pie-slice fill.
+#:
+#: The palette borrows from common node-editor conventions (Blender,
+#: Houdini): images blue, numerics orange, structures green/violet,
+#: booleans red. When introducing a new :class:`IoDataType`, add an
+#: entry here so the UI doesn't fall back to the neutral default.
+PORT_TYPE_COLORS: dict[IoDataType, QColor] = {
+    IoDataType.IMAGE:       QColor( 59, 130, 246),  # blue
+    IoDataType.IMAGE_GREY:  QColor(156, 163, 175),  # light grey
+    IoDataType.SCALAR:      QColor(245, 158,  11),  # orange
+    IoDataType.MATRIX:      QColor(139,  92, 246),  # violet
+    IoDataType.DATASET:     QColor( 16, 185, 129),  # green
+    IoDataType.BOOL:        QColor(239,  68,  68),  # red
+    IoDataType.STRING:      QColor( 20, 184, 166),  # teal
+    IoDataType.ENUM:        QColor(236,  72, 153),  # pink
+    IoDataType.PATH:        QColor(161,  98,   7),  # brown
+}
+
+#: Fallback ring colour used by :class:`~ui.port_item.PortItem` for any
+#: :class:`IoDataType` not present in :data:`PORT_TYPE_COLORS` — keeps
+#: the UI usable while a new type is being added without forcing a
+#: theme update in the same patch. Same neutral grey as the legacy
+#: input ring.
+PORT_TYPE_DEFAULT_COLOR   = QColor(210, 210, 210)
+
+#: Glyph colour for the small triangle drawn beside an output port to
+#: signal flow direction. Light grey so it reads against both the
+#: canvas background and the node body without competing with the
+#: type-coloured ring.
+PORT_DIRECTION_GLYPH_COLOR = QColor(210, 210, 210)
 
 LINK_COLOR                = QColor(180, 180, 180)
 LINK_SELECTED_COLOR       = QColor(240, 200,   0)


### PR DESCRIPTION
## Summary

Redesigned port item visuals to encode three orthogonal dimensions of information: data type (colour), direction (glyph), and semantics (stroke style). Ports now render as multi-coloured pie rings when multiple types are accepted/emitted, with output ports gaining a small right-pointing triangle glyph to indicate flow direction.

## Key Changes

- **Type encoding via colour**: Ports now display their accepted (input) or emitted (output) `IoDataType` set as coloured arcs around the ring. Added `PORT_TYPE_COLORS` palette in `theme.py` mapping each `IoDataType` to a distinct colour (image=blue, scalar=orange, dataset=green, bool=red, etc.), with `PORT_TYPE_DEFAULT_COLOR` as fallback for unmapped types.

- **Direction glyph for outputs**: Output ports render a small right-pointing triangle beside the dot using `PORT_DIRECTION_GLYPH_COLOR`. Input ports remain plain since their left-edge position already disambiguates direction.

- **Semantics via stroke style**: Ring appearance now signals port semantics:
  - Required inputs and all outputs: thick solid ring (`_RING_WIDTH_DEFAULT = 1.4`)
  - Optional inputs: thin solid ring (`_RING_WIDTH_OPTIONAL = 1.0`)
  - Held inputs: dashed ring (via `Qt.PenStyle.DashLine`)

- **Custom paint implementation**: Replaced static pen/brush setup with a full `paint()` override that draws:
  - Interior fill (black when unconnected, pie-sliced by type when connected, white on hover)
  - Type-coloured ring arcs with appropriate stroke style
  - Direction glyph for outputs

- **Expanded bounding rect for outputs**: Output ports' bounding rect now extends right to accommodate the direction glyph, preventing clipping when scrolled near viewport edges.

- **Removed legacy colour-based semantics**: Eliminated the previous scheme where output=yellow and input=grey, with optional/held variants. All visual encoding now uses the three-axis system.

## Implementation Details

- Added `_types()` method to retrieve port's accepted/emitted types in stable sorted order (by enum name) for consistent ring rendering across runs.
- Added `_type_color()` static method for centralized type-to-colour lookup.
- Introduced geometry constants for the direction glyph (`_GLYPH_BASE_OFFSET`, `_GLYPH_LENGTH`, `_GLYPH_HALF_HEIGHT`).
- Added `_FULL_CIRCLE_16THS` constant (5760) to avoid magic numbers in arc/pie calculations.
- Hover state now tracked via `_hovered` boolean flag instead of directly modifying brush.
- Updated `add_link()` and `remove_link()` to call `update()` instead of `_apply_default_brush()`.
- Removed `_apply_default_brush()` method entirely.
- Updated docstring with detailed visual encoding explanation.

https://claude.ai/code/session_013bACMLkJR9ZujZmrQRk7n9