### PR TITLE
Make FileSink image write robust by encoding and explicit file write with errors

### DIFF
--- a/src/nodes/sinks/file_sink.py
+++ b/src/nodes/sinks/file_sink.py
@@ -83,7 +83,21 @@ class FileSink(SinkNodeBase):
             raise ValueError(f"Unsupported output format: {self._output_format}")
 
         output.parent.mkdir(parents=True, exist_ok=True)
-        cv2.imwrite(str(output), self.inputs[0].data.image)
+        image = self.inputs[0].data.image
+        ext = output.suffix or ".png"
+        encoded_ok, encoded = cv2.imencode(ext, image)
+        if not encoded_ok:
+            raise OSError(
+                f"File Sink failed to encode image for {output!s} "
+                f"(format {ext!r})."
+            )
+        try:
+            encoded.tofile(str(output))
+        except OSError as exc:
+            raise OSError(
+                f"File Sink failed to write image to {output!s}. "
+                "The destination path may be invalid or unavailable."
+            ) from exc
 
     # ── Internals ──────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
### Motivation
- Replace direct use of `cv2.imwrite` because writing via OpenCV to a `Path` can fail silently or be unreliable for some targets, and encoding failures should be surfaced clearly.

### Description
- Replace `cv2.imwrite(str(output), image)` with an explicit `cv2.imencode(ext, image)` followed by `encoded.tofile(str(output))` to separate encoding from file IO. 
- Determine the encoding extension via `ext = output.suffix or ".png"` so a default format is used when no suffix is present. 
- Raise an `OSError` if `cv2.imencode` fails and wrap any `OSError` from `tofile` with a clearer message about write failures.

### Testing
- Ran the targeted file-sink tests `pytest tests/nodes/sinks/test_file_sink.py` to validate image encoding and write paths and they passed. 
- Ran the sinks-related test folder `pytest tests/nodes/sinks` to exercise edge cases and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7168479cc832ba369f2ca89e1551b)