### PR TITLE
Display: meta-info mode + smart copy

### DIFF
--- a/src/constants.py
+++ b/src/constants.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 APP_NAME:         str = "Stjörnhorn"
 APP_DISPLAY_NAME: str = "Stjörnhorn"
-APP_VERSION:      str = "0.3.0.61"
+APP_VERSION:      str = "0.3.0.62"
 API_URL:    str = "https://beltoforion.de"
 
 # Public, online-hosted version of the welcome page. The start page tries

--- a/src/core/node_base.py
+++ b/src/core/node_base.py
@@ -130,15 +130,24 @@ class HeaderItem:
 
 @dataclass(frozen=True)
 class Command(HeaderItem):
-    """One-shot header button. Click runs ``handler``; if it returns a
-    non-empty string, the editor copies it to the clipboard and
-    surfaces a brief notification. Use this for fire-and-forget
-    affordances like "copy meta", "reset cache", or "delete node"."""
+    """One-shot header button. Click runs ``handler``; the editor
+    dispatches on the return type:
+
+    - ``str`` (non-empty) → text is pushed to the clipboard.
+    - ``numpy.ndarray`` → pixels are pushed to the clipboard as an
+      image (uint8 greyscale / BGR / BGRA, matching the convention
+      already used by the preview widgets).
+    - falsy (``None``, ``""``) → silent no-op.
+
+    Use this for fire-and-forget affordances like "copy meta",
+    "copy image", "reset cache", or "delete node". The return-type
+    contract keeps the node side Qt-free — the node never touches
+    the clipboard or constructs a QImage itself."""
 
     #: Material Icons name (must exist in ``ui.icons._CODEPOINTS``).
     glyph: str
     tooltip: str
-    handler: Callable[[], str | None]
+    handler: Callable[[], object]
 
 
 @dataclass(frozen=True)

--- a/src/nodes/filters/display.py
+++ b/src/nodes/filters/display.py
@@ -7,8 +7,9 @@ import numpy as np
 from typing_extensions import override
 
 from core.io_data import IMAGE_TYPES, IoData, IoDataType
-from core.node_base import NodeBase
+from core.node_base import Command, NodeBase, Toggle
 from core.port import InputPort, OutputPort
+from nodes.debug.meta_inspector import format_meta
 
 
 _DISPLAY_TYPES = frozenset(IMAGE_TYPES | {IoDataType.SCALAR, IoDataType.MATRIX})
@@ -38,13 +39,33 @@ class Display(NodeBase):
     def __init__(self) -> None:
         super().__init__("Display", section="Output")
         self._latest_frame:    np.ndarray | None = None
+        self._last_data:       IoData | None = None
         self._frame_callback:  Callable[[IoData], None] | None = None
         self._last_frame_ts:   float | None = None
         self._fps_ema:         float | None = None
         self._frame_count:     int = 0
+        # Header toggle: when on, the preview swaps the image / status
+        # bar for a scrollable meta-text view (the same rendering as
+        # the standalone MetaInspector). The widget polls
+        # :attr:`show_meta` on each repaint and re-subscribes to mode
+        # flips via :meth:`set_show_meta_callback`.
+        self._show_meta:                bool = False
+        self._show_meta_callback:       Callable[[], None] | None = None
 
         self._add_input(InputPort("image", set(_DISPLAY_TYPES)))
         self._add_output(OutputPort("image", set(_DISPLAY_TYPES)))
+
+        self._header_items.append(Toggle(
+            glyph="info",
+            tooltip="Show frame metadata instead of image",
+            handler=self._toggle_show_meta,
+            is_active=lambda: self._show_meta,
+        ))
+        self._header_items.append(Command(
+            glyph="content_copy",
+            tooltip="Copy what's shown in the preview to the clipboard",
+            handler=self._copy_visible,
+        ))
 
     # ── Properties ─────────────────────────────────────────────────────────────
 
@@ -72,6 +93,13 @@ class Display(NodeBase):
         """
         return self._fps_ema
 
+    @property
+    def show_meta(self) -> bool:
+        """True when the preview should render frame metadata instead
+        of the image / status bar. Flipped by the header toggle; the
+        widget polls this on each repaint."""
+        return self._show_meta
+
     # ── UI integration ─────────────────────────────────────────────────────────
 
     def set_frame_callback(
@@ -91,12 +119,53 @@ class Display(NodeBase):
         """
         self._frame_callback = callback
 
+    def set_show_meta_callback(
+        self, callback: Callable[[], None] | None,
+    ) -> None:
+        """Attach (or clear) a callback fired when :attr:`show_meta`
+        flips. The preview widget uses it to swap which page of its
+        stack is visible without polling."""
+        self._show_meta_callback = callback
+
+    def _toggle_show_meta(self) -> None:
+        """Header-toggle handler: flip ``show_meta`` and notify the
+        widget so it can repaint in the new mode."""
+        self._show_meta = not self._show_meta
+        if self._show_meta_callback is not None:
+            self._show_meta_callback()
+
+    def _copy_visible(self) -> object:
+        """Header-command handler: return whatever the preview is
+        currently showing, in the form the editor's clipboard
+        dispatcher expects.
+
+        - Meta mode → the formatted meta text (str).
+        - Image mode + IMAGE payload → the raw uint8 array (ndarray;
+          the editor pushes it as an image).
+        - Image mode + SCALAR / MATRIX payload → the rendered text
+          (str), matching what's drawn in the preview label.
+        - No frame seen yet → ``None`` (silent no-op).
+        """
+        data = self._last_data
+        if data is None:
+            return None
+        if self._show_meta:
+            return format_meta(data)
+        if data.type is IoDataType.SCALAR:
+            return format_scalar(data.payload)
+        if data.type is IoDataType.MATRIX:
+            return format_matrix(data.payload)
+        # IMAGE: hand the array over; the editor turns it into a
+        # QImage and writes ``setImage`` on the system clipboard.
+        return data.payload
+
     # ── NodeBase interface ─────────────────────────────────────────────────────
 
     @override
     def _before_run_impl(self) -> None:
         super()._before_run_impl()
         self._latest_frame  = None
+        self._last_data     = None
         self._last_frame_ts = None
         self._fps_ema       = None
         self._frame_count   = 0
@@ -104,6 +173,7 @@ class Display(NodeBase):
     @override
     def process_impl(self) -> None:
         in_data = self.inputs[0].data
+        self._last_data = in_data
 
         self._frame_count += 1
 
@@ -130,3 +200,27 @@ class Display(NodeBase):
             self._frame_callback(in_data)
 
         self.outputs[0].send(in_data)
+
+
+def format_scalar(arr: np.ndarray) -> str:
+    """Format a 0-d numpy array for the Display preview label and the
+    "copy visible" command.
+
+    Integers render without a decimal point; floats use up to 4
+    decimals so a multiplier like 0.5 stays legible without trailing
+    zero-noise.
+    """
+    value = arr.item()
+    if isinstance(value, (int, np.integer)):
+        return str(int(value))
+    return f"{float(value):.4g}"
+
+
+def format_matrix(arr: np.ndarray) -> str:
+    """Format a 2-D numpy array as a compact text grid for the
+    preview label and the "copy visible" command.
+
+    Caps the rendered shape so a large matrix doesn't blow out the
+    preview label; truncated rows/cols are indicated with an ellipsis.
+    """
+    return np.array2string(arr, precision=3, suppress_small=True, threshold=64)

--- a/src/ui/node_item.py
+++ b/src/ui/node_item.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import logging
 from typing_extensions import override
 
+import numpy as np
+
 from PySide6.QtCore import QEvent, QObject, QPointF, QRectF, Qt, QTimer, Signal
 from PySide6.QtGui import (
     QBrush,
@@ -35,7 +37,7 @@ from core.node_base import (
 from ui.icons import paint_material_glyph
 from ui.param_widgets import ParamWidgetBase, build_param_widget
 from ui.port_item import PortItem
-from ui.preview_widgets import build_preview_widget
+from ui.preview_widgets import build_preview_widget, numpy_to_qimage
 from ui.theme import (
     BORDER_FROM_CATEGORY,
     FILTER_HEADER_COLOR,
@@ -261,9 +263,8 @@ class _HeaderButtonItem(QGraphicsItem):
             self.update()
             if self.boundingRect().contains(event.pos()):
                 result = self._item.handler()
-                if isinstance(self._item, Command) and result:
-                    QGuiApplication.clipboard().setText(result)
-                    notifications.info("Copied to clipboard")
+                if isinstance(self._item, Command):
+                    self._dispatch_command_result(result)
                 if isinstance(self._item, Toggle):
                     # A toggle flips node state that affects what the
                     # flow does on the next run; emit ``param_changed``
@@ -276,6 +277,30 @@ class _HeaderButtonItem(QGraphicsItem):
             event.accept()
             return
         super().mouseReleaseEvent(event)
+
+    @staticmethod
+    def _dispatch_command_result(result: object) -> None:
+        """Send a :class:`Command` handler's return value to the
+        clipboard. Strings go as text, ndarrays as images; anything
+        falsy (``None``, ``""``) is a silent no-op so the click costs
+        nothing when there's nothing to copy yet."""
+        if isinstance(result, str):
+            if not result:
+                return
+            QGuiApplication.clipboard().setText(result)
+            notifications.info("Copied to clipboard")
+            return
+        if isinstance(result, np.ndarray):
+            try:
+                qimg = numpy_to_qimage(result)
+            except Exception as exc:
+                logger.exception("Header command: image-copy conversion failed")
+                notifications.warn(f"Could not copy image: {exc}")
+                return
+            QGuiApplication.clipboard().setImage(qimg)
+            notifications.info("Image copied to clipboard")
+            return
+        # Everything else (None, falsy str, …) is a deliberate no-op.
 
 
 class _HeaderSeparatorItem(QGraphicsItem):

--- a/src/ui/preview_widgets.py
+++ b/src/ui/preview_widgets.py
@@ -14,6 +14,7 @@ from PySide6.QtWidgets import (
     QPushButton,
     QScrollArea,
     QSizePolicy,
+    QStackedWidget,
     QVBoxLayout,
     QWidget,
 )
@@ -23,7 +24,7 @@ from core.io_data import IoData, IoDataType
 from core.node_base import NodeBase
 from nodes.debug.meta_inspector import MetaInspector, format_meta
 from nodes.debug.play_gate import PlayGate
-from nodes.filters.display import Display
+from nodes.filters.display import Display, format_matrix, format_scalar
 
 logger = logging.getLogger(__name__)
 
@@ -49,12 +50,20 @@ class _PreviewWidgetBase(QWidget):
 class DisplayPreview(_PreviewWidgetBase):
     """Inline preview for :class:`~nodes.filters.display.Display`.
 
-    Shows every frame the Display sees as a scaled pixmap inside the
-    node body, with a status line beneath the image listing FPS,
-    running frame number, and image resolution. Frames arrive on the
-    worker thread via the node's ``frame_callback``; a queued
-    :class:`Signal` hops them to the UI thread where the pixmap and
-    status line are swapped in.
+    Two modes, switched by the node's "show metadata" header toggle:
+
+    - **Image mode (default).** Every frame the Display sees is
+      rendered as a scaled pixmap (or formatted text for SCALAR /
+      MATRIX payloads), with a status line beneath listing FPS,
+      running frame number, and payload shape.
+    - **Meta mode.** A scrollable text dump of the IoMeta + payload
+      summary — the same rendering the standalone
+      :class:`MetaInspector` provides.
+
+    Both pages stay in sync with each frame so toggling the header
+    swap is instant. Frames arrive on the worker thread via the
+    node's ``frame_callback``; queued :class:`Signal`-s hop them to
+    the UI thread before any QLabel updates.
     """
 
     #: Worker thread emits a ready QImage and the status string for
@@ -64,14 +73,21 @@ class DisplayPreview(_PreviewWidgetBase):
     #: Worker thread emits formatted text and the status string for
     #: SCALAR / MATRIX payloads.
     _text_ready = Signal(str, str)
+    #: Worker thread emits the formatted meta dump for the meta page.
+    _meta_ready = Signal(str)
+    #: UI thread emits when the node's ``show_meta`` flag flips so
+    #: the stacked widget can swap pages without polling.
+    _mode_changed = Signal()
 
     _PREVIEW_MIN_W: int = 180
     _PREVIEW_MIN_H: int = 100
 
     _STATUS_PLACEHOLDER: str = "—"
+    _META_PLACEHOLDER: str = "(run the flow to see meta)"
 
     def __init__(self, node: Display) -> None:
         super().__init__(node)
+        # ── Image page ──────────────────────────────────────────────
         self._label = QLabel()
         self._label.setAlignment(Qt.AlignmentFlag.AlignCenter)
         self._label.setMinimumSize(self._PREVIEW_MIN_W, self._PREVIEW_MIN_H)
@@ -101,15 +117,52 @@ class DisplayPreview(_PreviewWidgetBase):
             "         font-size: 11px; padding: 2px 6px; }"
         )
 
+        self._image_page = QWidget()
+        image_layout = QVBoxLayout(self._image_page)
+        image_layout.setContentsMargins(0, 0, 0, 0)
+        image_layout.setSpacing(0)
+        image_layout.addWidget(self._label, 1)
+        image_layout.addWidget(self._status, 0)
+
+        # ── Meta page ───────────────────────────────────────────────
+        self._meta_label = QLabel()
+        self._meta_label.setAlignment(
+            Qt.AlignmentFlag.AlignTop | Qt.AlignmentFlag.AlignLeft,
+        )
+        self._meta_label.setSizePolicy(
+            QSizePolicy.Policy.Expanding, QSizePolicy.Policy.MinimumExpanding,
+        )
+        self._meta_label.setStyleSheet(
+            "QLabel { background: #111; color: #d6d6d6; padding: 4px;"
+            "         font-family: 'Consolas','Menlo',monospace;"
+            "         font-size: 11px; }"
+        )
+        # Word-wrap so a long source_path doesn't blow out the body
+        # width and force the user to resize the node.
+        self._meta_label.setWordWrap(True)
+        self._meta_label.setText(self._META_PLACEHOLDER)
+
+        self._meta_scroll = QScrollArea()
+        self._meta_scroll.setWidget(self._meta_label)
+        self._meta_scroll.setWidgetResizable(True)
+        self._meta_scroll.setFrameShape(QFrame.Shape.Box)
+        self._meta_scroll.setMinimumSize(self._PREVIEW_MIN_W, self._PREVIEW_MIN_H)
+        self._meta_scroll.setStyleSheet(
+            "QScrollArea { background: #111; border: 1px solid #333; }"
+        )
+
+        # ── Stack ───────────────────────────────────────────────────
+        self._stack = QStackedWidget()
+        self._stack.addWidget(self._image_page)
+        self._stack.addWidget(self._meta_scroll)
+
         # Mirror Expanding on the enclosing widget so its parent layout
         # honours vertical stretch rather than collapsing to sizeHint.
         self.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding)
 
         layout = QVBoxLayout(self)
         layout.setContentsMargins(0, 0, 0, 0)
-        layout.setSpacing(0)
-        layout.addWidget(self._label, 1)
-        layout.addWidget(self._status, 0)
+        layout.addWidget(self._stack)
 
         # Original-resolution frame; we always scale from this to avoid
         # losing quality on successive resizes.
@@ -117,7 +170,14 @@ class DisplayPreview(_PreviewWidgetBase):
 
         self._frame_ready.connect(self._on_frame_ready)
         self._text_ready.connect(self._on_text_ready)
+        self._meta_ready.connect(self._on_meta_ready)
+        self._mode_changed.connect(self._on_mode_changed)
         node.set_frame_callback(self._emit_from_worker)
+        node.set_show_meta_callback(self._mode_changed.emit)
+        # Show whichever page matches the node's current flag (defaults
+        # to image, but a flow loaded with the toggle on would land
+        # straight on meta).
+        self._on_mode_changed()
 
     @override
     def resizeEvent(self, event) -> None:  # type: ignore[override]
@@ -129,13 +189,15 @@ class DisplayPreview(_PreviewWidgetBase):
     def _emit_from_worker(self, in_data: IoData) -> None:
         """Called from whichever thread runs the Display node's process.
 
-        Dispatches on payload kind: image payloads convert to a
-        self-owning QImage (so the underlying numpy buffer can be freed
-        without tearing the pixmap) and hop across threads via
-        ``_frame_ready``; SCALAR / MATRIX payloads format to a string
-        and hop via ``_text_ready``. The current FPS and frame count
-        are read from the node here, on the worker thread, so the
-        snapshot stays consistent with the payload being sent.
+        Updates both pages of the stack so the toggle is instant. The
+        meta-text emit is unconditional; image-mode dispatches on
+        payload kind: image payloads convert to a self-owning QImage
+        (so the underlying numpy buffer can be freed without tearing
+        the pixmap) and hop across threads via ``_frame_ready``;
+        SCALAR / MATRIX payloads format to a string and hop via
+        ``_text_ready``. The current FPS and frame count are read
+        from the node here, on the worker thread, so the snapshot
+        stays consistent with the payload being sent.
         """
         node = self._node
         assert isinstance(node, Display)
@@ -143,15 +205,19 @@ class DisplayPreview(_PreviewWidgetBase):
             node.current_fps, node.frames_processed, in_data.payload,
         )
 
+        # Keep the meta page in lockstep with the image page so
+        # toggling the header switches instantly to the right text.
+        self._meta_ready.emit(format_meta(in_data))
+
         if in_data.type is IoDataType.SCALAR:
-            self._text_ready.emit(_format_scalar(in_data.payload), status)
+            self._text_ready.emit(format_scalar(in_data.payload), status)
             return
         if in_data.type is IoDataType.MATRIX:
-            self._text_ready.emit(_format_matrix(in_data.payload), status)
+            self._text_ready.emit(format_matrix(in_data.payload), status)
             return
 
         try:
-            qimg = _numpy_to_qimage(in_data.payload)
+            qimg = numpy_to_qimage(in_data.payload)
         except Exception as exc:
             # Don't crash the run on a single bad frame; surface the
             # failure as a non-blocking warning so the user notices
@@ -181,6 +247,22 @@ class DisplayPreview(_PreviewWidgetBase):
         self._label.setPixmap(QPixmap())
         self._label.setText(text)
         self._status.setText(status)
+
+    @Slot(str)
+    def _on_meta_ready(self, text: str) -> None:
+        self._meta_label.setText(text)
+        # Same belt-and-braces nudge as the standalone MetaInspector
+        # widget — same-thread emits during click handlers can leave
+        # the proxy widget without a fresh paint until the next
+        # event-loop turn.
+        self._meta_label.update()
+
+    @Slot()
+    def _on_mode_changed(self) -> None:
+        node = self._node
+        assert isinstance(node, Display)
+        target = self._meta_scroll if node.show_meta else self._image_page
+        self._stack.setCurrentWidget(target)
 
     def _render_scaled(self) -> None:
         if self._source_image is None:
@@ -224,35 +306,10 @@ def _format_status(
     return f"FPS {fps_text}   N {frame_count}   {size_text}"
 
 
-# ── Scalar / matrix formatting ────────────────────────────────────────────────
-
-
-def _format_scalar(arr: np.ndarray) -> str:
-    """Format a 0-d numpy array for the Display preview label.
-
-    Integers render without a decimal point; floats use up to 4
-    decimals so a multiplier like 0.5 stays legible without trailing
-    zero-noise.
-    """
-    value = arr.item()
-    if isinstance(value, (int, np.integer)):
-        return str(int(value))
-    return f"{float(value):.4g}"
-
-
-def _format_matrix(arr: np.ndarray) -> str:
-    """Format a 2-D numpy array as a compact text grid for the preview.
-
-    Caps the rendered shape so a large matrix doesn't blow out the
-    preview label; truncated rows/cols are indicated with an ellipsis.
-    """
-    return np.array2string(arr, precision=3, suppress_small=True, threshold=64)
-
-
 # ── numpy → QImage ─────────────────────────────────────────────────────────────
 
 
-def _numpy_to_qimage(frame: np.ndarray) -> QImage:
+def numpy_to_qimage(frame: np.ndarray) -> QImage:
     """Wrap a uint8 numpy frame as a self-owning :class:`QImage`.
 
     Supports single-channel greyscale, 3-channel BGR, and 4-channel


### PR DESCRIPTION
## Summary

Folds the `MetaInspector`'s text dump into the `Display` node behind a header toggle so a single `Display` can show either the live image or the frame's metadata, on demand. The standalone `MetaInspector` node stays untouched for users who want a dedicated debug probe.

### Display side

- Tracks `_show_meta` flag, with `set_show_meta_callback` so the widget can repaint on flip without polling.
- Snapshots `_last_data` per frame so the copy command can re-format the latest frame even after it's been forwarded downstream.
- Two new header items (in the right cluster, left to right):
  - **`Toggle` (`info` glyph)** — "Show frame metadata instead of image".
  - **`Command` (`content_copy` glyph)** — "Copy what's shown in the preview to the clipboard".
- `_copy_visible` is mode-aware:
  - Meta mode → formatted meta text (str).
  - Image mode + IMAGE payload → raw uint8 `ndarray` (the editor converts to QImage and writes to clipboard).
  - Image mode + SCALAR / MATRIX → the rendered text (str).
  - No frame seen → `None` (silent no-op).

### Header-button dispatch

- `Command.handler` return type widened from `str | None` to `object`: strings still go to the text clipboard, `ndarray`s now go through `numpy_to_qimage` and `QClipboard.setImage`. Falsy results stay a silent no-op.
- New `_HeaderButtonItem._dispatch_command_result` does the type switch so the contract at the node side stays narrow: the node returns the data, the editor handles all Qt clipboard plumbing.

### DisplayPreview

- Restructured into a `QStackedWidget` with two pages:
  - **Image page**: existing image label + status bar.
  - **Meta page**: scrollable `QLabel` with the same rendering as the standalone MetaInspector preview.
- Both pages stay in sync per frame so toggling is instant. Mode swap is driven by `Display.set_show_meta_callback` via a queued `_mode_changed` Signal.

### Other moves

- `_format_scalar` / `_format_matrix` move from `ui/preview_widgets.py` to `nodes/filters/display.py` (renamed `format_scalar` / `format_matrix`) so the node's copy handler can reuse them without a UI → node import.
- `_numpy_to_qimage` → public `numpy_to_qimage` so `ui/node_item.py` can pull it in for the image-clipboard path.

Bump `APP_VERSION` 0.3.0.61 → 0.3.0.62.

## Test plan

- [ ] Drop a `Display` downstream of a streaming source. Run the flow.
  - Image renders + status line ticks as before.
  - Click the `info` header toggle: preview swaps to a scrollable meta dump (frame_index, source_path, payload kind & shape, etc.). Toggle again → back to image. Toggle is instant — both pages stay in lockstep with each frame.
  - In image mode click the copy button → image lands on clipboard, paste into another app shows the frame.
  - In meta mode click the copy button → text lands on clipboard.
  - In image mode with a SCALAR / MATRIX upstream → copy puts the rendered text on the clipboard.
  - Click the copy button before any frame has arrived → nothing happens (no toast, no stale clipboard).
- [ ] Standalone `MetaInspector` node still works exactly as before.
- [ ] `tests/test_meta_inspector.py` still passes.

https://claude.ai/code/session_012oex2Ken1p8LxVAUeYcCNX

---
_Generated by [Claude Code](https://claude.ai/code/session_012oex2Ken1p8LxVAUeYcCNX)_