### PR TITLE
Raise error when image write fails in FileSink

### DIFF
--- a/src/nodes/sinks/file_sink.py
+++ b/src/nodes/sinks/file_sink.py
@@ -83,7 +83,13 @@ class FileSink(SinkNodeBase):
             raise ValueError(f"Unsupported output format: {self._output_format}")
 
         output.parent.mkdir(parents=True, exist_ok=True)
-        cv2.imwrite(str(output), self.inputs[0].data.image)
+        written = cv2.imwrite(str(output), self.inputs[0].data.image)
+        if not written:
+            raise OSError(
+                f"File Sink failed to write image to {output!s}. "
+                "This often means the rendered filename/path is invalid "
+                "for the current OS."
+            )
 
     # ── Internals ──────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
### Motivation
- Surface failures from `cv2.imwrite` in `FileSink` so a broken or invalid rendered filename/path does not silently fail.

### Description
- Capture the boolean return value of `cv2.imwrite` and raise an `OSError` with a helpful message when it returns `False`, preserving existing path resolution and `output.parent.mkdir(...)` behavior.

### Testing
- Ran the repository's automated test suite and CI checks; all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7168479cc832ba369f2ca89e1551b)