### PR TITLE
Fix Mosaic hstack failure with mixed 3/4-channel images

### DIFF
--- a/src/nodes/filters/mosaic.py
+++ b/src/nodes/filters/mosaic.py
@@ -218,10 +218,20 @@ class Mosaic(NodeBase):
     def _promote(data: IoData, to_color: bool) -> np.ndarray:
         img = data.image
         if to_color:
-            if data.type == IoDataType.IMAGE_GREY:
-                return cv2.cvtColor(img, cv2.COLOR_GRAY2BGR)
-            if img.ndim == 3 and img.shape[2] == 4:
-                return cv2.cvtColor(img, cv2.COLOR_BGRA2BGR)
+            try:
+                if data.type == IoDataType.IMAGE_GREY:
+                    return cv2.cvtColor(img, cv2.COLOR_GRAY2BGR)
+                if img.ndim == 3 and img.shape[2] == 4:
+                    return cv2.cvtColor(img, cv2.COLOR_BGRA2BGR)
+            except Exception as exc:
+                source_path = data.meta.get("source_path")
+                source_hint = (
+                    f" source={source_path!s}" if source_path is not None else ""
+                )
+                raise ValueError(
+                    "Mosaic image promotion to target format failed:"
+                    f" type={data.type.name} shape={img.shape!r}.{source_hint}"
+                ) from exc
         return img
 
     @staticmethod

--- a/src/nodes/filters/mosaic.py
+++ b/src/nodes/filters/mosaic.py
@@ -217,8 +217,11 @@ class Mosaic(NodeBase):
     @staticmethod
     def _promote(data: IoData, to_color: bool) -> np.ndarray:
         img = data.image
-        if to_color and data.type == IoDataType.IMAGE_GREY:
-            return cv2.cvtColor(img, cv2.COLOR_GRAY2BGR)
+        if to_color:
+            if data.type == IoDataType.IMAGE_GREY:
+                return cv2.cvtColor(img, cv2.COLOR_GRAY2BGR)
+            if img.ndim == 3 and img.shape[2] == 4:
+                return cv2.cvtColor(img, cv2.COLOR_BGRA2BGR)
         return img
 
     @staticmethod


### PR DESCRIPTION
### Motivation
- The `Mosaic` node could receive a mixture of 3-channel BGR and 4-channel BGRA images (e.g. from `image_bulk_fft`), causing `np.hstack` to raise a channel-dimension mismatch `ValueError`.

### Description
- Update `_promote` in `src/nodes/filters/mosaic.py` to normalize color outputs by converting grayscale images to BGR as before and also converting 4-channel BGRA images to 3-channel BGR when `to_color` is true, ensuring all row images have a consistent 3-channel shape before `np.hstack`.

### Testing
- Ran `python -m compileall src/nodes/filters/mosaic.py` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7168479cc832ba369f2ca89e1551b)