### PR TITLE
Open welcome-page links in the system browser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,17 @@ once a first tagged release is cut.
 
 ## [0.3.0] — 2026-04-29
 
+### Fixed (Welcome page links open in the system browser)
+
+- **Welcome page link buttons (`Documentation`, `GitHub`, `Issues`,
+  `Releases`, `Impressum`, site logo) work again.** They are all
+  `target="_blank"` anchors, which `QWebEngineView` routes through
+  `QWebEnginePage.createWindow()`. The default returns a null page,
+  so the clicks were silently dropped. The start page now installs
+  a `_ExternalLinkPage` subclass that intercepts link clicks and
+  `target="_blank"` requests and forwards the URL to
+  `QDesktopServices.openUrl()`.
+
 ### Added (Online welcome page with offline fallback)
 
 - **Start page tries the live welcome page first.** The bundled

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ once a first tagged release is cut.
   `doc/welcome.html` is loaded synchronously so the user always sees
   content immediately. In parallel, a short HEAD probe (timeout
   `WELCOME_PROBE_TIMEOUT_MS` = 3 s) is fired against
-  `WELCOME_URL_ONLINE` (`http://stjornhorn.beltoforion.de/welcome.html`); on a
+  `WELCOME_URL_ONLINE` (`https://beltoforion.de/stjornhorn/welcome.txt`); on a
   successful response the `QWebEngineView` swaps to the online URL.
   When offline, DNS-blocked, timed out, or the server returns a
   non-2xx status, the local copy stays put and no further network

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,11 @@ once a first tagged release is cut.
   so the clicks were silently dropped. The start page now installs
   a `_ExternalLinkPage` subclass that intercepts link clicks and
   `target="_blank"` requests and forwards the URL to
-  `QDesktopServices.openUrl()`.
+  `QDesktopServices.openUrl()`. The popup page catches the request
+  in `acceptNavigationRequest` and returns `False`, so the URL is
+  handed to the OS unchanged — `http://stjornhorn.beltoforion.de`
+  reaches the browser as `http://`, not silently upgraded by the
+  embedded engine.
 
 ### Added (Online welcome page with offline fallback)
 

--- a/doc/internal/documentation_guidelines.md
+++ b/doc/internal/documentation_guidelines.md
@@ -126,7 +126,7 @@ architectural documentation lives under `doc/internal/`.
 - A row of button-style links (`a.button` inside `.links`)
   sits inside the hero header, immediately under the tagline,
   pointing at the hosted documentation
-  (`http://stjornhorn.beltoforion.de`), the GitHub repository,
+  (`https://beltoforion.de/stjornhorn`), the GitHub repository,
   the Issues tracker
   (`https://github.com/beltoforion/stjornhorn/issues`) and the
   Releases page

--- a/doc/internal/documentation_guidelines.md
+++ b/doc/internal/documentation_guidelines.md
@@ -126,7 +126,7 @@ architectural documentation lives under `doc/internal/`.
 - A row of button-style links (`a.button` inside `.links`)
   sits inside the hero header, immediately under the tagline,
   pointing at the hosted documentation
-  (`https://beltoforion.de/stjornhorn`), the GitHub repository,
+  (`https://beltoforion.de/stjornhorn/index.html`), the GitHub repository,
   the Issues tracker
   (`https://github.com/beltoforion/stjornhorn/issues`) and the
   Releases page

--- a/doc/welcome.html
+++ b/doc/welcome.html
@@ -224,7 +224,7 @@
         <h1>Welcome to Stjörnhorn <span class="version">v0.3.0</span></h1>
         <div class="tagline">A node-based image- and video-processing playground.</div>
         <div class="links">
-          <a class="button" href="http://stjornhorn.beltoforion.de" target="_blank" rel="noopener">Documentation</a>
+          <a class="button" href="https://beltoforion.de/stjornhorn" target="_blank" rel="noopener">Documentation</a>
           <a class="button" href="https://github.com/beltoforion/stjornhorn" target="_blank" rel="noopener">GitHub repository</a>
           <a class="button" href="https://github.com/beltoforion/stjornhorn/issues" target="_blank" rel="noopener">Issues</a>
           <a class="button" href="https://github.com/beltoforion/stjornhorn/releases" target="_blank" rel="noopener">Releases</a>

--- a/doc/welcome.html
+++ b/doc/welcome.html
@@ -224,7 +224,7 @@
         <h1>Welcome to Stjörnhorn <span class="version">v0.3.0</span></h1>
         <div class="tagline">A node-based image- and video-processing playground.</div>
         <div class="links">
-          <a class="button" href="https://beltoforion.de/stjornhorn" target="_blank" rel="noopener">Documentation</a>
+          <a class="button" href="https://beltoforion.de/stjornhorn/index.html" target="_blank" rel="noopener">Documentation</a>
           <a class="button" href="https://github.com/beltoforion/stjornhorn" target="_blank" rel="noopener">GitHub repository</a>
           <a class="button" href="https://github.com/beltoforion/stjornhorn/issues" target="_blank" rel="noopener">Issues</a>
           <a class="button" href="https://github.com/beltoforion/stjornhorn/releases" target="_blank" rel="noopener">Releases</a>

--- a/src/constants.py
+++ b/src/constants.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 APP_NAME:         str = "Stjörnhorn"
 APP_DISPLAY_NAME: str = "Stjörnhorn"
-APP_VERSION:      str = "0.3.0.45"
+APP_VERSION:      str = "0.3.0.46"
 API_URL:    str = "https://beltoforion.de"
 
 # Public, online-hosted version of the welcome page. The start page tries

--- a/src/constants.py
+++ b/src/constants.py
@@ -4,13 +4,13 @@ from pathlib import Path
 
 APP_NAME:         str = "Stjörnhorn"
 APP_DISPLAY_NAME: str = "Stjörnhorn"
-APP_VERSION:      str = "0.3.0.47"
+APP_VERSION:      str = "0.3.0.48"
 API_URL:    str = "https://beltoforion.de"
 
 # Public, online-hosted version of the welcome page. The start page tries
 # to fetch this first and silently falls back to the bundled copy when the
 # host is unreachable (offline, DNS failure, server down, …).
-WELCOME_URL_ONLINE:        str = "http://stjornhorn.beltoforion.de/welcome.html"
+WELCOME_URL_ONLINE:        str = "https://beltoforion.de/stjornhorn/welcome.txt"
 WELCOME_PROBE_TIMEOUT_MS:  int = 3000
 
 # Path resolution -----------------------------------------------------------

--- a/src/constants.py
+++ b/src/constants.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 APP_NAME:         str = "Stjörnhorn"
 APP_DISPLAY_NAME: str = "Stjörnhorn"
-APP_VERSION:      str = "0.3.0.46"
+APP_VERSION:      str = "0.3.0.47"
 API_URL:    str = "https://beltoforion.de"
 
 # Public, online-hosted version of the welcome page. The start page tries

--- a/src/ui/start_page.py
+++ b/src/ui/start_page.py
@@ -4,9 +4,9 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from PySide6.QtCore import QSize, Qt, QUrl, Signal
-from PySide6.QtGui import QAction, QIcon
+from PySide6.QtGui import QAction, QDesktopServices, QIcon
 from PySide6.QtNetwork import QNetworkAccessManager, QNetworkReply, QNetworkRequest
-from PySide6.QtWebEngineCore import QWebEngineSettings
+from PySide6.QtWebEngineCore import QWebEnginePage, QWebEngineSettings
 from PySide6.QtWebEngineWidgets import QWebEngineView
 from PySide6.QtWidgets import (
     QFileDialog,
@@ -37,6 +37,40 @@ if TYPE_CHECKING:
     from ui.recent_flows import RecentFlowsManager
 
 _FLOW_FILE_FILTER = "Flow (*.flowjs);;All files (*)"
+
+
+class _ExternalLinkPage(QWebEnginePage):
+    """QWebEnginePage that routes link clicks out to the system browser.
+
+    The welcome page lives inside a QWebEngineView but its buttons all
+    point at external URLs (documentation site, GitHub). Without this
+    indirection, regular link clicks would replace the welcome page in
+    the embedded view, and ``target="_blank"`` clicks would silently no-op
+    because the default ``createWindow`` returns a null page.
+
+    Issue: #281
+    """
+
+    def acceptNavigationRequest(  # noqa: N802 — Qt override
+        self, url: QUrl, nav_type: QWebEnginePage.NavigationType, is_main_frame: bool,
+    ) -> bool:
+        if nav_type == QWebEnginePage.NavigationType.NavigationTypeLinkClicked:
+            QDesktopServices.openUrl(url)
+            return False
+        return super().acceptNavigationRequest(url, nav_type, is_main_frame)
+
+    def createWindow(  # noqa: N802 — Qt override
+        self, _type: QWebEnginePage.WebWindowType,
+    ) -> QWebEnginePage:
+        # target="_blank" links route through createWindow, not
+        # acceptNavigationRequest. Return a throwaway page that captures
+        # the requested URL and hands it off to the system browser.
+        popup = QWebEnginePage(self)
+        def _open_and_dispose(url: QUrl, page: QWebEnginePage = popup) -> None:
+            QDesktopServices.openUrl(url)
+            page.deleteLater()
+        popup.urlChanged.connect(_open_and_dispose)
+        return popup
 
 
 class StartPage(PageBase):
@@ -79,6 +113,7 @@ class StartPage(PageBase):
 
         # Row 1: welcome web view — soaks up all remaining vertical space.
         self._welcome_view = QWebEngineView()
+        self._welcome_view.setPage(_ExternalLinkPage(self._welcome_view))
         self._welcome_view.settings().setAttribute(
             QWebEngineSettings.WebAttribute.ShowScrollBars, False,
         )

--- a/src/ui/start_page.py
+++ b/src/ui/start_page.py
@@ -51,9 +51,28 @@ class _ExternalLinkPage(QWebEnginePage):
     Issue: #281
     """
 
+    def __init__(
+        self, parent: "QWidget | QWebEnginePage | None" = None, *, _popup: bool = False,
+    ) -> None:
+        super().__init__(parent)
+        # Popup pages exist only to catch the URL of a target="_blank"
+        # request (see ``createWindow``) and open it externally before any
+        # network load actually happens. A non-popup page is the regular
+        # welcome view, which serves the bundled / live welcome.html and
+        # only diverts explicit link clicks.
+        self._popup = _popup
+
     def acceptNavigationRequest(  # noqa: N802 — Qt override
         self, url: QUrl, nav_type: QWebEnginePage.NavigationType, is_main_frame: bool,
     ) -> bool:
+        # Popup pages: every navigation is the user's link target. Hand
+        # the URL straight to the OS — *before* any actual navigation
+        # starts, so HSTS / browser scheme upgrades on the embedded
+        # engine can't rewrite ``http://`` to ``https://`` first.
+        if self._popup:
+            QDesktopServices.openUrl(url)
+            self.deleteLater()
+            return False
         if nav_type == QWebEnginePage.NavigationType.NavigationTypeLinkClicked:
             QDesktopServices.openUrl(url)
             return False
@@ -63,14 +82,10 @@ class _ExternalLinkPage(QWebEnginePage):
         self, _type: QWebEnginePage.WebWindowType,
     ) -> QWebEnginePage:
         # target="_blank" links route through createWindow, not
-        # acceptNavigationRequest. Return a throwaway page that captures
-        # the requested URL and hands it off to the system browser.
-        popup = QWebEnginePage(self)
-        def _open_and_dispose(url: QUrl, page: QWebEnginePage = popup) -> None:
-            QDesktopServices.openUrl(url)
-            page.deleteLater()
-        popup.urlChanged.connect(_open_and_dispose)
-        return popup
+        # acceptNavigationRequest on this page. Return a throwaway page
+        # whose acceptNavigationRequest catches the requested URL and
+        # hands it to QDesktopServices.openUrl before any load occurs.
+        return _ExternalLinkPage(self, _popup=True)
 
 
 class StartPage(PageBase):


### PR DESCRIPTION
Fixes #281.

## Summary

The start page renders `doc/welcome.html` inside a `QWebEngineView`. All link buttons (`Documentation`, `GitHub repository`, `Issues`, `Releases`, the site logo, the `Impressum` footer link) use `target="_blank"`, which Qt routes through `QWebEnginePage.createWindow()`. The default returns a null page, so every click on the welcome panel was silently dropped.

A new `_ExternalLinkPage` subclass on the welcome view now:

- intercepts `NavigationTypeLinkClicked` in `acceptNavigationRequest` and hands the URL to `QDesktopServices.openUrl()` (covers same-frame link clicks);
- overrides `createWindow` to return a throwaway page that captures the requested URL and forwards it the same way (covers `target="_blank"`).

Result: every link in the welcome panel opens in the user's system browser instead of doing nothing.

## Test plan

- [ ] Launch app, land on the start page, click `Documentation` — opens the docs site in the system browser.
- [ ] Click `GitHub repository`, `Issues`, `Releases`, the site logo, the `Impressum` link — each opens in the system browser, embedded view stays on the welcome page.
- [ ] Probe succeeds and the view swaps to the online welcome — same link behaviour holds.

Build version bumped to `0.3.0.46`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01VXnNEEqzUsGGw36PpFXHfg)_