### PR TITLE
Document f-string preference for Python string interpolation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,6 +41,7 @@
 
 ## Implementation
 - Keep performance in mind when writing code, especially on hot paths (per-frame video processing, image ops). Proactively surface non-trivial optimisation opportunities — skippable work, redundant copies, per-frame allocations in streaming paths — but do not spend effort on micro-optimisations (enum lookups, local variable binding, attribute lookup caching) that do not move the needle on real workloads.
+- Preferred style for value interpolation in Python strings is f-strings (`f"{var_name}"`). When you encounter `%`-formatting or `str.format()` in code you are already touching, convert it to an f-string as part of the change.
 - When fixing a bug tracked by a GitHub issue, reference the issue number in a source-code comment next to the fix (e.g. `Issue: #136`). This overrides any general guidance to keep ticket references out of source — for bug fixes the discoverability via `grep` outweighs the risk of stale references. Applies to bug fixes only; feature work and ordinary code do not need issue references in comments.
 - Existing saved flows (`.flowjs`) are not a backwards-compatibility constraint. Change node behaviour, parameter shape, port wiring or default values freely when the design is better; do not add migration shims, deprecation warnings, or flow-file schema versioning to keep old flows loading. Users will rebuild flows as needed. Bundled demo flows under `flow/` should be updated in the same PR that breaks them so the repo's own examples stay runnable.
 


### PR DESCRIPTION
Update the implementation guidelines to establish f-strings as the preferred style for value interpolation in Python strings.

## Summary
This change documents the preferred approach for string interpolation in the codebase, establishing f-strings as the standard while providing guidance on handling legacy code.

## Changes
- Added guidance to prefer f-strings (`f"{var_name}"`) for Python string interpolation
- Documented that when modifying code using `%`-formatting or `str.format()`, those should be converted to f-strings as part of the change
- This applies to code already being touched, encouraging incremental modernization of the codebase

## Rationale
F-strings are the modern Python standard (3.6+), offering better readability and performance compared to older string formatting methods. This guideline helps maintain consistency across the codebase while allowing for gradual migration of existing code.

https://claude.ai/code/session_012oex2Ken1p8LxVAUeYcCNX