### PR TITLE
Add online welcome page with offline fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ once a first tagged release is cut.
   `doc/welcome.html` is loaded synchronously so the user always sees
   content immediately. In parallel, a short HEAD probe (timeout
   `WELCOME_PROBE_TIMEOUT_MS` = 3 s) is fired against
-  `WELCOME_URL_ONLINE` (`http://stjornhorn.beltoforion.de`); on a
+  `WELCOME_URL_ONLINE` (`http://stjornhorn.beltoforion.de/welcome.html`); on a
   successful response the `QWebEngineView` swaps to the online URL.
   When offline, DNS-blocked, timed out, or the server returns a
   non-2xx status, the local copy stays put and no further network

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,18 @@ once a first tagged release is cut.
 
 ## [0.3.0] — 2026-04-29
 
+### Added (Online welcome page with offline fallback)
+
+- **Start page tries the live welcome page first.** The bundled
+  `doc/welcome.html` is loaded synchronously so the user always sees
+  content immediately. In parallel, a short HEAD probe (timeout
+  `WELCOME_PROBE_TIMEOUT_MS` = 3 s) is fired against
+  `WELCOME_URL_ONLINE` (`http://stjornhorn.beltoforion.de`); on a
+  successful response the `QWebEngineView` swaps to the online URL.
+  When offline, DNS-blocked, timed out, or the server returns a
+  non-2xx status, the local copy stays put and no further network
+  attempt is made for the session.
+
 ### Changed (Fit-to-window leaves panning room around the layout)
 
 - **`FlowView.fit_to_contents` now uses two padding ratios.** The

--- a/src/constants.py
+++ b/src/constants.py
@@ -10,7 +10,7 @@ API_URL:    str = "https://beltoforion.de"
 # Public, online-hosted version of the welcome page. The start page tries
 # to fetch this first and silently falls back to the bundled copy when the
 # host is unreachable (offline, DNS failure, server down, …).
-WELCOME_URL_ONLINE:        str = "http://stjornhorn.beltoforion.de"
+WELCOME_URL_ONLINE:        str = "http://stjornhorn.beltoforion.de/welcome.html"
 WELCOME_PROBE_TIMEOUT_MS:  int = 3000
 
 # Path resolution -----------------------------------------------------------

--- a/src/constants.py
+++ b/src/constants.py
@@ -4,8 +4,14 @@ from pathlib import Path
 
 APP_NAME:         str = "Stjörnhorn"
 APP_DISPLAY_NAME: str = "Stjörnhorn"
-APP_VERSION:      str = "0.3.0.44"
+APP_VERSION:      str = "0.3.0.45"
 API_URL:    str = "https://beltoforion.de"
+
+# Public, online-hosted version of the welcome page. The start page tries
+# to fetch this first and silently falls back to the bundled copy when the
+# host is unreachable (offline, DNS failure, server down, …).
+WELCOME_URL_ONLINE:        str = "http://stjornhorn.beltoforion.de"
+WELCOME_PROBE_TIMEOUT_MS:  int = 3000
 
 # Path resolution -----------------------------------------------------------
 #

--- a/src/ui/start_page.py
+++ b/src/ui/start_page.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING
 
 from PySide6.QtCore import QSize, Qt, QUrl, Signal
 from PySide6.QtGui import QAction, QIcon
+from PySide6.QtNetwork import QNetworkAccessManager, QNetworkReply, QNetworkRequest
 from PySide6.QtWebEngineCore import QWebEngineSettings
 from PySide6.QtWebEngineWidgets import QWebEngineView
 from PySide6.QtWidgets import (
@@ -19,7 +20,12 @@ from PySide6.QtWidgets import (
     QWidget,
 )
 
-from constants import FLOW_DIR, WELCOME_HTML_PATH
+from constants import (
+    FLOW_DIR,
+    WELCOME_HTML_PATH,
+    WELCOME_PROBE_TIMEOUT_MS,
+    WELCOME_URL_ONLINE,
+)
 from core.flow import DEFAULT_FLOW_NAME, is_valid_flow_name
 from ui.flow_layout import FlowLayout
 from ui.icons import material_icon
@@ -78,6 +84,7 @@ class StartPage(PageBase):
         )
         self._welcome_view.setUrl(QUrl.fromLocalFile(str(WELCOME_HTML_PATH)))
         root.addWidget(self._welcome_view, 1)
+        self._probe_remote_welcome()
 
         # Row 2: create + recent flows, sized to content.
         row = QHBoxLayout()
@@ -115,6 +122,33 @@ class StartPage(PageBase):
         self._rebuild_recent_tiles()
         if self._recent_flows is not None:
             self._recent_flows.changed.connect(self._rebuild_recent_tiles)
+
+    # ── Welcome content ────────────────────────────────────────────────────────
+
+    def _probe_remote_welcome(self) -> None:
+        """Fire a short HEAD request to the public welcome URL and, on
+        success, swap the view from the bundled file to the live page.
+
+        The local file is loaded synchronously in ``__init__`` so the user
+        always sees something immediately. When the host is unreachable
+        (no internet, DNS failure, timeout, non-2xx response) we keep the
+        local copy and never hit the network again for this session.
+        """
+        self._welcome_network = QNetworkAccessManager(self)
+        request = QNetworkRequest(QUrl(WELCOME_URL_ONLINE))
+        request.setTransferTimeout(WELCOME_PROBE_TIMEOUT_MS)
+        reply = self._welcome_network.head(request)
+        reply.finished.connect(lambda r=reply: self._on_remote_welcome_probed(r))
+
+    def _on_remote_welcome_probed(self, reply: QNetworkReply) -> None:
+        error = reply.error()
+        status = reply.attribute(QNetworkRequest.Attribute.HttpStatusCodeAttribute)
+        reply.deleteLater()
+        if error != QNetworkReply.NetworkError.NoError:
+            return
+        if not isinstance(status, int) or not 200 <= status < 400:
+            return
+        self._welcome_view.setUrl(QUrl(WELCOME_URL_ONLINE))
 
     # ── Page hooks ─────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
The start page now attempts to load a live welcome page from a remote server while maintaining a bundled HTML file as an offline fallback. This provides users with up-to-date content when online while ensuring the application remains functional without internet connectivity.

## Key Changes
- **Network probing**: Added `_probe_remote_welcome()` method that fires a non-blocking HEAD request to the online welcome URL with a 3-second timeout
- **Graceful fallback**: Implemented `_on_remote_welcome_probed()` to handle network responses and swap to the online URL only on successful 2xx-3xx responses
- **Immediate UX**: The bundled welcome page loads synchronously during initialization, ensuring users always see content immediately while the network probe happens in parallel
- **Silent degradation**: When offline, DNS-blocked, timed out, or receiving non-2xx status codes, the application silently keeps the local copy without retrying
- **Configuration**: Added new constants `WELCOME_URL_ONLINE` and `WELCOME_PROBE_TIMEOUT_MS` to `constants.py` for easy configuration
- **Version bump**: Updated app version from 0.3.0.44 to 0.3.0.45

## Implementation Details
- Uses `QNetworkAccessManager` and `QNetworkRequest` for the HEAD probe
- Network request has a 3-second transfer timeout to avoid hanging on slow/unreachable connections
- Only swaps the `QWebEngineView` URL if the HTTP status code is in the 2xx-3xx range
- The network manager is stored as an instance variable to prevent garbage collection before the request completes
- No retry logic—if the probe fails, the local copy persists for the entire session

https://claude.ai/code/session_0196jkcZLRewRpoFrhBc849F