### PR TITLE
Move port legend from canvas overlay to Node Documentation dock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,27 @@ once a first tagged release is cut.
 
 ## [Unreleased]
 
+### Changed (Port legend moved into the Node Documentation dock)
+
+- **The floating "Port types / Port roles" legend that used to
+  hover in the bottom-left of the canvas is gone.** The same
+  swatches and labels now live in the empty state of the
+  *Node Documentation* dock, directly under the
+  "Select a node…" hint. Selecting a node in the palette or on
+  the canvas swaps the legend out for that node's documentation;
+  clicking empty canvas brings it back. One surface, no overlay
+  to fight for screen space with the canvas, and the legend is
+  always reachable through the dock instead of through a
+  *View ▸ Port Legend* toggle.
+- The `View ▸ Port Legend` menu entry, the `port_legend_visible`
+  user setting, and the floating overlay's close-button + event-
+  filter machinery were removed; `PortLegend` was reshaped into a
+  chrome-less `PortLegendContent` widget that any layout can host.
+  `NodeDocPanel` now uses a `QStackedWidget` to flip between the
+  empty-state widget (hint label + legend) and its existing
+  `QTextBrowser` body — no per-frame repositioning, no overlay
+  parenting tricks.
+
 ### Added (Copy-to-clipboard button on the error/notification banner)
 
 - **The floating message banner now exposes a Copy button to the

--- a/doc/index.html
+++ b/doc/index.html
@@ -628,15 +628,14 @@
 
       <h3>Port legend</h3>
       <p>
-        A floating legend in the bottom-left of the canvas explains
-        the visual language of the ports. <em>View ▸ Port Legend</em>
-        toggles it; the small <kbd>✕</kbd> on the legend hides it
-        until the menu re-enables it.
+        The visual language of the ports is documented in the
+        <em>Node Documentation</em> dock: when no node is selected,
+        the dock shows a hint line followed by the port-type and
+        port-role legend. Pick a node in the palette or on the
+        canvas and the dock switches to that node's documentation;
+        click empty canvas to clear the selection and the legend
+        comes back.
       </p>
-      <figure class="screenshot legend">
-        <img src="images/node_editor_legend.png" alt="Port legend overlay on the canvas">
-        <figcaption>Port type and role legend, anchored to the bottom-left of the canvas.</figcaption>
-      </figure>
       <p>The legend covers two axes:</p>
       <ul>
         <li><strong>Port types</strong> — each
@@ -938,8 +937,9 @@
       <p>
         Each input and output port carries a colour for its data
         type and a ring style for its role (required, optional,
-        latched). The full visual key — together with a
-        screenshot of the on-canvas legend — is in
+        latched). The full visual key — embedded in the
+        <em>Node Documentation</em> dock whenever no node is
+        selected — is described in
         <a href="#node-editor">Node editor ▸ Port legend</a>.
       </p>
 

--- a/doc/internal/documentation_guidelines.md
+++ b/doc/internal/documentation_guidelines.md
@@ -55,12 +55,12 @@ architectural documentation lives under `doc/internal/`.
   parameters, source/filter/sink colour stripe. It links to
   the editor's port-legend section rather than repeating the
   legend itself.
-- The port-legend screenshot (`doc/images/node_editor_legend.png`)
-  belongs in the `Node editor` section under a "Port legend"
-  sub-heading, alongside the description of how connections work.
-  Display it via the `figure.screenshot.legend` class so it
-  renders at roughly its on-canvas size, not at full content
-  width.
+- The port legend lives in the `Node editor` section under a
+  "Port legend" sub-heading, alongside the description of how
+  connections work. The legend itself is embedded in the
+  Node Documentation dock's empty state inside the running app —
+  the docs explain that surface in prose rather than re-shipping
+  a screenshot of a floating overlay that no longer exists.
 - The `Frame metadata` section lists every metadata key the user
   is expected to encounter — `frame_index`, `source_path`, the
   scalar-port auto-stamp rule, plus dataset attribute conventions

--- a/src/constants.py
+++ b/src/constants.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 APP_NAME:         str = "Stjörnhorn"
 APP_DISPLAY_NAME: str = "Stjörnhorn"
-APP_VERSION:      str = "0.3.0.67"
+APP_VERSION:      str = "0.3.0.68"
 API_URL:    str = "https://beltoforion.de"
 
 # Public, online-hosted version of the welcome page. The start page tries

--- a/src/ui/node_doc_panel.py
+++ b/src/ui/node_doc_panel.py
@@ -28,23 +28,24 @@ from typing import TYPE_CHECKING
 from PySide6.QtCore import QSize, Qt
 from PySide6.QtWidgets import (
     QFrame,
+    QLabel,
+    QStackedWidget,
     QTextBrowser,
     QVBoxLayout,
     QWidget,
 )
 
 from core.node_doc import describe_node
+from ui.port_legend import PortLegendContent
 
 if TYPE_CHECKING:
     from core.node_base import NodeBase
     from core.node_registry import NodeEntry
 
 
-_EMPTY_STATE_HTML: str = (
-    '<span style="color: #9a9a9f; font-style: italic;">'
+_EMPTY_STATE_HINT: str = (
     "Select a node in the palette or on the canvas to see its "
     "documentation here."
-    "</span>"
 )
 
 #: CSS for the rendered body. Tuned for a narrow dock (≈ 220 px is
@@ -294,10 +295,12 @@ _PANEL_MIN_HINT: QSize = QSize(180, 80)
 class NodeDocPanel(QWidget):
     """Dockable panel that renders the docs of the currently selected node.
 
-    Hosts a single :class:`QTextBrowser` whose body is built by
-    :func:`render_node_html`. The browser scrolls internally when
-    content overflows, so the panel's reported size stays constant
-    across selection changes (issue #233).
+    Two stacked views: a :class:`QTextBrowser` for the per-node
+    documentation, and an empty-state widget (a hint label plus the
+    embedded :class:`PortLegendContent`) that shows when nothing is
+    selected. The browser scrolls internally when content overflows,
+    so the panel's reported size stays constant across selection
+    changes (issue #233).
     """
 
     def __init__(self, parent: QWidget | None = None) -> None:
@@ -321,9 +324,38 @@ class NodeDocPanel(QWidget):
             | Qt.TextInteractionFlag.TextSelectableByKeyboard
             | Qt.TextInteractionFlag.LinksAccessibleByMouse
         )
-        outer.addWidget(self._body)
+
+        self._empty = self._build_empty_state()
+
+        self._stack = QStackedWidget(self)
+        self._stack.addWidget(self._empty)
+        self._stack.addWidget(self._body)
+        outer.addWidget(self._stack)
 
         self.clear()
+
+    def _build_empty_state(self) -> QWidget:
+        """Compose the empty-state view: hint text on top, port legend below.
+
+        The hint reuses the panel's muted-italic styling so it reads
+        as a placeholder rather than a heading; the legend underneath
+        is the same content that used to live in a floating overlay
+        on the canvas, now consolidated into one place that's only
+        visible when no node steals attention from it.
+        """
+        widget = QWidget(self)
+        layout = QVBoxLayout(widget)
+        layout.setContentsMargins(8, 8, 8, 8)
+        layout.setSpacing(12)
+
+        hint = QLabel(_EMPTY_STATE_HINT, widget)
+        hint.setWordWrap(True)
+        hint.setStyleSheet("color: #9a9a9f; font-style: italic;")
+        layout.addWidget(hint)
+
+        layout.addWidget(PortLegendContent(widget))
+        layout.addStretch(1)
+        return widget
 
     # ── Size negotiation ──────────────────────────────────────────────────────
 
@@ -355,6 +387,7 @@ class NodeDocPanel(QWidget):
             )
             return
         self._body.setHtml(render_node_html(desc))
+        self._stack.setCurrentWidget(self._body)
 
     def show_entry(self, entry: NodeEntry) -> None:
         """Render documentation for a palette :class:`NodeEntry`."""
@@ -371,8 +404,8 @@ class NodeDocPanel(QWidget):
         self.show_class(cls)
 
     def clear(self) -> None:
-        """Show the empty-state hint."""
-        self._body.setHtml(_PANEL_CSS + _EMPTY_STATE_HTML)
+        """Show the empty-state hint + port legend."""
+        self._stack.setCurrentWidget(self._empty)
 
     # ── Internals ──────────────────────────────────────────────────────────────
 
@@ -381,3 +414,4 @@ class NodeDocPanel(QWidget):
             _PANEL_CSS
             + f'<span style="color: #e8a86b;">{message_html}</span>'
         )
+        self._stack.setCurrentWidget(self._body)

--- a/src/ui/node_editor_page.py
+++ b/src/ui/node_editor_page.py
@@ -37,8 +37,6 @@ from ui.node_list import NodeList
 from ui.node_list_state import restore_node_list_state, save_node_list_state
 from ui.recent_flows import RecentFlowsManager
 from ui.message_banner import MessageBanner
-from ui.port_legend import PortLegend
-from ui.settings import get_settings
 from ui.flow_status_widget import FlowStatusWidget
 from ui.theme import STATUS_MUTED_COLOR, STATUS_OK_COLOR
 
@@ -182,35 +180,6 @@ class NodeEditorPage(PageBase):
         # severities (see :class:`MessageBanner`).
         self._message_banner = MessageBanner(self._inner)
 
-        # Port-type colour legend pinned to the bottom-left corner of
-        # the canvas. Parented to the FlowView (not its ``viewport()``)
-        # so the legend is a sibling of the viewport widget rather
-        # than a child of it — pan and zoom only repaint the viewport,
-        # leaving the legend untouched. ``raise_()`` once at the end
-        # of construction puts it on top of the viewport and Qt's
-        # normal child-widget compositing keeps it there.
-        # Visibility is owned by ``AppSettings.port_legend_visible``,
-        # surfaced through the View menu and persisted across sessions.
-        self._port_legend = PortLegend(self._view)
-        self._port_legend.raise_()
-        settings = get_settings()
-        self._port_legend.setVisible(settings.port_legend_visible)
-        self._port_legend_action = QAction("Port Legend", self)
-        self._port_legend_action.setCheckable(True)
-        self._port_legend_action.setChecked(settings.port_legend_visible)
-        self._port_legend_action.toggled.connect(self._on_port_legend_toggled)
-        # Close glyph on the legend itself routes through the same
-        # setter so the button click and the View-menu toggle share
-        # one source of truth.
-        self._port_legend.close_requested.connect(
-            lambda: self._on_port_legend_toggled(False)
-        )
-        # Two-way binding so a programmatic settings change (e.g. from
-        # a future settings page) keeps the action's check state and
-        # the legend visibility in sync.
-        settings.port_legend_visible_changed.connect(self._port_legend_action.setChecked)
-        settings.port_legend_visible_changed.connect(self._port_legend.setVisible)
-
         # Bridge core.notifications → banner. Producers fire on worker
         # threads; the signal carries the payload back to the UI thread
         # via Qt's auto-queued connection.
@@ -291,8 +260,6 @@ class NodeEditorPage(PageBase):
         view_menu = menu.addMenu("View")
         view_menu.addAction(self._node_list_dock.toggleViewAction())
         view_menu.addAction(self._node_doc_dock.toggleViewAction())
-        view_menu.addSeparator()
-        view_menu.addAction(self._port_legend_action)
         return [menu]
 
     def on_activated(self) -> None:
@@ -427,13 +394,6 @@ class NodeEditorPage(PageBase):
 
     def _on_group_clicked(self) -> None:
         self._scene.create_group_around_selection()
-
-    def _on_port_legend_toggled(self, checked: bool) -> None:
-        # Push the new value into AppSettings; the singleton's signal
-        # then propagates back to both the action's check state and
-        # the legend's visibility, so any future binding (e.g. another
-        # editor page or a settings dialog) stays consistent.
-        get_settings().port_legend_visible = checked
 
     def _on_stack_vertical_clicked(self) -> None:
         """Align selected nodes on a shared X axis and stack them vertically."""

--- a/src/ui/port_legend.py
+++ b/src/ui/port_legend.py
@@ -1,13 +1,10 @@
 from __future__ import annotations
 
-from PySide6.QtCore import QEvent, QObject, QRectF, Qt, Signal
+from PySide6.QtCore import QRectF, Qt
 from PySide6.QtGui import QBrush, QColor, QPainter, QPainterPath, QPen
 from PySide6.QtWidgets import (
-    QFrame,
     QGridLayout,
-    QHBoxLayout,
     QLabel,
-    QToolButton,
     QWidget,
 )
 
@@ -108,54 +105,32 @@ class _Swatch(QWidget):
             painter.drawPath(path)
 
 
-class PortLegend(QFrame):
-    """Floating legend explaining the port visual language.
+class PortLegendContent(QWidget):
+    """Embeddable port-language legend.
 
-    Parented to :class:`~ui.flow_view.FlowView` (the
-    :class:`QAbstractScrollArea`, *not* its ``viewport()``) and pinned
-    to the bottom-left corner of that widget. The view's viewport is
-    just one of FlowView's children, so the legend sits as a sibling
-    that overlays the canvas through normal Qt widget compositing —
-    no scene item, no proxy, no per-frame repositioning. Pan and zoom
-    only repaint the viewport, so the legend stays put automatically;
-    only window resizes need a reposition (handled via an event
-    filter on the parent).
+    Pure content widget — no chrome, no overlay positioning, no close
+    button. Renders two sections:
 
-    Two sections:
       * **Port types** — one row per :class:`IoDataType` showing the
         colour used for that type's ring and (darker) fill.
       * **Port roles** — required / optional / latched input
         variants and the output glyph, all rendered in the neutral
         default colour so the variation is purely about ring stroke
         and direction marker rather than type colour.
+
+    Embed it directly in any layout. Used by the Node Documentation
+    panel as part of its empty-state hint.
     """
-
-    MARGIN: int = 12
-
-    #: Background opacity for the legend panel. Baked into the
-    #: stylesheet's rgba() rather than applied via
-    #: :class:`QGraphicsOpacityEffect`; the effect-based path interacts
-    #: badly with :class:`~PySide6.QtWidgets.QGraphicsView`'s
-    #: incremental update modes.
-    _BG_ALPHA: int = 220
 
     @staticmethod
     def _build_style() -> str:
-        """Compose the legend's stylesheet from the active theme so
-        the panel chrome (background, border, text) tracks the rest
-        of the app — navy-on-navy under neon, grey-on-grey under
-        classic."""
+        """Compose label colours from the active theme so the legend
+        tracks the rest of the app — navy text under neon, grey text
+        under classic — without needing a dedicated panel background."""
         theme = get_active_theme()
-        bg = theme.PALETTE_BASE
-        border = theme.PALETTE_HIGHLIGHT
         text = theme.PALETTE_TEXT
         title_text = theme.NODE_TITLE_TEXT_COLOR
         return f"""
-        QFrame#PortLegend {{
-            background: rgba({bg.red()}, {bg.green()}, {bg.blue()}, {PortLegend._BG_ALPHA});
-            border: 1px solid {border.name()};
-            border-radius: 4px;
-        }}
         QLabel#PortLegendTitle {{
             color: {title_text.name()};
             font-weight: bold;
@@ -165,50 +140,21 @@ class PortLegend(QFrame):
             color: {text.name()};
             background: transparent;
         }}
-        QToolButton#PortLegendClose {{
-            color: {text.name()};
-            background: transparent;
-            border: none;
-            padding: 0 4px;
-            font-size: 12px;
-        }}
-        QToolButton#PortLegendClose:hover {{
-            color: {title_text.name()};
-        }}
         """
 
-    #: Emitted when the user clicks the close button. The owning page
-    #: handles this by flipping ``AppSettings.port_legend_visible``,
-    #: which then propagates back to actually hide the widget — keeps
-    #: the close click and the View-menu toggle on a single source of
-    #: truth.
-    close_requested = Signal()
-
-    def __init__(self, parent: QWidget) -> None:
+    def __init__(self, parent: QWidget | None = None) -> None:
         super().__init__(parent)
-        self.setObjectName("PortLegend")
-        self.setAttribute(Qt.WidgetAttribute.WA_StyledBackground, True)
         self.setFocusPolicy(Qt.FocusPolicy.NoFocus)
         self.setStyleSheet(self._build_style())
 
         layout = QGridLayout(self)
-        layout.setContentsMargins(10, 8, 12, 8)
+        layout.setContentsMargins(0, 0, 0, 0)
         layout.setHorizontalSpacing(8)
         layout.setVerticalSpacing(4)
 
         row = 0
-        row = self._add_section(
-            layout, row, "Port types", self._type_rows(), with_close_button=True,
-        )
+        row = self._add_section(layout, row, "Port types", self._type_rows())
         row = self._add_section(layout, row, "Port roles", self._role_rows())
-
-        self.adjustSize()
-        # Stay anchored to the parent's bottom-left edge through window
-        # resizes. Pan and zoom don't fire a Resize on the parent
-        # (only on its viewport child), so this filter keeps the
-        # legend completely still during canvas interaction.
-        parent.installEventFilter(self)
-        self._reposition()
 
     # ── Row builders ───────────────────────────────────────────────────────────
 
@@ -253,8 +199,6 @@ class PortLegend(QFrame):
         start_row: int,
         title_text: str,
         rows: list[tuple[_Swatch, str]],
-        *,
-        with_close_button: bool = False,
     ) -> int:
         # First section sits flush; subsequent ones leave a small gap by
         # adding extra vertical room on the title row.
@@ -262,25 +206,7 @@ class PortLegend(QFrame):
         title.setObjectName("PortLegendTitle")
         if start_row > 0:
             title.setContentsMargins(0, 8, 0, 0)
-
-        if with_close_button:
-            # Wrap title + close button in a horizontal sub-layout so
-            # the close glyph anchors to the right edge of the legend.
-            header = QHBoxLayout()
-            header.setContentsMargins(0, 0, 0, 0)
-            header.setSpacing(8)
-            header.addWidget(title)
-            header.addStretch(1)
-            close = QToolButton(self)
-            close.setObjectName("PortLegendClose")
-            close.setText("✕")  # multiplication X
-            close.setToolTip("Hide legend (View ▸ Port Legend to show)")
-            close.setCursor(Qt.CursorShape.PointingHandCursor)
-            close.clicked.connect(self.close_requested)
-            header.addWidget(close)
-            layout.addLayout(header, start_row, 0, 1, 2)
-        else:
-            layout.addWidget(title, start_row, 0, 1, 2)
+        layout.addWidget(title, start_row, 0, 1, 2)
 
         next_row = start_row + 1
         for swatch, text in rows:
@@ -290,19 +216,3 @@ class PortLegend(QFrame):
             layout.addWidget(label, next_row, 1)
             next_row += 1
         return next_row
-
-    # ── Parent resize tracking ─────────────────────────────────────────────────
-
-    def eventFilter(self, obj: QObject, event: QEvent) -> bool:  # type: ignore[override]
-        if obj is self.parent() and event.type() == QEvent.Type.Resize:
-            self._reposition()
-        return super().eventFilter(obj, event)
-
-    def _reposition(self) -> None:
-        parent = self.parentWidget()
-        if parent is None:
-            return
-        margin = self.MARGIN
-        x = margin
-        y = parent.height() - self.height() - margin
-        self.move(x, max(margin, y))

--- a/src/ui/settings.py
+++ b/src/ui/settings.py
@@ -25,7 +25,6 @@ SETTINGS_FILE: Path = USER_CONFIG_DIR / "settings.json"
 _SETTINGS_VERSION: int = 1
 
 _DEFAULT_DEBUG_LOGGING: bool = False
-_DEFAULT_PORT_LEGEND_VISIBLE: bool = True
 #: Default theme key. ``ui.theme`` resolves the name against
 #: :data:`ui.theme.AVAILABLE_THEMES` at module-import time, so an
 #: unrecognised value silently falls back to the registered default.
@@ -65,7 +64,6 @@ class AppSettings(QObject):
     """
 
     debug_logging_changed = Signal(bool)
-    port_legend_visible_changed = Signal(bool)
     #: Emitted when the user picks a different theme on the Settings
     #: page. The change only takes visual effect on next launch — the
     #: theme is locked at ``ui.theme`` import time, so consumers
@@ -79,9 +77,6 @@ class AppSettings(QObject):
         data = _read_settings_file(path)
         self._debug_logging: bool = bool(
             data.get("debug_logging", _DEFAULT_DEBUG_LOGGING)
-        )
-        self._port_legend_visible: bool = bool(
-            data.get("port_legend_visible", _DEFAULT_PORT_LEGEND_VISIBLE)
         )
         raw_theme = data.get("theme_name", _DEFAULT_THEME_NAME)
         self._theme_name: str = (
@@ -104,19 +99,6 @@ class AppSettings(QObject):
         self.debug_logging_changed.emit(value)
 
     @property
-    def port_legend_visible(self) -> bool:
-        return self._port_legend_visible
-
-    @port_legend_visible.setter
-    def port_legend_visible(self, value: bool) -> None:
-        value = bool(value)
-        if value == self._port_legend_visible:
-            return
-        self._port_legend_visible = value
-        self._save()
-        self.port_legend_visible_changed.emit(value)
-
-    @property
     def theme_name(self) -> str:
         return self._theme_name
 
@@ -134,7 +116,6 @@ class AppSettings(QObject):
         payload = {
             "version": _SETTINGS_VERSION,
             "debug_logging": self._debug_logging,
-            "port_legend_visible": self._port_legend_visible,
             "theme_name": self._theme_name,
         }
         try:

--- a/tests/test_node_doc_panel_widget.py
+++ b/tests/test_node_doc_panel_widget.py
@@ -43,7 +43,7 @@ def registry() -> NodeRegistry:
 
 def test_panel_starts_in_empty_state(qapp: QApplication) -> None:
     panel = NodeDocPanel()
-    assert "Select a node" in panel._body.toHtml()
+    assert panel._stack.currentWidget() is panel._empty
 
 
 # ── show_class ─────────────────────────────────────────────────────────────────
@@ -97,7 +97,7 @@ def test_clear_returns_to_empty_state(qapp: QApplication) -> None:
     panel = NodeDocPanel()
     panel.show_class(GaussianBlur)
     panel.clear()
-    assert "Select a node" in panel._body.toHtml()
+    assert panel._stack.currentWidget() is panel._empty
 
 
 # ── show_entry (palette path) ──────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

The floating port legend that appeared in the bottom-left corner of the canvas has been removed and its content integrated into the Node Documentation dock's empty state. This consolidates the legend into a single, always-accessible location that doesn't compete for screen space with the canvas.

## Key Changes

- **Refactored `PortLegend` → `PortLegendContent`**: Removed all overlay chrome (background, border, close button, event filtering, repositioning logic) and converted it to a pure content widget that can be embedded in any layout.

- **Updated `NodeDocPanel`**: Now uses a `QStackedWidget` to switch between two views:
  - Empty state: hint label + embedded `PortLegendContent` (shown when nothing is selected)
  - Documentation view: `QTextBrowser` with node docs (shown when a node is selected)

- **Removed canvas overlay infrastructure from `NodeEditorPage`**:
  - Deleted `PortLegend` instance and all related positioning/visibility logic
  - Removed `View ▸ Port Legend` menu entry and toggle action
  - Removed event filter and parent resize tracking

- **Cleaned up settings**: Removed `port_legend_visible` property and signal from `AppSettings` since the legend visibility is now implicit (shown only in empty state).

- **Updated documentation**: Revised user-facing docs to explain the new location and behavior of the port legend.

## Implementation Details

- The `PortLegendContent` widget has zero margins by default, making it suitable for embedding in layouts without extra padding.
- The stylesheet was simplified to only style labels, removing all panel chrome styling.
- The empty-state widget wraps the hint label and legend in a `QVBoxLayout` with appropriate spacing and margins.
- Tests updated to verify the stacked widget shows the correct view rather than checking HTML content.

https://claude.ai/code/session_01QpjpoLFALPT2nkhVbEPCJx