### PR TITLE
Move MetaInspector copy button to node header

### DIFF
--- a/src/constants.py
+++ b/src/constants.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 APP_NAME:         str = "Stjörnhorn"
 APP_DISPLAY_NAME: str = "Stjörnhorn"
-APP_VERSION:      str = "0.3.0.59"
+APP_VERSION:      str = "0.3.0.60"
 API_URL:    str = "https://beltoforion.de"
 
 # Public, online-hosted version of the welcome page. The start page tries

--- a/src/core/node_base.py
+++ b/src/core/node_base.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 from abc import ABC, abstractmethod
 from collections.abc import Iterator
+from dataclasses import dataclass
 
 from enum import Enum
 from typing import Callable, final
@@ -112,6 +113,30 @@ NODE_PARAM_TYPE_TO_PORT_TYPE: dict[NodeParamType, IoDataType] = {
 }
 
 
+@dataclass(frozen=True)
+class HeaderAction:
+    """Declarative spec for a clickable button in a node's header.
+
+    A node populates ``self.header_actions`` with these so the editor
+    can render small Material-glyph buttons in the title bar without
+    the node module having to depend on Qt. The handler runs on the
+    UI thread when the user clicks; if it returns a non-empty string,
+    the editor copies that string to the system clipboard.
+
+    Keeping the contract this narrow (glyph + tooltip + handler) means
+    every node-specific affordance — copy meta, reset cache, dump
+    matrix — can live alongside the rest of the node's logic, and the
+    editor stays a generic renderer.
+    """
+
+    #: Material Icons name (must exist in ``ui.icons._CODEPOINTS``).
+    glyph: str
+    tooltip: str
+    #: Invoked on click. Return a string to push to the clipboard, or
+    #: ``None`` for a side-effect-only action.
+    handler: Callable[[], str | None]
+
+
 class NodeBase(ABC):
     """Abstract base class for all processing nodes.
 
@@ -185,6 +210,11 @@ class NodeBase(ABC):
         self._outputs: list[OutputPort] = []
         self._params: list[NodeParam] = []
         self._skipped: bool = False
+        # Per-instance list of header buttons. Subclasses append
+        # :class:`HeaderAction` entries in their own ``__init__`` to add
+        # node-specific affordances (e.g. MetaInspector's "copy meta"
+        # button) without the editor needing class-by-class knowledge.
+        self.header_actions: list[HeaderAction] = []
         # Initialise every descriptor's backing slot to its declared
         # default before subclass ``__init__`` runs, so ``self._<name>``
         # exists from the first line after ``super().__init__()``. The

--- a/src/nodes/debug/meta_inspector.py
+++ b/src/nodes/debug/meta_inspector.py
@@ -5,7 +5,7 @@ from typing import Callable
 from typing_extensions import override
 
 from core.io_data import IoData, IoDataType
-from core.node_base import NodeBase
+from core.node_base import HeaderAction, NodeBase
 from core.port import InputPort, OutputPort
 
 
@@ -26,7 +26,10 @@ class MetaInspector(NodeBase):
     widget renders the field-by-field text on the main thread.
 
     The node itself is Qt-free; the worker-thread → main-thread hop
-    is the preview widget's responsibility (queued signal).
+    is the preview widget's responsibility (queued signal). The
+    "copy meta" header button declared in :attr:`header_actions`
+    is also Qt-free at the node level: the handler returns the text,
+    and :class:`ui.node_item.NodeItem` performs the clipboard write.
     """
 
     HEADER_ICON = "info"
@@ -36,6 +39,15 @@ class MetaInspector(NodeBase):
         self._frame_callback: Callable[[IoData], None] | None = None
         self._add_input(InputPort("data", set(_ALL_TYPES)))
         self._add_output(OutputPort("data", set(_ALL_TYPES)))
+        # Snapshot of the most recent frame so the "copy meta" header
+        # button can re-format it on demand. Held by reference; the
+        # node never mutates the envelope.
+        self._last_data: IoData | None = None
+        self.header_actions.append(HeaderAction(
+            glyph="content_copy",
+            tooltip="Copy meta to clipboard",
+            handler=self._copy_meta_text,
+        ))
 
     # ── UI integration ─────────────────────────────────────────────────────────
 
@@ -52,11 +64,46 @@ class MetaInspector(NodeBase):
         """
         self._frame_callback = callback
 
+    def _copy_meta_text(self) -> str | None:
+        """Return the formatted meta text for the most recent frame, or
+        ``None`` if no frame has been seen yet (so the header button
+        is a no-op before the flow runs)."""
+        if self._last_data is None:
+            return None
+        return format_meta(self._last_data)
+
     # ── NodeBase interface ─────────────────────────────────────────────────────
 
     @override
     def process_impl(self) -> None:
         in_data = self.inputs[0].data
+        self._last_data = in_data
         if self._frame_callback is not None:
             self._frame_callback(in_data)
         self.outputs[0].send(in_data)
+
+
+def format_meta(data: IoData) -> str:
+    """Render an :class:`IoData` envelope's meta + payload summary as
+    readable text for the inspector preview and copy-to-clipboard.
+
+    The meta bag is open-ended; every key is rendered in sorted order
+    so the inspector reflects whatever the upstream nodes stamped,
+    without hard-coding which keys exist.
+    """
+    shape = getattr(data.payload, "shape", None)
+    payload_line = (
+        f"payload: {data.type.name} shape={shape}"
+        if shape is not None
+        else f"payload: {data.type.name} value={data.payload!r}"
+    )
+    if not data.meta:
+        return f"meta: (empty)\n{payload_line}"
+
+    # Right-pad keys to a common width so values line up vertically.
+    key_width = max(len(k) for k in data.meta)
+    meta_lines = [
+        f"{key.ljust(key_width)}  {data.meta[key]}"
+        for key in sorted(data.meta)
+    ]
+    return "\n".join(meta_lines + [payload_line])

--- a/src/ui/icons.py
+++ b/src/ui/icons.py
@@ -116,6 +116,8 @@ _CODEPOINTS: Final[dict[str, str]] = {
     "merge":              "eb98",
     "arrow_outward":      "f8ce",
     "vertical_align_center": "e240",
+    # Header-action buttons
+    "content_copy":       "e14d",
 }
 
 

--- a/src/ui/node_item.py
+++ b/src/ui/node_item.py
@@ -9,6 +9,7 @@ from PySide6.QtGui import (
     QColor,
     QFont,
     QFontMetricsF,
+    QGuiApplication,
     QPainter,
     QPainterPath,
     QPen,
@@ -20,7 +21,8 @@ from PySide6.QtWidgets import (
     QWidget,
 )
 
-from core.node_base import NodeBase, SinkNodeBase, SourceNodeBase
+from core import notifications
+from core.node_base import HeaderAction, NodeBase, SinkNodeBase, SourceNodeBase
 from ui.icons import paint_material_glyph
 from ui.param_widgets import ParamWidgetBase, build_param_widget
 from ui.port_item import PortItem
@@ -324,6 +326,83 @@ class _SkipButtonItem(QGraphicsItem):
         super().mouseReleaseEvent(event)
 
 
+class _HeaderActionButtonItem(QGraphicsItem):
+    """Generic header button rendered for a :class:`HeaderAction`.
+
+    The button paints a Material Icons glyph in the node header and,
+    on click, runs the action's handler. If the handler returns a
+    non-empty string, it's pushed to the system clipboard and a brief
+    notification surfaces as feedback. Returning ``None`` makes the
+    click a pure side-effect.
+
+    One instance is created per entry in the owning node's
+    ``header_actions`` list; positioning and width-reservation are the
+    parent :class:`NodeItem`'s responsibility.
+    """
+
+    SIZE: float = 14.0
+    Z_VALUE = 2
+
+    def __init__(self, node_item: "NodeItem", action: HeaderAction) -> None:
+        super().__init__(parent=node_item)
+        self._node_item = node_item
+        self._action = action
+        self._hovered = False
+        self._pressed = False
+        self.setZValue(self.Z_VALUE)
+        self.setAcceptHoverEvents(True)
+        self.setAcceptedMouseButtons(Qt.MouseButton.LeftButton)
+        self.setCursor(Qt.CursorShape.ArrowCursor)
+        self.setToolTip(action.tooltip)
+
+    def boundingRect(self) -> QRectF:  # type: ignore[override]
+        return QRectF(0, 0, self.SIZE, self.SIZE)
+
+    def paint(self, painter: QPainter, option, widget=None) -> None:  # type: ignore[override]
+        painter.setRenderHint(QPainter.RenderHint.Antialiasing, True)
+        if self._hovered or self._pressed:
+            painter.setPen(Qt.NoPen)
+            painter.setBrush(QBrush(QColor(255, 255, 255, 70)))
+            painter.drawRoundedRect(self.boundingRect(), 2, 2)
+        paint_material_glyph(
+            painter,
+            self._action.glyph,
+            self.boundingRect(),
+            color=NODE_TITLE_TEXT_COLOR,
+        )
+
+    def hoverEnterEvent(self, event) -> None:  # type: ignore[override]
+        self._hovered = True
+        self.update()
+        super().hoverEnterEvent(event)
+
+    def hoverLeaveEvent(self, event) -> None:  # type: ignore[override]
+        self._hovered = False
+        self.update()
+        super().hoverLeaveEvent(event)
+
+    def mousePressEvent(self, event) -> None:  # type: ignore[override]
+        if event.button() == Qt.MouseButton.LeftButton:
+            self._pressed = True
+            self.update()
+            event.accept()
+            return
+        super().mousePressEvent(event)
+
+    def mouseReleaseEvent(self, event) -> None:  # type: ignore[override]
+        if event.button() == Qt.MouseButton.LeftButton and self._pressed:
+            self._pressed = False
+            self.update()
+            if self.boundingRect().contains(event.pos()):
+                result = self._action.handler()
+                if result:
+                    QGuiApplication.clipboard().setText(result)
+                    notifications.info("Copied to clipboard")
+            event.accept()
+            return
+        super().mouseReleaseEvent(event)
+
+
 class NodeItem(QGraphicsItem):
     """A single node drawn on the flow canvas.
 
@@ -417,6 +496,13 @@ class NodeItem(QGraphicsItem):
         self._skip_button: _SkipButtonItem | None = (
             _SkipButtonItem(self) if node.is_skippable else None
         )
+        # Per-instance header buttons declared by the node (e.g.
+        # MetaInspector's "copy meta" action). One QGraphicsItem per
+        # ``HeaderAction``; positioning is handled in ``_relayout``.
+        self._header_action_buttons: list[_HeaderActionButtonItem] = [
+            _HeaderActionButtonItem(self, action)
+            for action in node.header_actions
+        ]
         self._resize_grip = _ResizeGripItem(self)
 
         self._build_ports()
@@ -758,12 +844,18 @@ class NodeItem(QGraphicsItem):
 
     def _title_right_reserve(self) -> float:
         """Horizontal space reserved on the header's right edge for the
-        close button, the (source-only) tick-count badge, and the
-        (skippable-only) step-over button — which sits between the
-        title text and the tick badge."""
+        close button, the (source-only) tick-count badge, the
+        (skippable-only) step-over button, and any node-declared
+        header-action buttons. All cluster between the title text and
+        the right edge in that order."""
         reserve = self.CLOSE_BUTTON_SIZE + self.PADDING + self._tick_label_width()
         if self._skip_button is not None:
             reserve += self.SKIP_BUTTON_SIZE + self.HEADER_BUTTON_GAP
+        n_actions = len(self._header_action_buttons)
+        if n_actions:
+            reserve += n_actions * (
+                _HeaderActionButtonItem.SIZE + self.HEADER_BUTTON_GAP
+            )
         return reserve
 
     def _title_left(self) -> float:
@@ -1134,6 +1226,26 @@ class NodeItem(QGraphicsItem):
                 self._skip_button_x(),
                 (self.HEADER_HEIGHT - self.SKIP_BUTTON_SIZE) / 2,
             )
+        # Header-action buttons sit just left of the skip button (or, if
+        # the node isn't skippable, just left of the tick badge / close
+        # button). Walked in from the right so the close button stays
+        # flush with the right padding regardless of how many actions
+        # are declared.
+        if self._header_action_buttons:
+            if self._skip_button is not None:
+                cluster_right = self._skip_button_x()
+            else:
+                cluster_right = (
+                    self._width
+                    - self.PADDING
+                    - self.CLOSE_BUTTON_SIZE
+                    - self._tick_label_width()
+                )
+            x = cluster_right - self.HEADER_BUTTON_GAP
+            for btn in reversed(self._header_action_buttons):
+                x -= btn.SIZE
+                btn.setPos(x, (self.HEADER_HEIGHT - btn.SIZE) / 2)
+                x -= self.HEADER_BUTTON_GAP
         self._resize_grip.setPos(
             self._width - self.RESIZE_GRIP_SIZE - 1,
             self._body_height - self.RESIZE_GRIP_SIZE - 1,

--- a/src/ui/preview_widgets.py
+++ b/src/ui/preview_widgets.py
@@ -7,10 +7,9 @@ import numpy as np
 from typing_extensions import override
 
 from PySide6.QtCore import Qt, Signal, Slot
-from PySide6.QtGui import QGuiApplication, QImage, QPixmap
+from PySide6.QtGui import QImage, QPixmap
 from PySide6.QtWidgets import (
     QFrame,
-    QHBoxLayout,
     QLabel,
     QPushButton,
     QScrollArea,
@@ -22,7 +21,7 @@ from PySide6.QtWidgets import (
 from core import notifications
 from core.io_data import IoData, IoDataType
 from core.node_base import NodeBase
-from nodes.debug.meta_inspector import MetaInspector
+from nodes.debug.meta_inspector import MetaInspector, format_meta
 from nodes.debug.play_gate import PlayGate
 from nodes.filters.display import Display
 
@@ -344,29 +343,11 @@ class MetaInspectorPreview(_PreviewWidgetBase):
             "QScrollArea { background: #111; border: 1px solid #333; }"
         )
 
-        self._copy_button = QPushButton("Copy")
-        self._copy_button.setToolTip("Copy meta text to clipboard")
-        self._copy_button.setCursor(Qt.CursorShape.PointingHandCursor)
-        self._copy_button.setStyleSheet(
-            "QPushButton { background: #2b6cb0; color: white;"
-            "              border: 1px solid #1a4577;"
-            "              padding: 2px 10px; font-size: 11px; }"
-            "QPushButton:hover { background: #3478c2; }"
-            "QPushButton:pressed { background: #1f5391; }"
-        )
-        self._copy_button.clicked.connect(self._on_copy_clicked)
-
-        button_row = QHBoxLayout()
-        button_row.setContentsMargins(0, 0, 0, 2)
-        button_row.addStretch(1)
-        button_row.addWidget(self._copy_button)
-
         self.setSizePolicy(
             QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding,
         )
         layout = QVBoxLayout(self)
         layout.setContentsMargins(0, 0, 0, 0)
-        layout.addLayout(button_row)
         layout.addWidget(self._scroll)
 
         # Auto-connection delivers cross-thread emits via a queued
@@ -377,7 +358,7 @@ class MetaInspectorPreview(_PreviewWidgetBase):
         node.set_frame_callback(self._emit_from_worker)
 
     def _emit_from_worker(self, data: IoData) -> None:
-        self._text_ready.emit(_format_meta(data))
+        self._text_ready.emit(format_meta(data))
 
     @Slot(str)
     def _on_text_ready(self, text: str) -> None:
@@ -388,37 +369,6 @@ class MetaInspectorPreview(_PreviewWidgetBase):
         # paint event until the next event-loop turn. Forcing
         # ``update`` is cheap and removes any timing ambiguity.
         self._label.update()
-
-    @Slot()
-    def _on_copy_clicked(self) -> None:
-        QGuiApplication.clipboard().setText(self._label.text())
-        notifications.info("Meta copied to clipboard")
-
-
-def _format_meta(data: IoData) -> str:
-    """Render an :class:`IoData` envelope's meta + payload summary as
-    readable text for the inspector preview.
-
-    The meta bag is open-ended; we render every key in sorted order
-    so the inspector reflects whatever the upstream nodes stamped,
-    without hard-coding which keys exist.
-    """
-    shape = getattr(data.payload, "shape", None)
-    payload_line = (
-        f"payload: {data.type.name} shape={shape}"
-        if shape is not None
-        else f"payload: {data.type.name} value={data.payload!r}"
-    )
-    if not data.meta:
-        return f"meta: (empty)\n{payload_line}"
-
-    # Right-pad keys to a common width so values line up vertically.
-    key_width = max(len(k) for k in data.meta)
-    meta_lines = [
-        f"{key.ljust(key_width)}  {data.meta[key]}"
-        for key in sorted(data.meta)
-    ]
-    return "\n".join(meta_lines + [payload_line])
 
 
 # ── PlayGate preview ──────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Promotes the per-node "Copy meta" button out of the preview body and into the node header, via a small generic header-action framework so future nodes can do the same without editor changes.

- **`HeaderAction` framework.** `core.node_base.HeaderAction` is a frozen dataclass `{glyph, tooltip, handler}`. Nodes append entries to a per-instance `NodeBase.header_actions` list during `__init__`. The handler runs on click; if it returns a non-empty string, the editor writes that string to the system clipboard via `QGuiApplication.clipboard()`. The node side stays Qt-free.
- **Editor renderer.** `ui.node_item._HeaderActionButtonItem` paints the glyph as a small clickable `QGraphicsItem` and clusters left of the skip / tick / close buttons. `_title_right_reserve()` and `_relayout()` reserve and position the cluster so the close button stays flush with the right padding regardless of how many actions a node declares.
- **`MetaInspector` integration.** Snapshots the last `IoData` it sees and declares one header action — `content_copy` glyph, tooltip "Copy meta to clipboard". The `format_meta` helper moves to the node module so the handler and the preview widget share one formatter without a UI ↔ node import. The body-level Copy button drops out of `MetaInspectorPreview`.
- **`content_copy` glyph** added to `ui.icons._CODEPOINTS` (the Material Icons standard for copy-to-clipboard).
- Bump `APP_VERSION` 0.3.0.59 → 0.3.0.60.

## Test plan

- [ ] Drop a `Meta Inspector` into a flow downstream of a node that emits rich meta. Run the flow.
- [ ] A small `content_copy` glyph appears in the inspector's header, between the title text and the close button.
- [ ] Hovering the glyph shows the tooltip "Copy meta to clipboard"; clicking copies the formatted meta text to the system clipboard and surfaces an info toast.
- [ ] Before any frame has run through, the click is a silent no-op (no clipboard write, no toast).
- [ ] Other node types render unchanged — no extra header buttons, header layout unaffected, close/skip/tick badges still flush right.
- [ ] Existing `tests/test_meta_inspector.py` still passes (pass-through behaviour, frame callback, optional callback).

https://claude.ai/code/session_012oex2Ken1p8LxVAUeYcCNX

---
_Generated by [Claude Code](https://claude.ai/code/session_012oex2Ken1p8LxVAUeYcCNX)_