### PR TITLE
FileSink: write through imencode + Path.write_bytes for non-ASCII paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,18 +31,22 @@ once a first tagged release is cut.
   `QTextBrowser` body — no per-frame repositioning, no overlay
   parenting tricks.
 
-### Changed (Sink write failures now name the offending non-ASCII characters)
+### Fixed (FileSink writes succeed on paths with non-ASCII characters)
 
-- **`FileSink` and `VideoSink` failure messages now list the
-  non-ASCII characters in the path.** OpenCV's writers
-  (`cv2.imwrite`, `cv2.VideoWriter`) silently fail on Windows when
-  the path contains characters outside the active ANSI code page —
-  `C:\Users\…\stjörnhorn\output\…` was reported as a generic
-  "filename invalid for the current OS" with no pointer to the real
-  cause. A new `core.path_utils.write_failure_hint` helper appends
-  `The path contains non-ASCII characters ('ö')` to the message
-  when the path has any; ASCII-only paths still get the generic
-  note. Both sinks share the helper.
+- **`FileSink` now writes correctly when the output path contains
+  umlauts or other non-ASCII characters** (the
+  `C:\Users\…\stjörnhorn\output\…` case that triggered the
+  recent diagnostic-only round). `cv2.imwrite` opens the
+  destination through the C runtime's ANSI `fopen` on Windows
+  and silently fails for any path outside the active code page;
+  the sink now encodes via `cv2.imencode` and streams the bytes
+  via `Path.write_bytes`, mirroring the read-side trick already
+  used by `ImageSource`. If the encoder itself refuses the
+  format (unsupported extension), the sink raises an `OSError`
+  that names the offending suffix instead of writing a
+  placeholder. `VideoSink` keeps its diagnostic-only treatment
+  for now — the underlying `cv2.VideoWriter` Unicode-path bug
+  is harder to fix and tracked as a follow-up.
 
 ### Added (Copy-to-clipboard button on the error/notification banner)
 

--- a/src/constants.py
+++ b/src/constants.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 APP_NAME:         str = "Stjörnhorn"
 APP_DISPLAY_NAME: str = "Stjörnhorn"
-APP_VERSION:      str = "0.3.0.69"
+APP_VERSION:      str = "0.3.0.70"
 API_URL:    str = "https://beltoforion.de"
 
 # Public, online-hosted version of the welcome page. The start page tries

--- a/src/nodes/sinks/file_sink.py
+++ b/src/nodes/sinks/file_sink.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from typing import Any
 
 import cv2
+import numpy as np
 from typing_extensions import override
 
 from constants import OUTPUT_DIR
@@ -12,7 +13,7 @@ from core.filename_template import expand as expand_template
 from core.io_data import IMAGE_TYPES
 from core.node_base import SinkNodeBase
 from core.params import FilePathParam
-from core.path_utils import resolve_against, write_failure_hint
+from core.path_utils import resolve_against
 from core.port import InputPort
 
 
@@ -83,14 +84,29 @@ class FileSink(SinkNodeBase):
             raise ValueError(f"Unsupported output format: {self._output_format}")
 
         output.parent.mkdir(parents=True, exist_ok=True)
-        written = cv2.imwrite(str(output), self.inputs[0].data.image)
-        if not written:
-            raise OSError(
-                f"File Sink failed to write image to {output!s}. "
-                f"{write_failure_hint(output)}"
-            )
+        self._encode_and_write(output, self.inputs[0].data.image)
 
     # ── Internals ──────────────────────────────────────────────────────────────
+
+    def _encode_and_write(self, output: Path, image: np.ndarray) -> None:
+        """Encode *image* in memory then stream the bytes to *output*.
+
+        ``cv2.imwrite`` opens the destination through the C runtime's
+        ANSI ``fopen`` on Windows and silently fails on any path with
+        characters outside the active code page (the ``ö`` in
+        ``stjörnhorn`` was a real-world reproducer). Encoding via
+        ``cv2.imencode`` and writing through Python's ``open()``
+        sidesteps that limitation — the same trick lives on the read
+        side in :class:`~nodes.sources.image_source.ImageSource`.
+        """
+        ok, buf = cv2.imencode(output.suffix, image)
+        if not ok:
+            raise OSError(
+                f"File Sink failed to encode image for {output!s}. "
+                f"The extension {output.suffix!r} may not be supported "
+                "by OpenCV's encoders."
+            )
+        output.write_bytes(buf.tobytes())
 
     def _resolved_template(self, meta: dict[str, Any]) -> Path:
         """Expand the user's template against *meta*, then resolve

--- a/tests/test_file_sink.py
+++ b/tests/test_file_sink.py
@@ -109,14 +109,15 @@ def test_sink_has_no_tick_port(tmp_path: Path) -> None:
     assert sink.inputs[0].name == "image"
 
 
-# ── Error handling: cv2.imwrite failure ──────────────────────────────────────
+# ── Non-ASCII paths + encode-failure handling ────────────────────────────────
 #
-# ``cv2.imwrite`` returns False instead of raising when the underlying
-# C-runtime ``fopen`` rejects the path. The sink's job is to translate
-# that opaque False into an OSError whose message points at the most
-# likely cause — non-ASCII characters in the path on Windows. The tests
-# here monkeypatch ``cv2.imwrite`` to simulate the failure so they run
-# the same way on every platform (Linux's GLIBC fopen accepts UTF-8).
+# ``cv2.imwrite`` opens the destination through the C runtime's ANSI
+# ``fopen`` on Windows, which silently fails on any path with characters
+# outside the active code page — the ``ö`` in ``stjörnhorn`` was a
+# real-world reproducer. The sink now encodes via ``cv2.imencode`` and
+# streams the bytes through Python's ``open()`` (Path.write_bytes), so
+# umlauts in the path are transparent. The tests below pin both the
+# new success behaviour and the encode-failure error message.
 
 
 def _drive_one_frame(sink: FileSink) -> None:
@@ -126,13 +127,43 @@ def _drive_one_frame(sink: FileSink) -> None:
     image_feeder.send(IoData.from_image(_make_image()))
 
 
-def test_imwrite_failure_on_ascii_path_raises_generic_oserror(
+def test_writes_to_path_with_umlauts_succeeds(tmp_path: Path) -> None:
+    """Headline regression: a parent folder with ``ö`` (the
+    ``stjörnhorn`` case) must round-trip — the sink encodes in
+    memory and writes the bytes via Python's file I/O, which on
+    every supported OS handles non-ASCII paths."""
+    sink = FileSink()
+    out = tmp_path / "stjörnhorn" / "out.png"
+    sink.output_path = out
+
+    _drive_one_frame(sink)
+
+    assert out.exists()
+    # File must be a valid PNG, not an empty placeholder — i.e. the
+    # encoded bytes actually landed on disk.
+    assert out.read_bytes()[:8] == b"\x89PNG\r\n\x1a\n"
+
+
+def test_writes_to_path_with_multiple_non_ascii_chars(tmp_path: Path) -> None:
+    """Multiple offenders in the path are not a problem — Python's
+    open() handles arbitrary Unicode."""
+    sink = FileSink()
+    out = tmp_path / "öäü" / "café.png"
+    sink.output_path = out
+
+    _drive_one_frame(sink)
+
+    assert out.exists() and out.stat().st_size > 0
+
+
+def test_imencode_failure_raises_oserror_naming_the_extension(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """When cv2 refuses an ASCII path the message stays generic — we
-    have no specific diagnosis, so the user gets the 'invalid for the
-    current OS' fallback instead of a misleading umlaut hint."""
-    monkeypatch.setattr(cv2, "imwrite", lambda _path, _img: False)
+    """If the in-memory encoder rejects the format (typically an
+    extension OpenCV doesn't ship a codec for), the user gets an
+    explicit OSError pointing at the suffix rather than a silent
+    write of an empty file."""
+    monkeypatch.setattr(cv2, "imencode", lambda _ext, _img: (False, None))
     sink = FileSink()
     sink.output_path = tmp_path / "out.png"
 
@@ -140,53 +171,20 @@ def test_imwrite_failure_on_ascii_path_raises_generic_oserror(
         _drive_one_frame(sink)
 
     msg = str(exc_info.value)
-    assert "File Sink failed to write image" in msg
-    assert "out.png" in msg
-    assert "invalid" in msg.lower()
-    assert "non-ASCII" not in msg
+    assert "failed to encode image" in msg
+    assert "'.png'" in msg
 
 
-def test_imwrite_failure_on_umlaut_path_calls_out_offending_chars(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """The headline regression: a path with ``ö`` (e.g. the user's
-    home folder ``stjörnhorn``) must produce an error message that
-    explicitly names the offending character and the encoding cause,
-    so the user can act on it without consulting the source."""
-    monkeypatch.setattr(cv2, "imwrite", lambda _path, _img: False)
+def test_write_to_missing_directory_raises_oserror(tmp_path: Path) -> None:
+    """Python's open() raises a clear OSError for filesystem-level
+    failures; the sink doesn't swallow it. ``mkdir(parents=True)``
+    handles missing intermediate dirs in the normal case, so we
+    target a path whose *parent* is a regular file to force the
+    failure."""
+    blocker = tmp_path / "not_a_dir"
+    blocker.write_bytes(b"x")
     sink = FileSink()
-    sink.output_path = tmp_path / "stjörnhorn" / "out.png"
+    sink.output_path = blocker / "out.png"
 
-    with pytest.raises(OSError) as exc_info:
+    with pytest.raises((OSError, NotADirectoryError, FileExistsError)):
         _drive_one_frame(sink)
-
-    msg = str(exc_info.value)
-    assert "File Sink failed to write image" in msg
-    assert "non-ASCII" in msg
-    assert "'ö'" in msg
-
-
-def test_imwrite_failure_message_lists_each_offender_once(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """``ä`` and ``ö`` both present → both surface, each exactly once.
-    Sorted order keeps the message deterministic across runs."""
-    monkeypatch.setattr(cv2, "imwrite", lambda _path, _img: False)
-    sink = FileSink()
-    sink.output_path = tmp_path / "äöäö" / "out.png"
-
-    with pytest.raises(OSError) as exc_info:
-        _drive_one_frame(sink)
-
-    msg = str(exc_info.value)
-    assert msg.count("'ä'") == 1
-    assert msg.count("'ö'") == 1
-
-
-def test_imwrite_success_does_not_raise(tmp_path: Path) -> None:
-    """Sanity counterpart to the failure tests: when cv2 actually
-    writes the file, no error path triggers."""
-    sink = FileSink()
-    sink.output_path = tmp_path / "ok.png"
-    _drive_one_frame(sink)
-    assert (tmp_path / "ok.png").exists()


### PR DESCRIPTION
## Summary

- `cv2.imwrite` opens the destination through the C runtime's ANSI `fopen` on Windows and silently fails on any path containing characters outside the active code page — the `ö` in `C:\Users\…\stjörnhorn\output\…` was the real-world reproducer (`image_bulk_fft.flowjs` failing on every frame).
- `FileSink` now encodes the image in memory via `cv2.imencode` and streams the bytes via `Path.write_bytes`. Python's `open()` uses `_wfopen` on Windows, so arbitrary Unicode paths work transparently. Same trick already lives on the read side in `ImageSource`.
- If the encoder itself refuses the format (unsupported extension), the sink raises an `OSError` that names the offending suffix instead of writing a placeholder.
- `VideoSink` keeps its diagnostic-only treatment for now — `cv2.VideoWriter` has no in-memory encode equivalent, so a proper fix needs a temp-path-then-rename dance and is tracked as a follow-up.

## Test plan

- [x] `pytest tests/test_file_sink.py tests/test_path_utils.py tests/test_video_sink.py` — 35 passed.
- [x] End-to-end: drove `FileSink` against `<tmp>/stjörnhorn/output/00017_fft_hsv.png` and verified the file lands on disk with a valid PNG magic header.
- [x] Encode-failure path: monkeypatched `cv2.imencode` to return `(False, None)` and confirmed the new `OSError` names the suffix.
- [x] Filesystem-failure path: targeted a directory that's actually a file, confirmed the OS-level `OSError` bubbles up unswallowed.
- [ ] Verify on Windows with a user profile / project directory containing umlauts (the original repro).

https://claude.ai/code/session_016rUHq1C4NmQsyr9WSNhpZG

---
_Generated by [Claude Code](https://claude.ai/code/session_016rUHq1C4NmQsyr9WSNhpZG)_