### PR TITLE
Make welcome page theme-aware via CSS custom properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,23 @@ once a first tagged release is cut.
 
 ## [Unreleased]
 
+### Changed (Welcome page tracks the active theme)
+
+- **The bundled `welcome.html` now follows whichever theme the
+  user picked on the Settings page — no more grey panel sitting
+  in the middle of a navy neon UI.** Surface colours, button and
+  card chrome, accent / hover state, divider lines and the
+  per-category card headlines (`Sources` / `Filters` / `Sinks`)
+  are all driven by CSS custom properties on `:root`. After every
+  load (initial bundled file and any later swap to the remote
+  copy), `StartPage._apply_theme_to_welcome` rebinds those
+  properties from the active :class:`Theme`'s palette and
+  category accents via `runJavaScript` on the embedded
+  `QWebEngineView`. A small CSS fade-in (`@keyframes
+  welcome-reveal`) hides the un-themed flash if the page is ever
+  opened directly in a browser. Only one HTML file is maintained;
+  no per-theme variant.
+
 ### Fixed (Port-legend chrome now tracks the active theme)
 
 - **The Port Types legend overlay no longer renders in

--- a/doc/welcome.html
+++ b/doc/welcome.html
@@ -5,14 +5,30 @@
   <title>Welcome to Stjörnhorn</title>
   <style>
     :root {
-      --bg:            #262629;
-      --bg-panel:      #2f2f33;
-      --bg-panel-alt:  #35353a;
-      --border:        #1a1a1d;
-      --text:          #e0e0e0;
-      --text-muted:    #9a9a9f;
-      --accent:        #f0c83c;
+      --bg:                 #262629;
+      --bg-panel:           #2f2f33;
+      --bg-panel-alt:       #35353a;
+      --border:             #1a1a1d;
+      --text:               #e0e0e0;
+      --text-muted:         #9a9a9f;
+      --accent:             #f0c83c;
+      --card-source-color:  #7fb6ee;
+      --card-filter-color:  #7dd896;
+      --card-sink-color:    #e8a86b;
     }
+
+    /* Render with whatever the embedded :root defaults are, but fade in
+       briefly so a Qt-side theme injection (start_page.py overrides the
+       custom properties on document.documentElement after loadFinished)
+       can land before the user notices a colour mismatch. The CSS
+       animation is the safety net for the case where no JS runs at all
+       (the page is opened directly in a browser): the body still
+       appears, just 120 ms later. */
+    body {
+      opacity: 0;
+      animation: welcome-reveal 0s 200ms forwards;
+    }
+    @keyframes welcome-reveal { to { opacity: 1; } }
 
     * { box-sizing: border-box; }
 
@@ -170,9 +186,9 @@
       color: var(--text-muted);
       font-size: 13px;
     }
-    .card.source h3 { color: #7fb6ee; }
-    .card.filter h3 { color: #7dd896; }
-    .card.sink   h3 { color: #e8a86b; }
+    .card.source h3 { color: var(--card-source-color); }
+    .card.filter h3 { color: var(--card-filter-color); }
+    .card.sink   h3 { color: var(--card-sink-color); }
 
     kbd {
       background: var(--bg-panel-alt);

--- a/src/constants.py
+++ b/src/constants.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 APP_NAME:         str = "Stjörnhorn"
 APP_DISPLAY_NAME: str = "Stjörnhorn"
-APP_VERSION:      str = "0.3.0.53"
+APP_VERSION:      str = "0.3.0.54"
 API_URL:    str = "https://beltoforion.de"
 
 # Public, online-hosted version of the welcome page. The start page tries

--- a/src/ui/start_page.py
+++ b/src/ui/start_page.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -29,6 +30,7 @@ from constants import (
 from core.flow import DEFAULT_FLOW_NAME, is_valid_flow_name
 from ui.flow_layout import FlowLayout
 from ui.icons import material_icon
+from ui.theme import get_active_theme
 from typing_extensions import override
 
 from ui.page import PageBase, ToolbarSection
@@ -132,6 +134,13 @@ class StartPage(PageBase):
         self._welcome_view.settings().setAttribute(
             QWebEngineSettings.WebAttribute.ShowScrollBars, False,
         )
+        # Push the active theme's colours into the page after every load
+        # — both the initial bundled file load and a later swap to the
+        # remote URL if the probe succeeds. The page itself ships with
+        # placeholder CSS custom properties on :root; this re-binds them
+        # so the welcome page tracks whatever theme the rest of the app
+        # is wearing without requiring a parallel HTML variant per theme.
+        self._welcome_view.loadFinished.connect(self._apply_theme_to_welcome)
         self._welcome_view.setUrl(QUrl.fromLocalFile(str(WELCOME_HTML_PATH)))
         root.addWidget(self._welcome_view, 1)
         self._probe_remote_welcome()
@@ -189,6 +198,53 @@ class StartPage(PageBase):
         request.setTransferTimeout(WELCOME_PROBE_TIMEOUT_MS)
         reply = self._welcome_network.head(request)
         reply.finished.connect(lambda r=reply: self._on_remote_welcome_probed(r))
+
+    def _apply_theme_to_welcome(self, ok: bool) -> None:
+        """Push the active theme's colours into the welcome page.
+
+        ``welcome.html`` is a single static file shared between every
+        theme — its `:root` ships with placeholder CSS custom
+        properties. After each load (bundled file or remote swap) we
+        rebind those properties from the active :class:`Theme`, so
+        backgrounds, panels, buttons, borders, accent colour and the
+        per-category card headlines all track whatever the user picked
+        on the Settings page.
+
+        Issue: dynamic-theme-background
+        """
+        if not ok:
+            return
+        theme = get_active_theme()
+        # Derive the welcome page's surface palette from the active theme:
+        # use the app window colour as the page background, the button
+        # colour as the raised "panel" surface (cards, buttons, kbd
+        # chips), a slightly lightened version for hover states, and a
+        # dimmer derivative of the window for divider lines.
+        panel = theme.PALETTE_BUTTON
+        css_vars = {
+            "--bg":                theme.PALETTE_WINDOW.name(),
+            "--bg-panel":          panel.name(),
+            "--bg-panel-alt":      panel.lighter(120).name(),
+            "--border":            theme.PALETTE_WINDOW.darker(135).name(),
+            "--text":              theme.PALETTE_TEXT.name(),
+            "--text-muted":        theme.STATUS_MUTED_COLOR.name(),
+            "--accent":            theme.NODE_BORDER_SELECTED.name(),
+            "--card-source-color": theme.SOURCE_HEADER_COLOR.name(),
+            "--card-filter-color": theme.FILTER_HEADER_COLOR.name(),
+            "--card-sink-color":   theme.SINK_HEADER_COLOR.name(),
+        }
+        # ``json.dumps`` on the dict gives us a JS-safe object literal
+        # (proper string escaping, no risk of breaking the call if a
+        # colour name ever contains a quote or backslash).
+        js = (
+            "(function(){"
+            "var s=document.documentElement.style;"
+            f"var v={json.dumps(css_vars)};"
+            "for (var k in v) s.setProperty(k, v[k]);"
+            "document.body.style.opacity='1';"
+            "})();"
+        )
+        self._welcome_view.page().runJavaScript(js)
 
     def _on_remote_welcome_probed(self, reply: QNetworkReply) -> None:
         error = reply.error()


### PR DESCRIPTION
## Summary

The welcome page now dynamically adapts to the active theme instead of displaying with hardcoded colors. This is achieved by injecting theme colors into the page's CSS custom properties after each load via JavaScript.

## Key Changes

- **Dynamic theme injection**: Added `_apply_theme_to_welcome()` method to `StartPage` that runs after the welcome page loads and injects the active theme's colors into CSS custom properties (backgrounds, panels, text, accents, and category-specific card colors)
- **HTML refactoring**: Converted hardcoded color values in `welcome.html` to use CSS custom properties (`--bg`, `--bg-panel`, `--border`, `--text`, `--accent`, `--card-source-color`, etc.)
- **Fade-in animation**: Added a CSS fade-in animation (`@keyframes welcome-reveal`) that delays body visibility by 200ms to hide any color flash during theme injection, with a fallback for direct browser access
- **Theme integration**: Connected the `loadFinished` signal to trigger theme application on both initial bundled file load and any subsequent remote URL swap
- **Safe JavaScript execution**: Used `json.dumps()` to safely serialize theme colors into a JavaScript object literal, avoiding injection risks

## Implementation Details

- The welcome page ships with placeholder CSS custom properties on `:root`, allowing a single HTML file to work across all themes
- Theme colors are derived from the active `Theme` object's palette: window color for background, button color for panels, text and muted text colors, accent color for highlights, and category-specific header colors
- The JavaScript injection uses an IIFE to set all custom properties on `document.documentElement.style` and then sets body opacity to 1 to reveal the themed page
- Version bumped to 0.3.0.54

https://claude.ai/code/session_017yC9gaWixtt9VBzQZW2k8v