### PR TITLE
Improve sink error messages with non-ASCII character detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,17 +12,16 @@ once a first tagged release is cut.
 
 ### Changed (Sink write failures now name the offending non-ASCII characters)
 
-- **`FileSink` and `VideoSink` failure messages explicitly call out
-  umlauts / accented letters in the path.** OpenCV's writers
+- **`FileSink` and `VideoSink` failure messages now list the
+  non-ASCII characters in the path.** OpenCV's writers
   (`cv2.imwrite`, `cv2.VideoWriter`) silently fail on Windows when
   the path contains characters outside the active ANSI code page —
   `C:\Users\…\stjörnhorn\output\…` was reported as a generic
-  "filename invalid for the current OS", giving no hint at the real
-  cause. A new `core.path_utils.write_failure_hint` helper inspects
-  the path and produces an actionable message that lists the
-  offending characters and points at the Windows ANSI-encoding
-  cause; ASCII-only paths still get the generic note. Both sinks
-  share the helper so the diagnostic stays consistent.
+  "filename invalid for the current OS" with no pointer to the real
+  cause. A new `core.path_utils.write_failure_hint` helper appends
+  `The path contains non-ASCII characters ('ö')` to the message
+  when the path has any; ASCII-only paths still get the generic
+  note. Both sinks share the helper.
 
 ### Added (Copy-to-clipboard button on the error/notification banner)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,20 @@ once a first tagged release is cut.
 
 ## [Unreleased]
 
+### Changed (Sink write failures now name the offending non-ASCII characters)
+
+- **`FileSink` and `VideoSink` failure messages explicitly call out
+  umlauts / accented letters in the path.** OpenCV's writers
+  (`cv2.imwrite`, `cv2.VideoWriter`) silently fail on Windows when
+  the path contains characters outside the active ANSI code page —
+  `C:\Users\…\stjörnhorn\output\…` was reported as a generic
+  "filename invalid for the current OS", giving no hint at the real
+  cause. A new `core.path_utils.write_failure_hint` helper inspects
+  the path and produces an actionable message that lists the
+  offending characters and points at the Windows ANSI-encoding
+  cause; ASCII-only paths still get the generic note. Both sinks
+  share the helper so the diagnostic stays consistent.
+
 ### Added (Copy-to-clipboard button on the error/notification banner)
 
 - **The floating message banner now exposes a Copy button to the

--- a/src/constants.py
+++ b/src/constants.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 APP_NAME:         str = "Stjörnhorn"
 APP_DISPLAY_NAME: str = "Stjörnhorn"
-APP_VERSION:      str = "0.3.0.67"
+APP_VERSION:      str = "0.3.0.68"
 API_URL:    str = "https://beltoforion.de"
 
 # Public, online-hosted version of the welcome page. The start page tries

--- a/src/core/path_utils.py
+++ b/src/core/path_utils.py
@@ -51,3 +51,37 @@ def resolve_against(path: Path, base_dir: Path) -> Path:
     if path.is_absolute():
         return path
     return base_dir / path
+
+
+_GENERIC_WRITE_HINT = (
+    "This often means the rendered filename/path is invalid for the "
+    "current OS."
+)
+
+
+def non_ascii_chars(path: Path | str) -> list[str]:
+    """Return the sorted, de-duplicated non-ASCII characters in *path*."""
+    return sorted({c for c in str(path) if ord(c) > 127})
+
+
+def write_failure_hint(path: Path | str) -> str:
+    """Diagnostic hint for OpenCV file-write failures on *path*.
+
+    OpenCV's writers (``cv2.imwrite``, ``cv2.VideoWriter``) on Windows
+    route through the C runtime's ANSI ``fopen``, which silently fails
+    on any path containing characters outside the active code page —
+    most commonly umlauts and accented letters in the user profile or
+    project directory. The sinks call this helper to turn that opaque
+    failure into an actionable error message; if the path is plain
+    ASCII, the generic 'invalid filename' note is returned instead.
+    """
+    bad = non_ascii_chars(path)
+    if not bad:
+        return _GENERIC_WRITE_HINT
+    rendered = ", ".join(f"'{c}'" for c in bad)
+    return (
+        f"The path contains non-ASCII characters ({rendered}) — OpenCV's "
+        "file writer uses the C runtime's ANSI encoding on Windows and "
+        "silently fails on umlauts / accented letters. Move the output "
+        "directory to an ASCII-only path."
+    )

--- a/src/core/path_utils.py
+++ b/src/core/path_utils.py
@@ -79,9 +79,4 @@ def write_failure_hint(path: Path | str) -> str:
     if not bad:
         return _GENERIC_WRITE_HINT
     rendered = ", ".join(f"'{c}'" for c in bad)
-    return (
-        f"The path contains non-ASCII characters ({rendered}) — OpenCV's "
-        "file writer uses the C runtime's ANSI encoding on Windows and "
-        "silently fails on umlauts / accented letters. Move the output "
-        "directory to an ASCII-only path."
-    )
+    return f"The path contains non-ASCII characters ({rendered})."

--- a/src/nodes/sinks/file_sink.py
+++ b/src/nodes/sinks/file_sink.py
@@ -12,7 +12,7 @@ from core.filename_template import expand as expand_template
 from core.io_data import IMAGE_TYPES
 from core.node_base import SinkNodeBase
 from core.params import FilePathParam
-from core.path_utils import resolve_against
+from core.path_utils import resolve_against, write_failure_hint
 from core.port import InputPort
 
 
@@ -87,8 +87,7 @@ class FileSink(SinkNodeBase):
         if not written:
             raise OSError(
                 f"File Sink failed to write image to {output!s}. "
-                "This often means the rendered filename/path is invalid "
-                "for the current OS."
+                f"{write_failure_hint(output)}"
             )
 
     # ── Internals ──────────────────────────────────────────────────────────────

--- a/src/nodes/sinks/video_sink.py
+++ b/src/nodes/sinks/video_sink.py
@@ -12,7 +12,7 @@ from core.filename_template import expand as expand_template
 from core.io_data import IMAGE_TYPES, IoData
 from core.node_base import SinkNodeBase
 from core.params import EnumParam, FilePathParam, FloatParam
-from core.path_utils import resolve_against
+from core.path_utils import resolve_against, write_failure_hint
 from core.port import InputPort
 
 
@@ -141,7 +141,10 @@ class VideoSink(SinkNodeBase):
         )
         if not self._writer.isOpened():
             self._writer = None
-            raise OSError(f"cv2.VideoWriter failed to open: {path}")
+            raise OSError(
+                f"cv2.VideoWriter failed to open: {path}. "
+                f"{write_failure_hint(path)}"
+            )
 
     def _release_writer(self) -> None:
         if self._writer is not None:

--- a/tests/test_file_sink.py
+++ b/tests/test_file_sink.py
@@ -144,7 +144,6 @@ def test_imwrite_failure_on_ascii_path_raises_generic_oserror(
     assert "out.png" in msg
     assert "invalid" in msg.lower()
     assert "non-ASCII" not in msg
-    assert "umlaut" not in msg.lower()
 
 
 def test_imwrite_failure_on_umlaut_path_calls_out_offending_chars(
@@ -165,8 +164,6 @@ def test_imwrite_failure_on_umlaut_path_calls_out_offending_chars(
     assert "File Sink failed to write image" in msg
     assert "non-ASCII" in msg
     assert "'ö'" in msg
-    assert "umlaut" in msg.lower()
-    assert "ANSI" in msg or "encoding" in msg.lower()
 
 
 def test_imwrite_failure_message_lists_each_offender_once(

--- a/tests/test_file_sink.py
+++ b/tests/test_file_sink.py
@@ -11,7 +11,9 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import cv2
 import numpy as np
+import pytest
 
 from core.io_data import IoData, IoDataType, IoMeta
 from core.port import OutputPort
@@ -105,3 +107,89 @@ def test_sink_has_no_tick_port(tmp_path: Path) -> None:
     sink = FileSink()
     assert len(sink.inputs) == 1
     assert sink.inputs[0].name == "image"
+
+
+# ── Error handling: cv2.imwrite failure ──────────────────────────────────────
+#
+# ``cv2.imwrite`` returns False instead of raising when the underlying
+# C-runtime ``fopen`` rejects the path. The sink's job is to translate
+# that opaque False into an OSError whose message points at the most
+# likely cause — non-ASCII characters in the path on Windows. The tests
+# here monkeypatch ``cv2.imwrite`` to simulate the failure so they run
+# the same way on every platform (Linux's GLIBC fopen accepts UTF-8).
+
+
+def _drive_one_frame(sink: FileSink) -> None:
+    image_feeder = OutputPort("img", {IoDataType.IMAGE})
+    image_feeder.connect(sink.inputs[0])
+    sink.before_run()
+    image_feeder.send(IoData.from_image(_make_image()))
+
+
+def test_imwrite_failure_on_ascii_path_raises_generic_oserror(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When cv2 refuses an ASCII path the message stays generic — we
+    have no specific diagnosis, so the user gets the 'invalid for the
+    current OS' fallback instead of a misleading umlaut hint."""
+    monkeypatch.setattr(cv2, "imwrite", lambda _path, _img: False)
+    sink = FileSink()
+    sink.output_path = tmp_path / "out.png"
+
+    with pytest.raises(OSError) as exc_info:
+        _drive_one_frame(sink)
+
+    msg = str(exc_info.value)
+    assert "File Sink failed to write image" in msg
+    assert "out.png" in msg
+    assert "invalid" in msg.lower()
+    assert "non-ASCII" not in msg
+    assert "umlaut" not in msg.lower()
+
+
+def test_imwrite_failure_on_umlaut_path_calls_out_offending_chars(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The headline regression: a path with ``ö`` (e.g. the user's
+    home folder ``stjörnhorn``) must produce an error message that
+    explicitly names the offending character and the encoding cause,
+    so the user can act on it without consulting the source."""
+    monkeypatch.setattr(cv2, "imwrite", lambda _path, _img: False)
+    sink = FileSink()
+    sink.output_path = tmp_path / "stjörnhorn" / "out.png"
+
+    with pytest.raises(OSError) as exc_info:
+        _drive_one_frame(sink)
+
+    msg = str(exc_info.value)
+    assert "File Sink failed to write image" in msg
+    assert "non-ASCII" in msg
+    assert "'ö'" in msg
+    assert "umlaut" in msg.lower()
+    assert "ANSI" in msg or "encoding" in msg.lower()
+
+
+def test_imwrite_failure_message_lists_each_offender_once(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``ä`` and ``ö`` both present → both surface, each exactly once.
+    Sorted order keeps the message deterministic across runs."""
+    monkeypatch.setattr(cv2, "imwrite", lambda _path, _img: False)
+    sink = FileSink()
+    sink.output_path = tmp_path / "äöäö" / "out.png"
+
+    with pytest.raises(OSError) as exc_info:
+        _drive_one_frame(sink)
+
+    msg = str(exc_info.value)
+    assert msg.count("'ä'") == 1
+    assert msg.count("'ö'") == 1
+
+
+def test_imwrite_success_does_not_raise(tmp_path: Path) -> None:
+    """Sanity counterpart to the failure tests: when cv2 actually
+    writes the file, no error path triggers."""
+    sink = FileSink()
+    sink.output_path = tmp_path / "ok.png"
+    _drive_one_frame(sink)
+    assert (tmp_path / "ok.png").exists()

--- a/tests/test_path_utils.py
+++ b/tests/test_path_utils.py
@@ -3,7 +3,12 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from core.path_utils import resolve_against, store_relative_to
+from core.path_utils import (
+    non_ascii_chars,
+    resolve_against,
+    store_relative_to,
+    write_failure_hint,
+)
 
 
 # ── store_relative_to ────────────────────────────────────────────────────────
@@ -91,6 +96,59 @@ def test_resolve_absolute_passes_through() -> None:
     abs_path = Path("/elsewhere/video.mp4")
     out = resolve_against(abs_path, Path("/input"))
     assert out == abs_path
+
+
+# ── non_ascii_chars / write_failure_hint ─────────────────────────────────────
+
+
+def test_non_ascii_chars_returns_empty_for_pure_ascii() -> None:
+    assert non_ascii_chars(Path("/home/user/output/frame_0001.png")) == []
+
+
+def test_non_ascii_chars_collects_unique_sorted_offenders() -> None:
+    """Multiple occurrences of the same offender collapse; the result
+    is sorted so the message is stable across runs."""
+    out = non_ascii_chars(Path(r"C:\Users\jürgen\stjörnhorn\öutput\f.png"))
+    assert out == ["ö", "ü"]
+    assert non_ascii_chars("äöüäö") == ["ä", "ö", "ü"]
+
+
+def test_non_ascii_chars_accepts_string_input() -> None:
+    assert non_ascii_chars("plain") == []
+    assert non_ascii_chars("café") == ["é"]
+
+
+def test_write_failure_hint_pure_ascii_falls_back_to_generic() -> None:
+    """An ASCII path yields the generic 'invalid filename' note —
+    we have no specific diagnosis to offer in that case."""
+    hint = write_failure_hint(Path("/tmp/output/frame.png"))
+    assert "non-ASCII" not in hint
+    assert "invalid" in hint.lower()
+
+
+def test_write_failure_hint_flags_non_ascii_path_with_offending_chars() -> None:
+    """A path with umlauts / accents must surface the actual offending
+    characters and explicitly mention the Windows ANSI-encoding cause,
+    so the user can map the message to a fix without guessing."""
+    hint = write_failure_hint(
+        Path(r"C:\Users\user\Documents\GitHub\stjörnhorn\output\00017.png"),
+    )
+    assert "non-ASCII" in hint
+    assert "'ö'" in hint
+    assert "umlaut" in hint.lower()
+    assert "ANSI" in hint or "encoding" in hint.lower()
+
+
+def test_write_failure_hint_lists_each_offending_char_once() -> None:
+    """Repeated offenders collapse to one mention each; sorted order
+    keeps the message deterministic."""
+    hint = write_failure_hint("/tmp/öäöä/ä.png")
+    assert hint.count("'ä'") == 1
+    assert hint.count("'ö'") == 1
+    assert hint.index("'ä'") < hint.index("'ö'")
+
+
+# ── resolve_against ──────────────────────────────────────────────────────────
 
 
 def test_round_trip_inside_base(tmp_path: Path) -> None:

--- a/tests/test_path_utils.py
+++ b/tests/test_path_utils.py
@@ -128,15 +128,12 @@ def test_write_failure_hint_pure_ascii_falls_back_to_generic() -> None:
 
 def test_write_failure_hint_flags_non_ascii_path_with_offending_chars() -> None:
     """A path with umlauts / accents must surface the actual offending
-    characters and explicitly mention the Windows ANSI-encoding cause,
-    so the user can map the message to a fix without guessing."""
+    characters so the user can map the message to a fix without guessing."""
     hint = write_failure_hint(
         Path(r"C:\Users\user\Documents\GitHub\stjörnhorn\output\00017.png"),
     )
     assert "non-ASCII" in hint
     assert "'ö'" in hint
-    assert "umlaut" in hint.lower()
-    assert "ANSI" in hint or "encoding" in hint.lower()
 
 
 def test_write_failure_hint_lists_each_offending_char_once() -> None:

--- a/tests/test_video_sink.py
+++ b/tests/test_video_sink.py
@@ -355,6 +355,4 @@ def test_videowriter_failure_on_umlaut_path_calls_out_offending_chars(
     assert "VideoWriter failed to open" in msg
     assert "non-ASCII" in msg
     assert "'ö'" in msg
-    assert "umlaut" in msg.lower()
-    assert "ANSI" in msg or "encoding" in msg.lower()
     assert node._writer is None

--- a/tests/test_video_sink.py
+++ b/tests/test_video_sink.py
@@ -274,3 +274,87 @@ def test_output_path_template_with_no_tokens_is_unchanged(
     up.finish()
 
     assert (tmp_path / "static.mp4").exists()
+
+
+# ── Error handling: cv2.VideoWriter failure ──────────────────────────────────
+#
+# ``cv2.VideoWriter`` reports failures via ``isOpened()`` rather than
+# raising — the writer object is constructed either way. When the
+# backend fails to open the container (most often: a non-ASCII path on
+# Windows), the sink's job is to translate that into an OSError whose
+# message names the likely cause. Tests monkeypatch ``cv2.VideoWriter``
+# with a stub so they run identically on every platform.
+
+
+class _FakeVideoWriter:
+    """Stand-in for ``cv2.VideoWriter`` whose ``isOpened()`` is
+    parameterised — the constructor accepts and ignores the same
+    positional args as the real class. The ``fourcc`` static method
+    is preserved because the sink calls it before constructing."""
+
+    opened: bool = False
+    fourcc = staticmethod(cv2.VideoWriter.fourcc)
+
+    def __init__(self, *_args, **_kwargs) -> None:
+        pass
+
+    def isOpened(self) -> bool:  # noqa: N802 — matches OpenCV API
+        return type(self).opened
+
+    def write(self, _frame: np.ndarray) -> None:
+        pass
+
+    def release(self) -> None:
+        pass
+
+
+def _drive_one_video_frame(node: VideoSink) -> None:
+    up = _wire(node)
+    node.before_run()
+    up.send(IoData.from_image(_bgr_frame()))
+
+
+def test_videowriter_failure_on_ascii_path_raises_generic_oserror(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The non-umlaut counterpart: a writer that won't open with an
+    ASCII path produces the generic 'invalid for the current OS' note
+    rather than the umlaut-specific hint."""
+    _FakeVideoWriter.opened = False
+    monkeypatch.setattr(cv2, "VideoWriter", _FakeVideoWriter)
+    node = VideoSink()
+    node.output_path = tmp_path / "out.mp4"
+
+    with pytest.raises(OSError) as exc_info:
+        _drive_one_video_frame(node)
+
+    msg = str(exc_info.value)
+    assert "VideoWriter failed to open" in msg
+    assert "out.mp4" in msg
+    assert "invalid" in msg.lower()
+    assert "non-ASCII" not in msg
+    # Writer was reset so a retry on the next frame won't see stale state.
+    assert node._writer is None
+
+
+def test_videowriter_failure_on_umlaut_path_calls_out_offending_chars(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Same regression as FileSink, just for video output: a path
+    with ``ö`` must surface an error that names the offender and
+    points at Windows ANSI encoding."""
+    _FakeVideoWriter.opened = False
+    monkeypatch.setattr(cv2, "VideoWriter", _FakeVideoWriter)
+    node = VideoSink()
+    node.output_path = tmp_path / "stjörnhorn" / "out.mp4"
+
+    with pytest.raises(OSError) as exc_info:
+        _drive_one_video_frame(node)
+
+    msg = str(exc_info.value)
+    assert "VideoWriter failed to open" in msg
+    assert "non-ASCII" in msg
+    assert "'ö'" in msg
+    assert "umlaut" in msg.lower()
+    assert "ANSI" in msg or "encoding" in msg.lower()
+    assert node._writer is None


### PR DESCRIPTION
## Summary

Enhanced error messages from `FileSink` and `VideoSink` to explicitly identify non-ASCII characters in file paths that cause OpenCV write failures on Windows. This addresses a common pain point where users with umlauts or accented characters in their home directories (e.g., `C:\Users\stjörnhorn\`) received generic "invalid filename" errors with no actionable guidance.

## Key Changes

- **New `core.path_utils` helpers:**
  - `non_ascii_chars(path)`: Extracts and returns sorted, deduplicated non-ASCII characters from a path
  - `write_failure_hint(path)`: Generates diagnostic messages that either list offending characters (e.g., "The path contains non-ASCII characters ('ö')") or fall back to a generic "invalid for the current OS" note for ASCII-only paths

- **Updated sink error handling:**
  - `FileSink.process_impl()`: Now appends `write_failure_hint()` to the OSError message when `cv2.imwrite()` fails
  - `VideoSink._open_writer()`: Now appends `write_failure_hint()` to the OSError message when `cv2.VideoWriter` fails to open

- **Comprehensive test coverage:**
  - `test_path_utils.py`: Tests for `non_ascii_chars()` and `write_failure_hint()` covering ASCII paths, multiple offenders, and deduplication
  - `test_file_sink.py`: Tests for FileSink error handling with monkeypatched `cv2.imwrite` failures on both ASCII and non-ASCII paths
  - `test_video_sink.py`: Tests for VideoSink error handling with monkeypatched `cv2.VideoWriter` failures, including writer state reset verification

## Implementation Details

- The solution leverages monkeypatching in tests to simulate OpenCV failures consistently across platforms (Linux's GLIBC `fopen` accepts UTF-8, so real failures only occur on Windows)
- Error messages remain generic for ASCII-only paths to avoid misleading users when the actual cause is different
- Non-ASCII character detection uses `ord(c) > 127` to identify characters outside the ASCII range
- Characters are sorted and deduplicated to ensure deterministic, readable error messages
- Version bumped to 0.3.0.68

https://claude.ai/code/session_016rUHq1C4NmQsyr9WSNhpZG