### PR TITLE
Add copy-to-clipboard button to message banner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,14 +16,29 @@ once a first tagged release is cut.
   left of the Close button**, with a thin vertical separator
   between the two so a slightly off-target click on Copy cannot
   accidentally dismiss the banner. Copy puts the current message
-  text on the system clipboard (`QGuiApplication.clipboard()`),
-  which makes long stack traces and node-error messages much
-  easier to paste into bug reports. The three per-severity
-  stylesheets (`_ERROR_STYLE` / `_WARNING_STYLE` / `_INFO_STYLE`)
-  were collapsed into a single `_STYLE_TEMPLATE` parameterised by
-  palette, dropping ~60 lines of duplication and keeping the new
-  Copy button / separator styled in lockstep with the existing
-  Close button.
+  text on the system clipboard, which makes long stack traces and
+  node-error messages much easier to paste into bug reports. The
+  three per-severity stylesheets (`_ERROR_STYLE` / `_WARNING_STYLE`
+  / `_INFO_STYLE`) were collapsed into a single `_STYLE_TEMPLATE`
+  parameterised by palette, dropping ~60 lines of duplication and
+  keeping the new Copy button / separator styled in lockstep with
+  the existing Close button.
+
+### Changed (Clipboard writes go through a shared helper)
+
+- **New `ui.clipboard` module centralises every copy-to-clipboard
+  call site.** The previous implementation had duplicated
+  `QGuiApplication.clipboard().setText/setImage` logic in
+  `ui.node_item._HeaderButtonItem._dispatch_command_result` and
+  ad-hoc in the new banner copy button. Both now route through
+  `clipboard.copy_text` / `clipboard.copy_image` /
+  `clipboard.dispatch_command_result`, which collapses the None
+  guard, the numpy → QImage conversion, and the user-visible
+  notifications into one place. Pure refactor — no user-visible
+  change beyond the new banner button itself. Drops the now-unused
+  `numpy`, `QGuiApplication`, `notifications`, and `logging`
+  imports from `ui.node_item` and removes the static
+  `_dispatch_command_result` wrapper.
 
 ### Fixed (Flow run failure no longer aborts the process on Windows)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,21 @@ once a first tagged release is cut.
 
 ## [Unreleased]
 
+### Added (Copy-to-clipboard button on the error/notification banner)
+
+- **The floating message banner now exposes a Copy button to the
+  left of the Close button**, with a thin vertical separator
+  between the two so a slightly off-target click on Copy cannot
+  accidentally dismiss the banner. Copy puts the current message
+  text on the system clipboard (`QGuiApplication.clipboard()`),
+  which makes long stack traces and node-error messages much
+  easier to paste into bug reports. The three per-severity
+  stylesheets (`_ERROR_STYLE` / `_WARNING_STYLE` / `_INFO_STYLE`)
+  were collapsed into a single `_STYLE_TEMPLATE` parameterised by
+  palette, dropping ~60 lines of duplication and keeping the new
+  Copy button / separator styled in lockstep with the existing
+  Close button.
+
 ### Fixed (Flow run failure no longer aborts the process on Windows)
 
 - **`_finalize_run` is now wired to `QThread.finished` instead of

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,14 @@ once a first tagged release is cut.
   parameterised by palette, dropping ~60 lines of duplication and
   keeping the new Copy button / separator styled in lockstep with
   the existing Close button.
+- **Both header buttons now have visible hover and pressed
+  states.** The previous stylesheet only nudged the text colour
+  one shade on hover, which read as flat — the buttons did not
+  feel clickable. They now grow a translucent white background on
+  hover (`rgba(255,255,255,0.18)`) and a stronger one when
+  pressed (`0.32`), with a 3px border-radius and 2px vertical
+  padding so the highlighted region reads as a proper button
+  surface.
 
 ### Changed (Clipboard writes go through a shared helper)
 

--- a/doc/internal/refactoring.md
+++ b/doc/internal/refactoring.md
@@ -17,7 +17,9 @@ Status markers:
 **Last reviewed:** 2026-05-03 (single-input filters now forward
 `IoData.meta` to their outputs and Mosaic propagates from the first
 non-empty cell — PR #293; the multi-input merge convention itself
-is now tracked as M14 / #294).
+is now tracked as M14 / #294; clipboard writes routed through new
+`ui.clipboard` helper, branch
+`claude/error-window-copy-button-Hn9um`).
 
 ## High
 
@@ -193,6 +195,21 @@ key dispatch to a Qt implementation detail.
 flag from `NodeItem`.
 
 ## Resolved
+
+### DONE — Duplicated clipboard write logic across the UI
+
+Resolved 2026-05-03 on branch
+`claude/error-window-copy-button-Hn9um`.
+
+`ui.node_item._HeaderButtonItem._dispatch_command_result` had its
+own `QGuiApplication.clipboard().setText / setImage` plumbing, the
+new message-banner Copy button was about to grow another, and the
+`numpy → QImage` failure path was duplicated alongside. Centralised
+into `ui.clipboard` (`copy_text`, `copy_image`,
+`dispatch_command_result`); both call sites now delegate. Frees
+`ui.node_item` of `numpy`, `QGuiApplication`, `notifications`, and
+`logging` imports along with the static `_dispatch_command_result`
+wrapper.
 
 ### DONE — PolarSpectrum was a too-special monolith
 

--- a/src/constants.py
+++ b/src/constants.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 APP_NAME:         str = "Stjörnhorn"
 APP_DISPLAY_NAME: str = "Stjörnhorn"
-APP_VERSION:      str = "0.3.0.65"
+APP_VERSION:      str = "0.3.0.66"
 API_URL:    str = "https://beltoforion.de"
 
 # Public, online-hosted version of the welcome page. The start page tries

--- a/src/constants.py
+++ b/src/constants.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 APP_NAME:         str = "Stjörnhorn"
 APP_DISPLAY_NAME: str = "Stjörnhorn"
-APP_VERSION:      str = "0.3.0.64"
+APP_VERSION:      str = "0.3.0.65"
 API_URL:    str = "https://beltoforion.de"
 
 # Public, online-hosted version of the welcome page. The start page tries

--- a/src/constants.py
+++ b/src/constants.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 APP_NAME:         str = "Stjörnhorn"
 APP_DISPLAY_NAME: str = "Stjörnhorn"
-APP_VERSION:      str = "0.3.0.66"
+APP_VERSION:      str = "0.3.0.67"
 API_URL:    str = "https://beltoforion.de"
 
 # Public, online-hosted version of the welcome page. The start page tries

--- a/src/ui/clipboard.py
+++ b/src/ui/clipboard.py
@@ -1,0 +1,87 @@
+"""Centralised clipboard write helpers for the Qt UI.
+
+All copy-to-clipboard call sites should funnel through this module so
+that the ``QGuiApplication.clipboard()`` lookup, its ``None`` guard,
+the ``numpy → QImage`` conversion and the user-visible feedback stay
+consistent across the app. Extending the behaviour (e.g. propagating
+to MIME data, supporting a secondary selection on X11, adding a
+visual flash) becomes a single edit instead of a hunt through every
+caller.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import numpy as np
+from PySide6.QtGui import QGuiApplication
+
+from core import notifications
+
+logger = logging.getLogger(__name__)
+
+
+def copy_text(text: str) -> bool:
+    """Push *text* onto the system clipboard.
+
+    Returns ``True`` if the clipboard was written, ``False`` when no
+    clipboard is available (headless environments, early startup
+    before ``QGuiApplication`` has a chance to materialise one). Does
+    not emit a notification — leave that to the caller so UI surfaces
+    that already give feedback (e.g. the message banner the user just
+    clicked) don't clobber themselves.
+    """
+    clipboard = QGuiApplication.clipboard()
+    if clipboard is None:
+        return False
+    clipboard.setText(text)
+    return True
+
+
+def copy_image(frame: np.ndarray) -> bool:
+    """Push *frame* onto the system clipboard as a ``QImage``.
+
+    Returns ``True`` on success, ``False`` if the clipboard is
+    unavailable or the array could not be converted. Conversion
+    failures are logged and reported via :mod:`notifications` so the
+    user gets a warning instead of a silent miss; callers do not need
+    their own try/except.
+    """
+    clipboard = QGuiApplication.clipboard()
+    if clipboard is None:
+        return False
+    # Local import: ``ui.preview_widgets`` pulls in OpenCV / heavy Qt
+    # widget code that text-only callers (the message banner) do not
+    # need at import time.
+    from ui.preview_widgets import numpy_to_qimage
+
+    try:
+        qimg = numpy_to_qimage(frame)
+    except Exception as exc:
+        logger.exception("Clipboard: numpy → QImage conversion failed")
+        notifications.warn(f"Could not copy image: {exc}")
+        return False
+    clipboard.setImage(qimg)
+    return True
+
+
+def dispatch_command_result(result: object) -> None:
+    """Send a node :class:`Command` handler's return value to the
+    clipboard.
+
+    - ``str`` (non-empty) → text + "Copied to clipboard" notification.
+    - :class:`numpy.ndarray` → image + "Image copied to clipboard"
+      notification.
+    - falsy (``None``, ``""``) or any other type → silent no-op so a
+      header click costs nothing when there is nothing to copy yet.
+    """
+    if isinstance(result, str):
+        if not result:
+            return
+        if copy_text(result):
+            notifications.info("Copied to clipboard")
+        return
+    if isinstance(result, np.ndarray):
+        if copy_image(result):
+            notifications.info("Image copied to clipboard")
+        return

--- a/src/ui/message_banner.py
+++ b/src/ui/message_banner.py
@@ -68,11 +68,17 @@ class MessageBanner(QFrame):
             color: {title_fg};
             background: transparent;
             border: none;
-            padding: 0 6px;
+            border-radius: 3px;
+            padding: 2px 6px;
             font-size: 14px;
         }}
         QFrame#MessageBanner QToolButton:hover {{
             color: #ffffff;
+            background: rgba(255, 255, 255, 0.18);
+        }}
+        QFrame#MessageBanner QToolButton:pressed {{
+            color: #ffffff;
+            background: rgba(255, 255, 255, 0.32);
         }}
         QFrame#MessageBannerSeparator {{
             color: {border};

--- a/src/ui/message_banner.py
+++ b/src/ui/message_banner.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from PySide6.QtCore import QEvent, QObject, Qt
+from PySide6.QtGui import QGuiApplication
 from PySide6.QtWidgets import (
     QFrame,
     QGraphicsOpacityEffect,
@@ -40,111 +41,72 @@ class MessageBanner(QFrame):
     MIN_HEIGHT: int = 120
     OPACITY: float = 0.85
 
-    # Per-severity palette. Both share the same shape so swapping
-    # styles at show-time is a single setStyleSheet call. The
-    # warning palette stays warm-amber so it reads as "attention
-    # needed" without the "something is broken" weight of red.
-    _ERROR_STYLE: str = """
-        QFrame#MessageBanner {
-            background: #5a1e22;
-            border: 1px solid #e05050;
+    # Per-severity palette. Each style is built from the same template so
+    # adding a new state (tweaking the header buttons, separator, etc.)
+    # only edits one place. The warning palette stays warm-amber so it
+    # reads as "attention needed" without the "something is broken"
+    # weight of red. Selectors target every QToolButton inside the banner
+    # so the copy and close buttons share the same look without per-name
+    # rules.
+    _STYLE_TEMPLATE: str = """
+        QFrame#MessageBanner {{
+            background: {bg};
+            border: 1px solid {border};
             border-radius: 4px;
-        }
-        QLabel#MessageBannerTitle {
-            color: #ffdcdc;
+        }}
+        QLabel#MessageBannerTitle {{
+            color: {title_fg};
             font-weight: bold;
             background: transparent;
-        }
-        QLabel#MessageBannerMessage {
-            color: #ffeaea;
+        }}
+        QLabel#MessageBannerMessage {{
+            color: {message_fg};
             background: transparent;
-        }
-        QToolButton#MessageBannerClose {
-            color: #ffdcdc;
+        }}
+        QFrame#MessageBanner QToolButton {{
+            color: {title_fg};
             background: transparent;
             border: none;
             padding: 0 6px;
             font-size: 14px;
-        }
-        QToolButton#MessageBannerClose:hover {
+        }}
+        QFrame#MessageBanner QToolButton:hover {{
             color: #ffffff;
-        }
-        QScrollArea#MessageBannerScroll {
+        }}
+        QFrame#MessageBannerSeparator {{
+            color: {border};
+            background: {border};
+            max-width: 1px;
+        }}
+        QScrollArea#MessageBannerScroll {{
             background: transparent;
             border: none;
-        }
-        QScrollArea#MessageBannerScroll > QWidget > QWidget {
+        }}
+        QScrollArea#MessageBannerScroll > QWidget > QWidget {{
             background: transparent;
-        }
+        }}
     """
 
-    _WARNING_STYLE: str = """
-        QFrame#MessageBanner {
-            background: #5a4a1e;
-            border: 1px solid #e0b850;
-            border-radius: 4px;
-        }
-        QLabel#MessageBannerTitle {
-            color: #fff0c8;
-            font-weight: bold;
-            background: transparent;
-        }
-        QLabel#MessageBannerMessage {
-            color: #fff5d8;
-            background: transparent;
-        }
-        QToolButton#MessageBannerClose {
-            color: #fff0c8;
-            background: transparent;
-            border: none;
-            padding: 0 6px;
-            font-size: 14px;
-        }
-        QToolButton#MessageBannerClose:hover {
-            color: #ffffff;
-        }
-        QScrollArea#MessageBannerScroll {
-            background: transparent;
-            border: none;
-        }
-        QScrollArea#MessageBannerScroll > QWidget > QWidget {
-            background: transparent;
-        }
-    """
+    _ERROR_STYLE: str = _STYLE_TEMPLATE.format(
+        bg="#5a1e22",
+        border="#e05050",
+        title_fg="#ffdcdc",
+        message_fg="#ffeaea",
+    )
 
-    _INFO_STYLE: str = """
-        QFrame#MessageBanner {
-            background: #1e3a5a;
-            border: 1px solid #5090e0;
-            border-radius: 4px;
-        }
-        QLabel#MessageBannerTitle {
-            color: #d8e8ff;
-            font-weight: bold;
-            background: transparent;
-        }
-        QLabel#MessageBannerMessage {
-            color: #e8f0ff;
-            background: transparent;
-        }
-        QToolButton#MessageBannerClose {
-            color: #d8e8ff;
-            background: transparent;
-            border: none;
-            padding: 0 6px;
-            font-size: 14px;
-        }
-        QToolButton#MessageBannerClose:hover {
-            color: #ffffff;
-        }
-        QScrollArea#MessageBannerScroll {
-            background: transparent;
-            border: none;
-        }
-        QScrollArea#MessageBannerScroll > QWidget > QWidget {
-            background: transparent;
-        }
-    """
+    _WARNING_STYLE: str = _STYLE_TEMPLATE.format(
+        bg="#5a4a1e",
+        border="#e0b850",
+        title_fg="#fff0c8",
+        message_fg="#fff5d8",
+    )
+
+    _INFO_STYLE: str = _STYLE_TEMPLATE.format(
+        bg="#1e3a5a",
+        border="#5090e0",
+        title_fg="#d8e8ff",
+        message_fg="#e8f0ff",
+    )
 
     def __init__(self, parent: QWidget) -> None:
         super().__init__(parent)
@@ -164,6 +126,21 @@ class MessageBanner(QFrame):
         self._title = QLabel("Error")
         self._title.setObjectName("MessageBannerTitle")
 
+        self._copy = QToolButton()
+        self._copy.setObjectName("MessageBannerCopy")
+        self._copy.setText("⧉")
+        self._copy.setToolTip("Copy message to clipboard")
+        self._copy.setCursor(Qt.CursorShape.PointingHandCursor)
+        self._copy.clicked.connect(self._copy_to_clipboard)
+
+        # Vertical hairline keeps a visual gap between Copy and Close so a
+        # mis-aimed click on the copy button does not dismiss the banner.
+        self._separator = QFrame()
+        self._separator.setObjectName("MessageBannerSeparator")
+        self._separator.setFrameShape(QFrame.Shape.VLine)
+        self._separator.setFrameShadow(QFrame.Shadow.Plain)
+        self._separator.setFixedWidth(1)
+
         self._close = QToolButton()
         self._close.setObjectName("MessageBannerClose")
         self._close.setText("✕")
@@ -176,6 +153,8 @@ class MessageBanner(QFrame):
         header.setSpacing(8)
         header.addWidget(self._title)
         header.addStretch(1)
+        header.addWidget(self._copy)
+        header.addWidget(self._separator)
         header.addWidget(self._close)
 
         self._message = QLabel("")
@@ -222,6 +201,12 @@ class MessageBanner(QFrame):
         no problem implied.
         """
         self._show(message, title, self._INFO_STYLE)
+
+    def _copy_to_clipboard(self) -> None:
+        """Copy the current banner message text onto the system clipboard."""
+        clipboard = QGuiApplication.clipboard()
+        if clipboard is not None:
+            clipboard.setText(self._message.text())
 
     def _show(self, message: str, title: str, style: str) -> None:
         # setStyleSheet on each show so the palette flips correctly

--- a/src/ui/message_banner.py
+++ b/src/ui/message_banner.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from PySide6.QtCore import QEvent, QObject, Qt
-from PySide6.QtGui import QGuiApplication
 from PySide6.QtWidgets import (
     QFrame,
     QGraphicsOpacityEffect,
@@ -12,6 +11,8 @@ from PySide6.QtWidgets import (
     QVBoxLayout,
     QWidget,
 )
+
+from ui import clipboard
 
 
 class MessageBanner(QFrame):
@@ -203,10 +204,14 @@ class MessageBanner(QFrame):
         self._show(message, title, self._INFO_STYLE)
 
     def _copy_to_clipboard(self) -> None:
-        """Copy the current banner message text onto the system clipboard."""
-        clipboard = QGuiApplication.clipboard()
-        if clipboard is not None:
-            clipboard.setText(self._message.text())
+        """Copy the current banner message text onto the system clipboard.
+
+        Routed through :mod:`ui.clipboard` so the same write path is
+        used everywhere (banner, node header buttons, future call
+        sites). No notification is fired — that would just clobber
+        the very banner the user clicked on.
+        """
+        clipboard.copy_text(self._message.text())
 
     def _show(self, message: str, title: str, style: str) -> None:
         # setStyleSheet on each show so the palette flips correctly

--- a/src/ui/node_item.py
+++ b/src/ui/node_item.py
@@ -1,9 +1,6 @@
 from __future__ import annotations
 
-import logging
 from typing_extensions import override
-
-import numpy as np
 
 from PySide6.QtCore import QEvent, QObject, QPointF, QRectF, Qt, QTimer, Signal
 from PySide6.QtGui import (
@@ -11,7 +8,6 @@ from PySide6.QtGui import (
     QColor,
     QFont,
     QFontMetricsF,
-    QGuiApplication,
     QPainter,
     QPainterPath,
     QPen,
@@ -23,7 +19,6 @@ from PySide6.QtWidgets import (
     QWidget,
 )
 
-from core import notifications
 from core.node_base import (
     Command,
     HeaderItem,
@@ -34,10 +29,11 @@ from core.node_base import (
     TickBadge,
     Toggle,
 )
+from ui import clipboard
 from ui.icons import paint_material_glyph
 from ui.param_widgets import ParamWidgetBase, build_param_widget
 from ui.port_item import PortItem
-from ui.preview_widgets import build_preview_widget, numpy_to_qimage
+from ui.preview_widgets import build_preview_widget
 from ui.theme import (
     BORDER_FROM_CATEGORY,
     FILTER_HEADER_COLOR,
@@ -53,9 +49,6 @@ from ui.theme import (
     SINK_HEADER_COLOR,
     SOURCE_HEADER_COLOR,
 )
-
-logger = logging.getLogger(__name__)
-
 
 class _NodeSignals(QObject):
     """QObject signal carrier for :class:`NodeItem`.
@@ -264,7 +257,7 @@ class _HeaderButtonItem(QGraphicsItem):
             if self.boundingRect().contains(event.pos()):
                 result = self._item.handler()
                 if isinstance(self._item, Command):
-                    self._dispatch_command_result(result)
+                    clipboard.dispatch_command_result(result)
                 if isinstance(self._item, Toggle):
                     # A toggle flips node state that affects what the
                     # flow does on the next run; emit ``param_changed``
@@ -277,30 +270,6 @@ class _HeaderButtonItem(QGraphicsItem):
             event.accept()
             return
         super().mouseReleaseEvent(event)
-
-    @staticmethod
-    def _dispatch_command_result(result: object) -> None:
-        """Send a :class:`Command` handler's return value to the
-        clipboard. Strings go as text, ndarrays as images; anything
-        falsy (``None``, ``""``) is a silent no-op so the click costs
-        nothing when there's nothing to copy yet."""
-        if isinstance(result, str):
-            if not result:
-                return
-            QGuiApplication.clipboard().setText(result)
-            notifications.info("Copied to clipboard")
-            return
-        if isinstance(result, np.ndarray):
-            try:
-                qimg = numpy_to_qimage(result)
-            except Exception as exc:
-                logger.exception("Header command: image-copy conversion failed")
-                notifications.warn(f"Could not copy image: {exc}")
-                return
-            QGuiApplication.clipboard().setImage(qimg)
-            notifications.info("Image copied to clipboard")
-            return
-        # Everything else (None, falsy str, …) is a deliberate no-op.
 
 
 class _HeaderSeparatorItem(QGraphicsItem):


### PR DESCRIPTION
## Summary

This PR adds a Copy button to the floating message banner (error/warning/info notifications) and refactors clipboard write logic into a shared helper module to eliminate duplication across the UI.

## Key Changes

- **Message banner Copy button**: Added a new copy-to-clipboard button (⧉) to the left of the Close button on the message banner header, with a thin vertical separator between them to prevent accidental dismissal. Clicking copies the current message text to the system clipboard.

- **Stylesheet refactoring**: Collapsed three separate per-severity stylesheets (`_ERROR_STYLE`, `_WARNING_STYLE`, `_INFO_STYLE`) into a single parameterized `_STYLE_TEMPLATE`, reducing duplication by ~60 lines while keeping all three severity levels styled consistently.

- **Enhanced button styling**: Both header buttons (Copy and Close) now have visible hover and pressed states with translucent white backgrounds (`rgba(255,255,255,0.18)` on hover, `0.32` when pressed) and proper border-radius/padding to feel like clickable surfaces.

- **New `ui.clipboard` module**: Centralized all clipboard write operations into a dedicated module with three functions:
  - `copy_text(text)`: Write text to clipboard
  - `copy_image(frame)`: Convert numpy array to QImage and write to clipboard
  - `dispatch_command_result(result)`: Route Command handler results to clipboard with appropriate notifications
  
  This eliminates duplicated `QGuiApplication.clipboard()` logic, None guards, and numpy→QImage conversion code.

- **Refactored `ui.node_item`**: Removed the static `_dispatch_command_result` method and now delegates to `clipboard.dispatch_command_result()`. Cleaned up unused imports (`numpy`, `QGuiApplication`, `notifications`, `logging`).

## Implementation Details

- The separator between Copy and Close buttons is a `QFrame` with `VLine` shape, styled to match the border color of each severity level via the template.
- The Copy button does not emit a notification (unlike header button commands) to avoid clobbering the banner the user just clicked.
- Clipboard availability is gracefully handled with None checks; operations return `bool` to indicate success/failure.
- Image conversion failures are logged and reported via notifications rather than silently failing.

https://claude.ai/code/session_01HLTZXbRAckWiTW5Xrrxyr7