### PR TITLE
Fix directory_source.py type-check errors for descriptor-backed attrs

### DIFF
--- a/src/constants.py
+++ b/src/constants.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 APP_NAME:         str = "Stjörnhorn"
 APP_DISPLAY_NAME: str = "Stjörnhorn"
-APP_VERSION:      str = "0.3.0.56"
+APP_VERSION:      str = "0.3.0.57"
 API_URL:    str = "https://beltoforion.de"
 
 # Public, online-hosted version of the welcome page. The start page tries

--- a/src/nodes/sources/directory_source.py
+++ b/src/nodes/sources/directory_source.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import logging
 from collections.abc import Iterator
 from pathlib import Path
-from typing import TYPE_CHECKING
 
 import cv2
 import numpy as np
@@ -50,13 +49,12 @@ class DirectorySource(SourceNodeBase):
 
     HEADER_ICON = "folder_open"
 
-    # The descriptor protocol annotates these private backing attrs on the
-    # owner class via ``_ParamBase.__set_name__`` at runtime, but static
-    # type-checkers don't execute that — declare them explicitly so
-    # ``self._directory`` / ``self._include_subdirectories`` resolve.
-    if TYPE_CHECKING:
-        _directory: Path
-        _include_subdirectories: bool
+    # ``_ParamBase.__set_name__`` annotates these private backing attrs at
+    # runtime, but static type-checkers don't execute that — declare them
+    # in source so ``self._directory`` / ``self._include_subdirectories``
+    # resolve.
+    _directory: Path
+    _include_subdirectories: bool
 
     def __init__(self) -> None:
         super().__init__("Directory Source", section="Sources")

--- a/src/nodes/sources/directory_source.py
+++ b/src/nodes/sources/directory_source.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 from collections.abc import Iterator
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import cv2
 import numpy as np
@@ -48,6 +49,14 @@ class DirectorySource(SourceNodeBase):
     include_subdirectories = BoolParam(False, constant=True)
 
     HEADER_ICON = "folder_open"
+
+    # The descriptor protocol annotates these private backing attrs on the
+    # owner class via ``_ParamBase.__set_name__`` at runtime, but static
+    # type-checkers don't execute that — declare them explicitly so
+    # ``self._directory`` / ``self._include_subdirectories`` resolve.
+    if TYPE_CHECKING:
+        _directory: Path
+        _include_subdirectories: bool
 
     def __init__(self) -> None:
         super().__init__("Directory Source", section="Sources")

--- a/src/nodes/sources/directory_source.py
+++ b/src/nodes/sources/directory_source.py
@@ -58,7 +58,7 @@ class DirectorySource(SourceNodeBase):
 
     def __init__(self) -> None:
         super().__init__("Directory Source", section="Sources")
-        
+
         self._add_output(OutputPort("image", {IoDataType.IMAGE}))
         self._apply_default_params()
 


### PR DESCRIPTION
## Summary

- `FilePathParam` / `BoolParam` descriptors annotate their `_<name>` backing attributes on the owner class at runtime via `__set_name__`. Static type-checkers (pyright/mypy) don't execute that, so `self._directory` and `self._include_subdirectories` flagged as unknown attributes during type checking.
- Declare `_directory: Path` and `_include_subdirectories: bool` at class scope inside `DirectorySource` so the checker resolves them. Runtime behaviour is unchanged.
- Bump `APP_VERSION` 0.3.0.56 → 0.3.0.57 per the repo's per-PR build-digit rule.

## Test plan

- [ ] `pyright src/nodes/sources/directory_source.py` no longer reports `reportAttributeAccessIssue` on the `_directory` / `_include_subdirectories` accesses.
- [ ] App still launches and a `DirectorySource` node still walks its directory and emits frames.

https://claude.ai/code/session_012oex2Ken1p8LxVAUeYcCNX