### PR TITLE
Improve fit-to-contents panning by separating view and scene padding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,14 @@ once a first tagged release is cut.
   rect there's empty canvas to pan into on every side.
   Constants `_FIT_VIEW_PADDING` / `_FIT_SCENE_PADDING` live next
   to the existing zoom limits in `ui/flow_view.py`.
+- **Pan margin guaranteed on both axes regardless of viewport
+  aspect.** `KeepAspectRatio` leaves slack on the non-fit axis,
+  so a wide layout in a wide viewport ended up with a vertical
+  visible area larger than the layout — eating into the 20%
+  scene padding and locking vertical panning. The scene rect is
+  now sized so the 20% pan margin sits *beyond the post-fit
+  visible area* on each axis (`scene_rect = max(layout, visible) + pan`),
+  not just beyond the layout bounds.
 
 ### Changed (Mosaic layout descriptor: rows of comma-separated cells, no spanning)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ once a first tagged release is cut.
 - **`FlowView.fit_to_contents` now uses two padding ratios.** The
   view zoom still fits the layout with a tight 5% margin so the
   graph reads as filling the viewport, but the scene rect is set
-  20% wider than the layout instead of matching the view rect.
+  33% wider than the layout instead of matching the view rect.
   Without that wider scene rect, the scroll-bars hit their
   end-stop right at the visible layout border, so middle-mouse
   panning had nowhere to go after a Fit. With the wider scene
@@ -29,7 +29,7 @@ once a first tagged release is cut.
   so a wide layout in a wide viewport ended up with a vertical
   visible area larger than the layout — eating into the 20%
   scene padding and locking vertical panning. The scene rect is
-  now sized so the 20% pan margin sits *beyond the post-fit
+  now sized so the 33% pan margin sits *beyond the post-fit
   visible area* on each axis (`scene_rect = max(layout, visible) + pan`),
   not just beyond the layout bounds.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,19 @@ once a first tagged release is cut.
 
 ## [0.3.0] — 2026-04-29
 
+### Changed (Fit-to-window leaves panning room around the layout)
+
+- **`FlowView.fit_to_contents` now uses two padding ratios.** The
+  view zoom still fits the layout with a tight 5% margin so the
+  graph reads as filling the viewport, but the scene rect is set
+  20% wider than the layout instead of matching the view rect.
+  Without that wider scene rect, the scroll-bars hit their
+  end-stop right at the visible layout border, so middle-mouse
+  panning had nowhere to go after a Fit. With the wider scene
+  rect there's empty canvas to pan into on every side.
+  Constants `_FIT_VIEW_PADDING` / `_FIT_SCENE_PADDING` live next
+  to the existing zoom limits in `ui/flow_view.py`.
+
 ### Changed (Mosaic layout descriptor: rows of comma-separated cells, no spanning)
 
 - **Mosaic's layout descriptor switched from a fixed-grid string to

--- a/src/constants.py
+++ b/src/constants.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 APP_NAME:         str = "Stjörnhorn"
 APP_DISPLAY_NAME: str = "Stjörnhorn"
-APP_VERSION:      str = "0.3.0.41"
+APP_VERSION:      str = "0.3.0.42"
 API_URL:    str = "https://beltoforion.de"
 
 # Path resolution -----------------------------------------------------------

--- a/src/constants.py
+++ b/src/constants.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 APP_NAME:         str = "Stjörnhorn"
 APP_DISPLAY_NAME: str = "Stjörnhorn"
-APP_VERSION:      str = "0.3.0.42"
+APP_VERSION:      str = "0.3.0.43"
 API_URL:    str = "https://beltoforion.de"
 
 # Path resolution -----------------------------------------------------------

--- a/src/constants.py
+++ b/src/constants.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 APP_NAME:         str = "Stjörnhorn"
 APP_DISPLAY_NAME: str = "Stjörnhorn"
-APP_VERSION:      str = "0.3.0.43"
+APP_VERSION:      str = "0.3.0.44"
 API_URL:    str = "https://beltoforion.de"
 
 # Path resolution -----------------------------------------------------------

--- a/src/ui/flow_view.py
+++ b/src/ui/flow_view.py
@@ -160,11 +160,13 @@ class FlowView(QGraphicsView):
         Two rects, two purposes:
           * **view rect** (layout + ``_FIT_VIEW_PADDING``) — passed to
             ``fitInView`` so the graph reads as "filling" the viewport.
-          * **scene rect** (layout + ``_FIT_SCENE_PADDING``) — set on
-            the scene so the user has empty canvas to pan into past
-            the layout edges. Without this, scroll-bars hit their
-            end-stop right at the visible layout border and panning
-            feels locked.
+          * **scene rect** — sized so that on each axis there's at
+            least ``_FIT_SCENE_PADDING`` of layout-relative pan
+            margin *beyond the post-fit visible area*. Naively
+            taking ``layout + 20%`` collapses to "no pan room" on
+            the non-fit axis when the viewport aspect mismatches
+            the layout, because KeepAspectRatio leaves slack there
+            that already exceeds the layout bounds.
 
         The bounding rect is computed from structural items only — node
         bodies and backdrops — *not* from wires. ``LinkItem`` is a cubic
@@ -194,9 +196,31 @@ class FlowView(QGraphicsView):
         view_pad_y = rect.height() * self._FIT_VIEW_PADDING
         view_rect = rect.adjusted(-view_pad_x, -view_pad_y, view_pad_x, view_pad_y)
 
-        scene_pad_x = rect.width() * self._FIT_SCENE_PADDING
-        scene_pad_y = rect.height() * self._FIT_SCENE_PADDING
-        scene_rect = rect.adjusted(-scene_pad_x, -scene_pad_y, scene_pad_x, scene_pad_y)
+        # Derive the post-fit scale up front so we know the visible
+        # scene area. With KeepAspectRatio, fitInView fills one axis
+        # exactly and leaves slack on the other — that slack inflates
+        # the visible scene rect on the non-fit axis well past
+        # ``view_rect``. If we sized ``scene_rect`` only relative to
+        # the layout, the slack would eat into the pan margin on that
+        # axis (typically: wide layout in a wide viewport → almost no
+        # vertical pan room). Compute the visible rect explicitly and
+        # ensure ``scene_rect`` extends ``_FIT_SCENE_PADDING`` *beyond
+        # the visible area* on each axis.
+        viewport_size = self.viewport().size()
+        sx = viewport_size.width() / view_rect.width()
+        sy = viewport_size.height() / view_rect.height()
+        fit_scale = min(min(sx, sy), self._ZOOM_MAX)
+        visible_w = viewport_size.width() / fit_scale
+        visible_h = viewport_size.height() / fit_scale
+
+        pan_x = rect.width() * self._FIT_SCENE_PADDING
+        pan_y = rect.height() * self._FIT_SCENE_PADDING
+        half_w = max(rect.width(), visible_w) / 2 + pan_x
+        half_h = max(rect.height(), visible_h) / 2 + pan_y
+        center = rect.center()
+        scene_rect = QRectF(
+            center.x() - half_w, center.y() - half_h, 2 * half_w, 2 * half_h,
+        )
 
         scene.setSceneRect(scene_rect)
         self.fitInView(view_rect, Qt.AspectRatioMode.KeepAspectRatio)

--- a/src/ui/flow_view.py
+++ b/src/ui/flow_view.py
@@ -37,7 +37,7 @@ class FlowView(QGraphicsView):
     # scene rect is set wider so the user has room to pan past the
     # layout edges without hitting the scroll-bar end-stop.
     _FIT_VIEW_PADDING:  float = 0.05
-    _FIT_SCENE_PADDING: float = 0.20
+    _FIT_SCENE_PADDING: float = 0.33
 
     def __init__(self, scene: FlowScene) -> None:
         super().__init__(scene)

--- a/src/ui/flow_view.py
+++ b/src/ui/flow_view.py
@@ -32,6 +32,13 @@ class FlowView(QGraphicsView):
     _ZOOM_MIN:  float = 0.2
     _ZOOM_MAX:  float = 5.0
 
+    # Fit-to-contents padding ratios. The view zooms to a tight rect
+    # around the layout (so the graph fills the viewport), but the
+    # scene rect is set wider so the user has room to pan past the
+    # layout edges without hitting the scroll-bar end-stop.
+    _FIT_VIEW_PADDING:  float = 0.05
+    _FIT_SCENE_PADDING: float = 0.20
+
     def __init__(self, scene: FlowScene) -> None:
         super().__init__(scene)
         self.setRenderHint(QPainter.RenderHint.Antialiasing, True)
@@ -147,8 +154,17 @@ class FlowView(QGraphicsView):
 
 
     def fit_to_contents(self) -> None:
-        """Resize the canvas to the node layout plus 5% padding on each
-        side, then zoom and scroll so the whole canvas fills the viewport.
+        """Zoom the view so the layout fills the viewport with a small
+        margin, while leaving a wider scene rect around it for panning.
+
+        Two rects, two purposes:
+          * **view rect** (layout + ``_FIT_VIEW_PADDING``) — passed to
+            ``fitInView`` so the graph reads as "filling" the viewport.
+          * **scene rect** (layout + ``_FIT_SCENE_PADDING``) — set on
+            the scene so the user has empty canvas to pan into past
+            the layout edges. Without this, scroll-bars hit their
+            end-stop right at the visible layout border and panning
+            feels locked.
 
         The bounding rect is computed from structural items only — node
         bodies and backdrops — *not* from wires. ``LinkItem`` is a cubic
@@ -173,11 +189,17 @@ class FlowView(QGraphicsView):
                 rect = item_rect if rect is None else rect.united(item_rect)
         if rect is None or rect.isEmpty():
             return
-        pad_x = rect.width() * 0.05
-        pad_y = rect.height() * 0.05
-        canvas = rect.adjusted(-pad_x, -pad_y, pad_x, pad_y)
-        scene.setSceneRect(canvas)
-        self.fitInView(canvas, Qt.AspectRatioMode.KeepAspectRatio)
+
+        view_pad_x = rect.width() * self._FIT_VIEW_PADDING
+        view_pad_y = rect.height() * self._FIT_VIEW_PADDING
+        view_rect = rect.adjusted(-view_pad_x, -view_pad_y, view_pad_x, view_pad_y)
+
+        scene_pad_x = rect.width() * self._FIT_SCENE_PADDING
+        scene_pad_y = rect.height() * self._FIT_SCENE_PADDING
+        scene_rect = rect.adjusted(-scene_pad_x, -scene_pad_y, scene_pad_x, scene_pad_y)
+
+        scene.setSceneRect(scene_rect)
+        self.fitInView(view_rect, Qt.AspectRatioMode.KeepAspectRatio)
         # If the layout is small enough that fitInView zoomed past our
         # max, clamp the scale — but keep the layout centered. The old
         # implementation called resetTransform() here, which dropped the
@@ -187,7 +209,7 @@ class FlowView(QGraphicsView):
         if scale > self._ZOOM_MAX:
             self.resetTransform()
             self.scale(self._ZOOM_MAX, self._ZOOM_MAX)
-        self.centerOn(canvas.center())
+        self.centerOn(view_rect.center())
 
     def reset_zoom(self) -> None:
         """Reset the view transform to the default 1:1 scale."""


### PR DESCRIPTION
## Summary

Refactored `FlowView.fit_to_contents()` to use two distinct padding ratios: a tight 5% margin for the view rect (what the user sees) and a wider 33% margin for the scene rect (the pannable area). This ensures users have adequate panning room on all sides after fitting the layout to the viewport, regardless of aspect ratio mismatches.

## Key Changes

- **Added two padding constants** to `FlowView`:
  - `_FIT_VIEW_PADDING` (0.05): Controls the tight margin around the layout when zooming to fit
  - `_FIT_SCENE_PADDING` (0.33): Controls the wider pannable area beyond the visible viewport

- **Rewrote scene rect calculation logic** to account for `KeepAspectRatio` slack:
  - Previously, the scene rect was sized uniformly relative to the layout bounds
  - Now explicitly calculates the post-fit visible area and ensures the scene rect extends the padding margin *beyond* the visible area on each axis
  - This prevents the non-fit axis from having its pan margin consumed by the aspect ratio slack

- **Updated documentation** in the method docstring to explain the two-rect approach and the aspect ratio consideration

## Implementation Details

The key insight is that `fitInView()` with `KeepAspectRatio` fills one axis completely while leaving slack on the other. For example, a wide layout in a wide viewport will have vertical slack that extends well past the layout bounds. The old approach of sizing the scene rect uniformly relative to the layout would have that slack consume the intended pan margin on the vertical axis.

The new implementation:
1. Calculates the fit scale based on the view rect
2. Derives the actual visible scene dimensions after the fit
3. Sizes the scene rect as `max(layout, visible) + padding` on each axis independently

This guarantees adequate panning room on both axes regardless of viewport aspect ratio.

https://claude.ai/code/session_01SE6EM5a5EJJ573jXHTMU6q