### PR TITLE
Add info toggle to every non-source node for frame metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,27 @@ once a first tagged release is cut.
 
 ## [Unreleased]
 
+### Added (Info button on every non-source node)
+
+- **Every filter and sink now carries the same "info" header
+  toggle the Display node introduced.** Clicking it surfaces a
+  scrollable dump of the latest input frame's
+  :class:`IoMeta` — payload kind, shape, and every meta key the
+  upstream stamped — directly inside the node body, with one
+  section per input port. Toggling it off collapses the preview
+  back to zero so the node looks unchanged when the user isn't
+  asking for meta. Source nodes stay unaffected: they have no
+  input meta to surface, so the toggle is intentionally absent.
+- The toggle plumbing (``show_meta`` flag, ``set_show_meta_callback``,
+  per-frame input snapshot, generic ``set_frame_callback``) moved
+  from ``Display`` up into ``NodeBase`` so every non-source node
+  inherits it without re-implementing the same wiring. The
+  ``Display`` and ``MetaInspector`` nodes shed their hand-rolled
+  copies in the process. ``MetaInspector`` opts out of the
+  auto-injected toggle (its preview is already a meta dump);
+  every other non-source node gets a ``GenericMetaPreview`` for
+  free that's only visible while the toggle is on.
+
 ### Changed (Port legend moved into the Node Documentation dock)
 
 - **The floating "Port types / Port roles" legend that used to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,23 +13,25 @@ once a first tagged release is cut.
 ### Added (Info button on every non-source node)
 
 - **Every filter and sink now carries the same "info" header
-  toggle the Display node introduced.** Clicking it surfaces a
-  scrollable dump of the latest input frame's
-  :class:`IoMeta` — payload kind, shape, and every meta key the
-  upstream stamped — directly inside the node body, with one
-  section per input port. Toggling it off collapses the preview
-  back to zero so the node looks unchanged when the user isn't
-  asking for meta. Source nodes stay unaffected: they have no
-  input meta to surface, so the toggle is intentionally absent.
-- The toggle plumbing (``show_meta`` flag, ``set_show_meta_callback``,
-  per-frame input snapshot, generic ``set_frame_callback``) moved
+  toggle the Display node introduced.** Clicking it raises a
+  scrollable dump of the latest input frame's :class:`IoMeta` —
+  payload kind, shape, and every meta key the upstream stamped —
+  over the entire body section below the header, with one
+  section per input port. The node's outer dimensions are
+  unchanged: the meta view fills whatever the body already is and
+  port labels / inline widgets / the regular preview hide
+  underneath until the toggle flips back off. Source nodes stay
+  unaffected (no input meta to surface).
+- The toggle plumbing (``show_meta`` flag,
+  ``set_show_meta_callback``, per-frame input snapshot, generic
+  ``set_frame_callback``, multi-cast ``add_meta_listener``) moved
   from ``Display`` up into ``NodeBase`` so every non-source node
   inherits it without re-implementing the same wiring. The
   ``Display`` and ``MetaInspector`` nodes shed their hand-rolled
   copies in the process. ``MetaInspector`` opts out of the
   auto-injected toggle (its preview is already a meta dump);
-  every other non-source node gets a ``GenericMetaPreview`` for
-  free that's only visible while the toggle is on.
+  every other non-source node carries a ``MetaOverlay`` that
+  rises on top of the body whenever the user asks for meta.
 
 ### Changed (Port legend moved into the Node Documentation dock)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,3 +28,15 @@ py-modules = ["main", "constants", "log"]
 
 [tool.setuptools.packages.find]
 where = ["src"]
+
+[tool.mypy]
+# Treat ``src/`` as the package root so type checkers recognise the
+# in-tree namespace packages (``core``, ``nodes``, ``ui``, ``ocvl``)
+# as the same module names runtime imports use. Without this the
+# checker resolves ``from ui.theme import ...`` against an installed
+# distribution of the same name and reports every project-internal
+# import as ``import-untyped``. Mirrors the runtime ``PYTHONPATH=src``
+# convention used by the test suite and the entry-point shim.
+mypy_path = "src"
+explicit_package_bases = true
+namespace_packages = true

--- a/src/constants.py
+++ b/src/constants.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 APP_NAME:         str = "Stjörnhorn"
 APP_DISPLAY_NAME: str = "Stjörnhorn"
-APP_VERSION:      str = "0.3.0.70"
+APP_VERSION:      str = "0.3.0.71"
 API_URL:    str = "https://beltoforion.de"
 
 # Public, online-hosted version of the welcome page. The start page tries

--- a/src/constants.py
+++ b/src/constants.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 APP_NAME:         str = "Stjörnhorn"
 APP_DISPLAY_NAME: str = "Stjörnhorn"
-APP_VERSION:      str = "0.3.0.71"
+APP_VERSION:      str = "0.3.0.72"
 API_URL:    str = "https://beltoforion.de"
 
 # Public, online-hosted version of the welcome page. The start page tries

--- a/src/core/node_base.py
+++ b/src/core/node_base.py
@@ -289,6 +289,14 @@ class NodeBase(ABC):
         # processed frame. Carries the node so a single subscription
         # can reach :attr:`last_inputs` and any node-specific state.
         self._frame_callback: Callable[["NodeBase"], None] | None = None
+        # Secondary per-frame fan-out reserved for the info-toggle
+        # meta overlay. Kept separate from :attr:`_frame_callback` so
+        # a node with a primary preview (DisplayPreview's image
+        # rendering, PlayGatePreview's button state) and an overlay
+        # (the meta dump) don't have to compete for the single-slot
+        # callback. Multiple listeners are fine — each runs on
+        # whichever thread :meth:`process` is on.
+        self._meta_listeners: list[Callable[["NodeBase"], None]] = []
         # Initialise every descriptor's backing slot to its declared
         # default before subclass ``__init__`` runs, so ``self._<name>``
         # exists from the first line after ``super().__init__()``. The
@@ -548,6 +556,19 @@ class NodeBase(ABC):
         """
         self._frame_callback = callback
 
+    def add_meta_listener(
+        self, callback: Callable[["NodeBase"], None],
+    ) -> None:
+        """Register a per-frame meta listener (multi-cast).
+
+        Used by the info-toggle :class:`~ui.preview_widgets.MetaOverlay`
+        so it can update its meta dump per frame without colliding
+        with the single-slot :meth:`set_frame_callback` that the
+        node's primary preview already owns. Fires on whichever
+        thread :meth:`process` is on; listeners marshal across to
+        the UI thread themselves (queued Qt signal)."""
+        self._meta_listeners.append(callback)
+
     # ── Header items (rendered in the title bar) ───────────────────────────────
 
     def header_items(self) -> list[HeaderItem]:
@@ -699,6 +720,14 @@ class NodeBase(ABC):
                 # A buggy preview must not bring down the flow.
                 logger.exception(
                     f"Frame callback raised on {type(self).__name__} "
+                    f"({self._display_name}); ignoring"
+                )
+        for listener in self._meta_listeners:
+            try:
+                listener(self)
+            except Exception:
+                logger.exception(
+                    f"Meta listener raised on {type(self).__name__} "
                     f"({self._display_name}); ignoring"
                 )
 

--- a/src/core/node_base.py
+++ b/src/core/node_base.py
@@ -245,6 +245,15 @@ class NodeBase(ABC):
     #: is rendered, matching the behaviour of every existing node.
     SHOW_ONLY_USED_INPUTS: bool = False
 
+    #: When True, :meth:`header_items` auto-injects an "info" :class:`Toggle`
+    #: that flips :attr:`show_meta`. Non-source nodes inherit ``True`` so
+    #: every filter / sink / debug probe surfaces the latest input frame's
+    #: meta on demand. :class:`SourceNodeBase` overrides to ``False`` (a
+    #: source has no input meta to show); nodes whose dedicated preview is
+    #: already a meta dump (``MetaInspector``) override to ``False`` to
+    #: avoid a redundant toggle.
+    HAS_INFO_TOGGLE: bool = True
+
     def __init__(self, display_name: str, section: str | None = None) -> None:
         self._display_name = display_name
         self._section = section if section is not None else self.DEFAULT_SECTION
@@ -260,6 +269,26 @@ class NodeBase(ABC):
         # for skippable nodes), so the storage list is the *node's
         # contribution*, not the full rendered list.
         self._header_items: list[HeaderItem] = []
+        # ── "Show meta" toggle state ────────────────────────────────────
+        # Flipped by the auto-injected info :class:`Toggle` (see
+        # :meth:`header_items`). Preview widgets poll :attr:`show_meta`
+        # on each repaint and re-subscribe to mode flips via
+        # :meth:`set_show_meta_callback`. Generic state lives here so
+        # every non-source node can surface frame meta without each one
+        # re-implementing the same toggle plumbing.
+        self._show_meta: bool = False
+        self._show_meta_callback: Callable[[], None] | None = None
+        # Per-input snapshot of the most recent :class:`IoData` envelope
+        # captured by :meth:`process` before :meth:`process_impl` runs.
+        # Preview widgets read this in their frame callback (after
+        # :meth:`process_impl` returns) to render meta / image without
+        # the node having to track the latest payload itself.
+        self._last_inputs: list[IoData | None] = []
+        # Generic per-frame callback fired after :meth:`process_impl`
+        # completes; preview widgets register here to refresh on each
+        # processed frame. Carries the node so a single subscription
+        # can reach :attr:`last_inputs` and any node-specific state.
+        self._frame_callback: Callable[["NodeBase"], None] | None = None
         # Initialise every descriptor's backing slot to its declared
         # default before subclass ``__init__`` runs, so ``self._<name>``
         # exists from the first line after ``super().__init__()``. The
@@ -469,14 +498,65 @@ class NodeBase(ABC):
         """Action handler for the auto-injected step-over toggle."""
         self.skipped = not self._skipped
 
+    # ── "Show meta" toggle (rendered as the info button) ────────────────────────
+
+    @property
+    def show_meta(self) -> bool:
+        """True when the node's inline preview should render frame
+        metadata instead of (or in addition to) its normal contents.
+        Flipped by the auto-injected info :class:`Toggle`; preview
+        widgets poll this on each repaint."""
+        return self._show_meta
+
+    def set_show_meta_callback(
+        self, callback: Callable[[], None] | None,
+    ) -> None:
+        """Attach (or clear) a callback fired when :attr:`show_meta`
+        flips. The preview widget uses it to swap which page of its
+        stack is visible (or to grow / shrink the preview area)
+        without polling."""
+        self._show_meta_callback = callback
+
+    def _toggle_show_meta(self) -> None:
+        """Action handler for the auto-injected info toggle: flip
+        :attr:`show_meta` and notify the preview widget so it can
+        repaint in the new mode."""
+        self._show_meta = not self._show_meta
+        if self._show_meta_callback is not None:
+            self._show_meta_callback()
+
+    @property
+    def last_inputs(self) -> list[IoData | None]:
+        """Per-input snapshot of the most recent :class:`IoData`
+        envelope each input port carried into :meth:`process_impl`.
+        Indexed parallel to :attr:`inputs`; entries are ``None`` for
+        ports that had no data on the last dispatch (e.g. an
+        unconnected optional input)."""
+        return list(self._last_inputs)
+
+    def set_frame_callback(
+        self, callback: Callable[["NodeBase"], None] | None,
+    ) -> None:
+        """Attach (or clear) a callback invoked after every
+        :meth:`process_impl` call. The callback receives the node
+        itself; it can read :attr:`last_inputs` (and any node-specific
+        accessors) to render the new frame.
+
+        Fires on whichever thread :meth:`process` runs on — the UI
+        widget is responsible for marshalling back to the main
+        thread, typically via a queued Qt signal.
+        """
+        self._frame_callback = callback
+
     # ── Header items (rendered in the title bar) ───────────────────────────────
 
     def header_items(self) -> list[HeaderItem]:
         """Return the items :class:`ui.node_item.NodeItem` should render
         in this node's title bar, left-to-right.
 
-        Default: a step-over :class:`Toggle` (only when
-        :attr:`is_skippable`) followed by everything the subclass
+        Default order: the step-over :class:`Toggle` (only when
+        :attr:`is_skippable`), the info :class:`Toggle` (only when
+        :attr:`HAS_INFO_TOGGLE`), then everything the subclass
         appended to ``self._header_items``. Override (calling
         ``super().header_items()``) to weave in additional items;
         :class:`SourceNodeBase` does this to inject a frame-count
@@ -491,6 +571,13 @@ class NodeBase(ABC):
                 tooltip="Step over this node (pass inputs straight through)",
                 handler=self._toggle_skipped,
                 is_active=lambda: self._skipped,
+            ))
+        if self.HAS_INFO_TOGGLE:
+            items.append(Toggle(
+                glyph="info",
+                tooltip="Show frame metadata for this node",
+                handler=self._toggle_show_meta,
+                is_active=lambda: self._show_meta,
             ))
         items.extend(self._header_items)
         return items
@@ -570,6 +657,18 @@ class NodeBase(ABC):
                 # carry on so a buggy UI hook can't kill a flow.
                 logger.exception("Process observer raised; ignoring")
 
+        # Snapshot every input's current envelope before dispatch so
+        # post-process listeners (preview widgets reading
+        # :attr:`last_inputs` from the frame callback) see exactly the
+        # data the node operated on, not whatever a downstream
+        # ``InputPort.clear`` leaves behind. Captured before the
+        # port-driven attribute populate so the snapshot reflects
+        # raw inputs irrespective of how the node consumes them.
+        self._last_inputs = [
+            port.data if port.has_data else None
+            for port in self._inputs
+        ]
+
         try:
             # Populate self._<port_name> from any port currently driven
             # by an upstream, so process_impl can read its attributes
@@ -588,6 +687,20 @@ class NodeBase(ABC):
         except Exception:
             logger.exception(f"Exception in {type(self).__name__}.process_impl ({self._display_name})")
             raise
+
+        # Frame-callback fires after a successful process_impl so a
+        # preview widget never sees a half-computed state. A failed
+        # process_impl re-raises before we get here — the run is
+        # already coming down, so a missed preview repaint is moot.
+        if self._frame_callback is not None:
+            try:
+                self._frame_callback(self)
+            except Exception:
+                # A buggy preview must not bring down the flow.
+                logger.exception(
+                    f"Frame callback raised on {type(self).__name__} "
+                    f"({self._display_name}); ignoring"
+                )
 
     # ── Port-driven attribute population ────────────────────────────────────────
 
@@ -705,6 +818,10 @@ class NodeBase(ABC):
     def _before_run_impl(self) -> None:
         """Prepare node data before a run."""
         logger.debug(f"_before_run_impl: {self._display_name} ({type(self).__name__})")
+        # Clear the input snapshot so a preview widget doesn't render
+        # stale meta from the previous run before any new frame
+        # arrives. Populated again on the first :meth:`process` call.
+        self._last_inputs = []
 
     @final
     def after_run(self, run_success: bool) -> None:
@@ -774,6 +891,10 @@ class SourceNodeBase(NodeBase, ABC):
 
     DEFAULT_SECTION: str = "Sources"
     HEADER_ICON: str = "play_arrow"
+    # A source has no input meta to surface, so the auto-injected info
+    # toggle would have nothing to show. Opt out so the source's
+    # title-bar cluster stays the per-frame tick badge + close button.
+    HAS_INFO_TOGGLE: bool = False
 
     @property
     def is_reactive(self) -> bool:

--- a/src/nodes/debug/meta_inspector.py
+++ b/src/nodes/debug/meta_inspector.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from typing import Callable
-
 from typing_extensions import override
 
 from core.io_data import IoData, IoDataType
@@ -33,16 +31,15 @@ class MetaInspector(NodeBase):
     """
 
     HEADER_ICON = "info"
+    # The inspector's preview *is* the meta dump, so the auto-injected
+    # info :class:`Toggle` would be redundant — opt out so the title
+    # bar stays uncluttered.
+    HAS_INFO_TOGGLE: bool = False
 
     def __init__(self) -> None:
         super().__init__("Meta Inspector", section="Debug")
-        self._frame_callback: Callable[[IoData], None] | None = None
         self._add_input(InputPort("data", set(_ALL_TYPES)))
         self._add_output(OutputPort("data", set(_ALL_TYPES)))
-        # Snapshot of the most recent frame so the "copy meta" header
-        # button can re-format it on demand. Held by reference; the
-        # node never mutates the envelope.
-        self._last_data: IoData | None = None
         self._header_items.append(Command(
             glyph="content_copy",
             tooltip="Copy meta to clipboard",
@@ -51,35 +48,20 @@ class MetaInspector(NodeBase):
 
     # ── UI integration ─────────────────────────────────────────────────────────
 
-    def set_frame_callback(
-        self, callback: Callable[[IoData], None] | None,
-    ) -> None:
-        """Attach (or clear) a callback invoked with each new IoData.
-
-        The full envelope is handed over so the preview can render
-        meta fields, payload kind, and payload shape side by side.
-        Fires on whichever thread :meth:`process_impl` runs on; the
-        UI widget is responsible for marshalling back to the main
-        thread.
-        """
-        self._frame_callback = callback
-
     def _copy_meta_text(self) -> str | None:
         """Return the formatted meta text for the most recent frame, or
         ``None`` if no frame has been seen yet (so the header button
         is a no-op before the flow runs)."""
-        if self._last_data is None:
+        data = self._last_inputs[0] if self._last_inputs else None
+        if data is None:
             return None
-        return format_meta(self._last_data)
+        return format_meta(data)
 
     # ── NodeBase interface ─────────────────────────────────────────────────────
 
     @override
     def process_impl(self) -> None:
         in_data = self.inputs[0].data
-        self._last_data = in_data
-        if self._frame_callback is not None:
-            self._frame_callback(in_data)
         self.outputs[0].send(in_data)
 
 

--- a/src/nodes/filters/display.py
+++ b/src/nodes/filters/display.py
@@ -1,13 +1,12 @@
 from __future__ import annotations
 
 import time
-from typing import Callable
 
 import numpy as np
 from typing_extensions import override
 
-from core.io_data import IMAGE_TYPES, IoData, IoDataType
-from core.node_base import Command, NodeBase, Toggle
+from core.io_data import IMAGE_TYPES, IoDataType
+from core.node_base import Command, NodeBase
 from core.port import InputPort, OutputPort
 from nodes.debug.meta_inspector import format_meta
 
@@ -39,28 +38,16 @@ class Display(NodeBase):
     def __init__(self) -> None:
         super().__init__("Display", section="Output")
         self._latest_frame:    np.ndarray | None = None
-        self._last_data:       IoData | None = None
-        self._frame_callback:  Callable[[IoData], None] | None = None
         self._last_frame_ts:   float | None = None
         self._fps_ema:         float | None = None
         self._frame_count:     int = 0
-        # Header toggle: when on, the preview swaps the image / status
-        # bar for a scrollable meta-text view (the same rendering as
-        # the standalone MetaInspector). The widget polls
-        # :attr:`show_meta` on each repaint and re-subscribes to mode
-        # flips via :meth:`set_show_meta_callback`.
-        self._show_meta:                bool = False
-        self._show_meta_callback:       Callable[[], None] | None = None
 
         self._add_input(InputPort("image", set(_DISPLAY_TYPES)))
         self._add_output(OutputPort("image", set(_DISPLAY_TYPES)))
 
-        self._header_items.append(Toggle(
-            glyph="info",
-            tooltip="Show frame metadata instead of image",
-            handler=self._toggle_show_meta,
-            is_active=lambda: self._show_meta,
-        ))
+        # The info :class:`Toggle` (show frame meta instead of image)
+        # is auto-injected by :class:`NodeBase.header_items` for every
+        # non-source node — Display gets it for free.
         self._header_items.append(Command(
             glyph="content_copy",
             tooltip="Copy what's shown in the preview to the clipboard",
@@ -93,46 +80,7 @@ class Display(NodeBase):
         """
         return self._fps_ema
 
-    @property
-    def show_meta(self) -> bool:
-        """True when the preview should render frame metadata instead
-        of the image / status bar. Flipped by the header toggle; the
-        widget polls this on each repaint."""
-        return self._show_meta
-
     # ── UI integration ─────────────────────────────────────────────────────────
-
-    def set_frame_callback(
-        self, callback: Callable[[IoData], None] | None,
-    ) -> None:
-        """Attach (or clear) a callback invoked with each new IoData.
-
-        Receives the full :class:`IoData` envelope (not just the array)
-        so the preview widget can dispatch on payload kind — image
-        pixmap vs. scalar/matrix text. The widget can read
-        :attr:`current_fps` and :attr:`frames_processed` from the node
-        at callback time to render the status line.
-
-        The callback fires on whichever thread :meth:`process_impl`
-        runs on — the UI widget is responsible for marshalling back
-        to the main thread, typically via a queued Qt signal.
-        """
-        self._frame_callback = callback
-
-    def set_show_meta_callback(
-        self, callback: Callable[[], None] | None,
-    ) -> None:
-        """Attach (or clear) a callback fired when :attr:`show_meta`
-        flips. The preview widget uses it to swap which page of its
-        stack is visible without polling."""
-        self._show_meta_callback = callback
-
-    def _toggle_show_meta(self) -> None:
-        """Header-toggle handler: flip ``show_meta`` and notify the
-        widget so it can repaint in the new mode."""
-        self._show_meta = not self._show_meta
-        if self._show_meta_callback is not None:
-            self._show_meta_callback()
 
     def _copy_visible(self) -> object:
         """Header-command handler: return whatever the preview is
@@ -146,7 +94,7 @@ class Display(NodeBase):
           (str), matching what's drawn in the preview label.
         - No frame seen yet → ``None`` (silent no-op).
         """
-        data = self._last_data
+        data = self._last_inputs[0] if self._last_inputs else None
         if data is None:
             return None
         if self._show_meta:
@@ -165,7 +113,6 @@ class Display(NodeBase):
     def _before_run_impl(self) -> None:
         super()._before_run_impl()
         self._latest_frame  = None
-        self._last_data     = None
         self._last_frame_ts = None
         self._fps_ema       = None
         self._frame_count   = 0
@@ -173,7 +120,6 @@ class Display(NodeBase):
     @override
     def process_impl(self) -> None:
         in_data = self.inputs[0].data
-        self._last_data = in_data
 
         self._frame_count += 1
 
@@ -195,10 +141,6 @@ class Display(NodeBase):
         self._last_frame_ts = now
 
         self._latest_frame = in_data.payload
-
-        if self._frame_callback is not None:
-            self._frame_callback(in_data)
-
         self.outputs[0].send(in_data)
 
 

--- a/src/ui/node_item.py
+++ b/src/ui/node_item.py
@@ -33,7 +33,7 @@ from ui import clipboard
 from ui.icons import paint_material_glyph
 from ui.param_widgets import ParamWidgetBase, build_param_widget
 from ui.port_item import PortItem
-from ui.preview_widgets import build_preview_widget
+from ui.preview_widgets import build_meta_overlay, build_preview_widget
 from ui.theme import (
     BORDER_FROM_CATEGORY,
     FILTER_HEADER_COLOR,
@@ -427,6 +427,15 @@ class NodeItem(QGraphicsItem):
         self._param_proxies_by_row: dict[int, QGraphicsProxyWidget] = {}
         self._preview_widget: QWidget | None = None
         self._preview_proxy: QGraphicsProxyWidget | None = None
+        # Meta overlay for the auto-injected info toggle. Always built
+        # for non-source nodes (``HAS_INFO_TOGGLE``); positioned to
+        # cover the entire body area below the header whenever
+        # ``show_meta`` is on, hidden otherwise. Decoupled from
+        # ``_preview_widget`` so a node like Display keeps its image
+        # preview between toggle flips and the overlay simply rises
+        # on top of the rest of the body.
+        self._meta_overlay_widget: QWidget | None = None
+        self._meta_overlay_proxy: QGraphicsProxyWidget | None = None
         self._body_height: float = 0.0
         self._width: float = self.MAX_WIDTH
         # User-chosen overrides (from resize grip or flow load). None
@@ -649,6 +658,11 @@ class NodeItem(QGraphicsItem):
         )
 
         # ── port labels ──
+        # Skipped entirely when the info toggle is on: the meta
+        # overlay covers the body section below the header, so port
+        # labels would just bleed through.
+        if self._node.show_meta:
+            return
         painter.setPen(QPen(NODE_PARAM_LABEL_COLOR))
         label_inset = PortItem.LABEL_OFFSET
 
@@ -827,14 +841,49 @@ class NodeItem(QGraphicsItem):
             QTimer.singleShot(0, lambda: scene.remove_node_item(self))
 
     def _on_show_meta_changed(self) -> None:
-        """Forward the node's :attr:`show_meta` flip to the preview
-        widget (so it can swap pages or refresh content) and re-run
-        the layout pass so a preview whose footprint depends on the
-        flag (see :class:`GenericMetaPreview`) grows into or collapses
-        out of the body in lock-step with the toggle."""
-        if self._preview_widget is not None:
-            self._preview_widget.on_show_meta_changed()
-        self._relayout()
+        """Apply the node's :attr:`show_meta` flip: raise / hide the
+        meta overlay and dim the body content (ports + inline widgets
+        + regular preview) underneath. The node's outer dimensions are
+        intentionally untouched so the toggle never grows or shrinks
+        the node — the overlay simply fills whatever the body already
+        is and the user trades port-label visibility for a roomy meta
+        view at the existing size."""
+        self._apply_show_meta()
+        self.update()  # repaint to drop / restore port labels
+
+    def _apply_show_meta(self) -> None:
+        """Sync the visibility of every body-content child item to the
+        node's current :attr:`show_meta` flag.
+
+        Hidden when meta is on: every visible input port socket,
+        every per-row inline param widget, every constant-param
+        widget, and the regular preview (Display's image, PlayGate's
+        button). Output port sockets stay visible so a meta-mode
+        node can still be wired and link rerouting on drag keeps
+        working — the sockets paint to the body rim, well clear of
+        the overlay's scroll area.
+
+        Recomputes the per-row "would normally be visible" mask via
+        :meth:`_visible_input_count` rather than reading each
+        widget's current ``isVisible``: a previous meta-on pass set
+        them all to False, so reading current state would strand
+        rows hidden after the toggle flips back off. Called from
+        both :meth:`_on_show_meta_changed` (on toggle flip) and
+        :meth:`_relayout` (so a freshly built or rebuilt node lands
+        in the right state).
+        """
+        meta_on = self._node.show_meta
+        n_visible = self._visible_input_count()
+        for i, port in enumerate(self._input_ports):
+            port.setVisible(not meta_on and i < n_visible)
+        for i, proxy in self._param_proxies_by_row.items():
+            proxy.setVisible(not meta_on and i < n_visible)
+        for proxy in self._constant_proxies_by_row.values():
+            proxy.setVisible(not meta_on)
+        if self._preview_proxy is not None:
+            self._preview_proxy.setVisible(not meta_on)
+        if self._meta_overlay_proxy is not None:
+            self._meta_overlay_proxy.setVisible(meta_on)
 
     def _header_path(self) -> QPainterPath:
         """Path for the header strip: top corners rounded, bottom
@@ -932,14 +981,12 @@ class NodeItem(QGraphicsItem):
             port_need = max(port_need, row_need)
 
         # Preview widget asks for as much width as it can get; cap at
-        # MAX_WIDTH via the outer min() below. A preview that's
-        # currently inactive (e.g. :class:`GenericMetaPreview` with
-        # the info toggle off) reserves no extra width — otherwise
-        # a long port name on a non-source node would force every
-        # node to a wider footprint just because the dormant preview
-        # exists.
+        # MAX_WIDTH via the outer min() below. The meta overlay is
+        # explicitly excluded from sizing — its footprint is the body
+        # the rest of the node already establishes, so the toggle
+        # never grows or shrinks the node.
         preview_need = 0.0
-        if self._preview_widget is not None and self._preview_widget.is_active():
+        if self._preview_widget is not None:
             preview_need = float(self._preview_widget.sizeHint().width()) + 2 * self.PADDING
 
         content = max(header_need, port_need, preview_need)
@@ -1045,6 +1092,19 @@ class NodeItem(QGraphicsItem):
         else:
             self._preview_proxy = None
 
+        # Info-toggle meta overlay (every non-source node). Built once,
+        # positioned over the body in :meth:`_relayout`, visibility
+        # driven by the node's :attr:`show_meta` flag in
+        # :meth:`_apply_show_meta`. Sits at a higher Z than the rest of
+        # the body proxies so it cleanly covers them when raised.
+        overlay = build_meta_overlay(self._node)
+        if overlay is not None:
+            self._meta_overlay_widget = overlay
+            self._meta_overlay_proxy = QGraphicsProxyWidget(self)
+            self._meta_overlay_proxy.setWidget(overlay)
+            self._meta_overlay_proxy.setZValue(self.Z_VALUE + 1)
+            self._meta_overlay_proxy.setVisible(self._node.show_meta)
+
     def _visible_input_count(self) -> int:
         """Return how many input rows the body should render.
 
@@ -1116,15 +1176,8 @@ class NodeItem(QGraphicsItem):
 
         # Preview (if any) gets a natural minimum and stretches to fill
         # whatever vertical space the user dragged the resize grip to.
-        # An *inactive* preview (the info-toggle-off case for
-        # :class:`GenericMetaPreview`) collapses to zero so a non-source
-        # node looks unchanged whenever the user isn't asking for meta.
-        preview_active = (
-            self._preview_widget is not None
-            and self._preview_widget.is_active()
-        )
         natural_preview_h = 0.0
-        if preview_active:
+        if self._preview_widget is not None:
             natural_preview_h = max(
                 float(self._preview_widget.sizeHint().height()),
                 100.0,  # don't collapse below something legible
@@ -1139,10 +1192,10 @@ class NodeItem(QGraphicsItem):
         )
 
         # ── Body height ────────────────────────────────────────────────────────
-        if self._user_height is not None and preview_active:
-            # Only nodes whose preview is currently allocating space
+        if self._user_height is not None and self._preview_widget is not None:
+            # Only nodes that have something that can stretch (a preview)
             # honour vertical resize. For others the grip's Y drag is
-            # absorbed without effect — there's nothing to stretch.
+            # absorbed without effect.
             self._body_height = max(
                 natural_body_h,
                 min(self.MAX_USER_HEIGHT, self._user_height),
@@ -1190,14 +1243,27 @@ class NodeItem(QGraphicsItem):
 
         # ── Preview widget below the IO rows ───────────────────────────────────
         if self._preview_widget is not None and self._preview_proxy is not None:
-            self._preview_proxy.setVisible(preview_active)
-            if preview_active:
-                preview_top = inputs_top + n_inputs * self.PORT_ROW_HEIGHT + gap_before_preview
-                preview_h = self._body_height - preview_top - self.PADDING
-                preview_h = max(natural_preview_h, preview_h)
-                self._preview_widget.setFixedWidth(int(self._width - 2 * self.PADDING))
-                self._preview_widget.setFixedHeight(int(preview_h))
-                self._preview_proxy.setPos(self.PADDING, preview_top)
+            preview_top = inputs_top + n_inputs * self.PORT_ROW_HEIGHT + gap_before_preview
+            preview_h = self._body_height - preview_top - self.PADDING
+            preview_h = max(natural_preview_h, preview_h)
+            self._preview_widget.setFixedWidth(int(self._width - 2 * self.PADDING))
+            self._preview_widget.setFixedHeight(int(preview_h))
+            self._preview_proxy.setPos(self.PADDING, preview_top)
+
+        # ── Meta overlay (covers the body section below the header) ───────────
+        # Sized to whatever the body already is (never pushes the
+        # node larger). Visibility flips with ``show_meta`` via
+        # :meth:`_apply_show_meta`, which also dims the body content
+        # underneath so the overlay doesn't have to be opaque-sized
+        # to hide ports.
+        if self._meta_overlay_widget is not None and self._meta_overlay_proxy is not None:
+            overlay_top = self.HEADER_HEIGHT
+            overlay_h = self._body_height - overlay_top - self.PADDING
+            overlay_w = self._width - 2 * self.PADDING
+            self._meta_overlay_widget.setFixedWidth(int(max(0.0, overlay_w)))
+            self._meta_overlay_widget.setFixedHeight(int(max(0.0, overlay_h)))
+            self._meta_overlay_proxy.setPos(self.PADDING, overlay_top)
+        self._apply_show_meta()
 
         self.refresh_all_links()
         self.update()

--- a/src/ui/node_item.py
+++ b/src/ui/node_item.py
@@ -221,7 +221,7 @@ class _HeaderButtonItem(QGraphicsItem):
         painter.setRenderHint(QPainter.RenderHint.Antialiasing, True)
         active = isinstance(self._item, Toggle) and self._item.is_active()
         if self._hovered or self._pressed or active:
-            painter.setPen(Qt.NoPen)
+            painter.setPen(Qt.PenStyle.NoPen)
             alpha = 120 if active else 70
             painter.setBrush(QBrush(QColor(255, 255, 255, alpha)))
             painter.drawRoundedRect(self.boundingRect(), 2, 2)
@@ -588,7 +588,7 @@ class NodeItem(QGraphicsItem):
             glow = QColor(glow_color)
             glow.setAlpha(alpha)
             painter.setPen(QPen(glow, 1.0))
-            painter.setBrush(Qt.NoBrush)
+            painter.setBrush(Qt.BrushStyle.NoBrush)
             painter.drawRoundedRect(
                 body_rect.adjusted(-offset, -offset, offset, offset),
                 self.CORNER_RADIUS + offset,
@@ -596,7 +596,7 @@ class NodeItem(QGraphicsItem):
             )
 
         # ── body fill ──
-        painter.setPen(Qt.NoPen)
+        painter.setPen(Qt.PenStyle.NoPen)
         painter.setBrush(QBrush(NODE_BODY_COLOR))
         painter.drawRoundedRect(body_rect, self.CORNER_RADIUS, self.CORNER_RADIUS)
 
@@ -606,7 +606,7 @@ class NodeItem(QGraphicsItem):
             # path with rounded top corners only so it tucks under
             # the body's rounded outline. Drawn before the border so
             # the border's stroke clips the strip's edges cleanly.
-            painter.setPen(Qt.NoPen)
+            painter.setPen(Qt.PenStyle.NoPen)
             painter.setBrush(QBrush(accent))
             painter.drawPath(self._header_path())
         else:
@@ -623,7 +623,7 @@ class NodeItem(QGraphicsItem):
 
         # ── border (stroked last so nothing covers it) ──
         painter.setPen(border_pen)
-        painter.setBrush(Qt.NoBrush)
+        painter.setBrush(Qt.BrushStyle.NoBrush)
         painter.drawRoundedRect(body_rect, self.CORNER_RADIUS, self.CORNER_RADIUS)
 
         # ── header icon (declared by the node class via HEADER_ICON) ──
@@ -709,9 +709,9 @@ class NodeItem(QGraphicsItem):
                 break
             y = inputs_top + (i + 0.5) * self.PORT_ROW_HEIGHT
             label_right = self._width - label_inset
-            proxy = self._param_proxies_by_row.get(i)
-            if proxy is not None:
-                label_right = proxy.pos().x() - self.WIDGET_INSET
+            input_proxy = self._param_proxies_by_row.get(i)
+            if input_proxy is not None:
+                label_right = input_proxy.pos().x() - self.WIDGET_INSET
             painter.drawText(
                 QRectF(label_inset, y - self.PORT_ROW_HEIGHT / 2,
                        max(0.0, label_right - label_inset),
@@ -1033,8 +1033,11 @@ class NodeItem(QGraphicsItem):
         # Per input-port-index → editor (if param-style) and proxy.
         # Using parallel dicts keyed by port index so a layout pass
         # can find the right widget for row N without walking lists.
-        self._param_widgets_by_row: dict[int, ParamWidgetBase] = {}
-        self._param_proxies_by_row: dict[int, QGraphicsProxyWidget] = {}
+        # Annotated on the instance attributes in ``__init__``; this
+        # method is the canonical (re)builder, so it just resets to
+        # empty dicts.
+        self._param_widgets_by_row = {}
+        self._param_proxies_by_row = {}
 
         for i, port_model in enumerate(self._node.inputs):
             port_item = PortItem(self, "input", i, port_model)

--- a/src/ui/node_item.py
+++ b/src/ui/node_item.py
@@ -457,6 +457,14 @@ class NodeItem(QGraphicsItem):
         self._resize_grip = _ResizeGripItem(self)
 
         self._build_ports()
+        # Subscribe to the node's :attr:`show_meta` flag. The preview
+        # widget (if any) handles the visual swap; the layout pass
+        # re-runs so a preview that's only active in meta mode (see
+        # :class:`GenericMetaPreview`) can grow into the body or
+        # collapse out of it on the toggle flip. NodeItem owns this
+        # single subscription so the node-side API stays a one-callback
+        # contract.
+        node.set_show_meta_callback(self._on_show_meta_changed)
         self._relayout()
         # Repaint the header badge whenever a constant param changes so the
         # tick count stays in sync with the current param values.
@@ -818,6 +826,16 @@ class NodeItem(QGraphicsItem):
         if scene is not None and hasattr(scene, "remove_node_item"):
             QTimer.singleShot(0, lambda: scene.remove_node_item(self))
 
+    def _on_show_meta_changed(self) -> None:
+        """Forward the node's :attr:`show_meta` flip to the preview
+        widget (so it can swap pages or refresh content) and re-run
+        the layout pass so a preview whose footprint depends on the
+        flag (see :class:`GenericMetaPreview`) grows into or collapses
+        out of the body in lock-step with the toggle."""
+        if self._preview_widget is not None:
+            self._preview_widget.on_show_meta_changed()
+        self._relayout()
+
     def _header_path(self) -> QPainterPath:
         """Path for the header strip: top corners rounded, bottom
         corners square. Used by themes that opt into the classic
@@ -914,9 +932,14 @@ class NodeItem(QGraphicsItem):
             port_need = max(port_need, row_need)
 
         # Preview widget asks for as much width as it can get; cap at
-        # MAX_WIDTH via the outer min() below.
+        # MAX_WIDTH via the outer min() below. A preview that's
+        # currently inactive (e.g. :class:`GenericMetaPreview` with
+        # the info toggle off) reserves no extra width — otherwise
+        # a long port name on a non-source node would force every
+        # node to a wider footprint just because the dormant preview
+        # exists.
         preview_need = 0.0
-        if self._preview_widget is not None:
+        if self._preview_widget is not None and self._preview_widget.is_active():
             preview_need = float(self._preview_widget.sizeHint().width()) + 2 * self.PADDING
 
         content = max(header_need, port_need, preview_need)
@@ -1093,8 +1116,15 @@ class NodeItem(QGraphicsItem):
 
         # Preview (if any) gets a natural minimum and stretches to fill
         # whatever vertical space the user dragged the resize grip to.
+        # An *inactive* preview (the info-toggle-off case for
+        # :class:`GenericMetaPreview`) collapses to zero so a non-source
+        # node looks unchanged whenever the user isn't asking for meta.
+        preview_active = (
+            self._preview_widget is not None
+            and self._preview_widget.is_active()
+        )
         natural_preview_h = 0.0
-        if self._preview_widget is not None:
+        if preview_active:
             natural_preview_h = max(
                 float(self._preview_widget.sizeHint().height()),
                 100.0,  # don't collapse below something legible
@@ -1109,10 +1139,10 @@ class NodeItem(QGraphicsItem):
         )
 
         # ── Body height ────────────────────────────────────────────────────────
-        if self._user_height is not None and self._preview_widget is not None:
-            # Only nodes that have something that can stretch (a preview)
+        if self._user_height is not None and preview_active:
+            # Only nodes whose preview is currently allocating space
             # honour vertical resize. For others the grip's Y drag is
-            # absorbed without effect.
+            # absorbed without effect — there's nothing to stretch.
             self._body_height = max(
                 natural_body_h,
                 min(self.MAX_USER_HEIGHT, self._user_height),
@@ -1160,12 +1190,14 @@ class NodeItem(QGraphicsItem):
 
         # ── Preview widget below the IO rows ───────────────────────────────────
         if self._preview_widget is not None and self._preview_proxy is not None:
-            preview_top = inputs_top + n_inputs * self.PORT_ROW_HEIGHT + gap_before_preview
-            preview_h = self._body_height - preview_top - self.PADDING
-            preview_h = max(natural_preview_h, preview_h)
-            self._preview_widget.setFixedWidth(int(self._width - 2 * self.PADDING))
-            self._preview_widget.setFixedHeight(int(preview_h))
-            self._preview_proxy.setPos(self.PADDING, preview_top)
+            self._preview_proxy.setVisible(preview_active)
+            if preview_active:
+                preview_top = inputs_top + n_inputs * self.PORT_ROW_HEIGHT + gap_before_preview
+                preview_h = self._body_height - preview_top - self.PADDING
+                preview_h = max(natural_preview_h, preview_h)
+                self._preview_widget.setFixedWidth(int(self._width - 2 * self.PADDING))
+                self._preview_widget.setFixedHeight(int(preview_h))
+                self._preview_proxy.setPos(self.PADDING, preview_top)
 
         self.refresh_all_links()
         self.update()

--- a/src/ui/node_item.py
+++ b/src/ui/node_item.py
@@ -855,13 +855,14 @@ class NodeItem(QGraphicsItem):
         """Sync the visibility of every body-content child item to the
         node's current :attr:`show_meta` flag.
 
-        Hidden when meta is on: every visible input port socket,
-        every per-row inline param widget, every constant-param
-        widget, and the regular preview (Display's image, PlayGate's
-        button). Output port sockets stay visible so a meta-mode
-        node can still be wired and link rerouting on drag keeps
-        working — the sockets paint to the body rim, well clear of
-        the overlay's scroll area.
+        Hidden when meta is on: the per-row inline param widgets, the
+        constants block widgets, and the regular preview (Display's
+        image, PlayGate's button) — anything that paints inside the
+        body rectangle and would bleed through the overlay's scroll
+        area. Port sockets on **both** sides stay visible: they sit
+        on the body rim (input dots at ``x = 0``, output dots at
+        ``x = width``), well clear of the overlay's ``PADDING`` inset,
+        so the user can keep wiring connections while reading meta.
 
         Recomputes the per-row "would normally be visible" mask via
         :meth:`_visible_input_count` rather than reading each
@@ -874,8 +875,6 @@ class NodeItem(QGraphicsItem):
         """
         meta_on = self._node.show_meta
         n_visible = self._visible_input_count()
-        for i, port in enumerate(self._input_ports):
-            port.setVisible(not meta_on and i < n_visible)
         for i, proxy in self._param_proxies_by_row.items():
             proxy.setVisible(not meta_on and i < n_visible)
         for proxy in self._constant_proxies_by_row.values():

--- a/src/ui/node_item.py
+++ b/src/ui/node_item.py
@@ -1122,7 +1122,12 @@ class NodeItem(QGraphicsItem):
             return len(all_inputs)
         last_connected = -1
         for i, port_item in enumerate(all_inputs):
-            if port_item.model.upstream is not None:
+            # ``PortItem.model`` is typed ``InputPort | OutputPort``;
+            # ``_input_ports`` only ever holds input-side items so
+            # ``upstream`` is always defined here. ``getattr`` keeps
+            # the static checker quiet without a redundant runtime
+            # ``isinstance`` narrow.
+            if getattr(port_item.model, "upstream", None) is not None:
                 last_connected = i
         # Show one row beyond the last connection — capped at the pool
         # size — and never less than one so the node has at least one

--- a/src/ui/node_item.py
+++ b/src/ui/node_item.py
@@ -1200,10 +1200,17 @@ class NodeItem(QGraphicsItem):
         )
 
         # ── Body height ────────────────────────────────────────────────────────
-        if self._user_height is not None and self._preview_widget is not None:
-            # Only nodes that have something that can stretch (a preview)
-            # honour vertical resize. For others the grip's Y drag is
-            # absorbed without effect.
+        # Honour the user's vertical resize on every node, not just
+        # nodes with a regular preview. The meta overlay added by the
+        # info toggle wants room to render its scrollable dump on
+        # filters and sinks that have no other body content to
+        # stretch — a Grayscale or FileSink should be growable so the
+        # user can read meta without scrolling.  The natural height
+        # is still the floor (the grip can never shrink past
+        # everything the body needs to show its ports / widgets /
+        # preview), and ``MAX_USER_HEIGHT`` still caps the top so a
+        # runaway drag doesn't turn the canvas into a wall.
+        if self._user_height is not None:
             self._body_height = max(
                 natural_body_h,
                 min(self.MAX_USER_HEIGHT, self._user_height),

--- a/src/ui/param_widgets.py
+++ b/src/ui/param_widgets.py
@@ -25,7 +25,7 @@ from PySide6.QtWidgets import (
 from constants import INPUT_DIR, OUTPUT_DIR
 from core.filename_template import expand as expand_template
 from core.io_data import IoDataType
-from core.node_base import NodeBase, NodeParamType
+from core.node_base import NodeBase, NodeParam, NodeParamType
 from core.port import InputPort
 from ui.controls.scene_aware_combobox import SceneAwareComboBox
 from ui.icons import material_icon
@@ -830,8 +830,16 @@ def _install_description_tooltip(
             child.setToolTip(desc)
 
 
-def build_param_widget(node: NodeBase, port: InputPort) -> ParamWidgetBase | None:
+def build_param_widget(
+    node: NodeBase, port: InputPort | NodeParam,
+) -> ParamWidgetBase | None:
     """Return a :class:`ParamWidgetBase` that edits *port* on *node*.
+
+    *port* may be either a port-style :class:`InputPort` (driveable
+    from upstream, rendered on its own port row) or a constant-style
+    :class:`NodeParam` (no socket, italic caption); both expose the
+    same ``name`` / ``metadata`` / ``upstream`` surface this builder
+    relies on.
 
     Returns ``None`` for unsupported param types, so callers can render a
     placeholder label instead of crashing.  Also returns ``None`` (with

--- a/src/ui/preview_widgets.py
+++ b/src/ui/preview_widgets.py
@@ -46,6 +46,24 @@ class _PreviewWidgetBase(QWidget):
         super().__init__()
         self._node = node
 
+    def is_active(self) -> bool:
+        """Return ``True`` when the preview wants to occupy body
+        space, ``False`` to collapse to zero height. ``NodeItem`` polls
+        this on every layout pass so a preview that's only relevant
+        when the node's info toggle is on (see
+        :class:`GenericMetaPreview`) doesn't take up vertical room
+        the rest of the time. Default: always active — most previews
+        are unconditional."""
+        return True
+
+    def on_show_meta_changed(self) -> None:
+        """Hook invoked when the owning node's :attr:`show_meta` flag
+        flips. Default: no-op. Override to swap which page of a stacked
+        widget is current (e.g. :class:`DisplayPreview` flips between
+        image and meta) or to refresh content the toggle should now
+        surface (e.g. :class:`GenericMetaPreview` re-emits the latest
+        meta when becoming visible)."""
+
 
 class DisplayPreview(_PreviewWidgetBase):
     """Inline preview for :class:`~nodes.filters.display.Display`.
@@ -173,11 +191,18 @@ class DisplayPreview(_PreviewWidgetBase):
         self._meta_ready.connect(self._on_meta_ready)
         self._mode_changed.connect(self._on_mode_changed)
         node.set_frame_callback(self._emit_from_worker)
-        node.set_show_meta_callback(self._mode_changed.emit)
         # Show whichever page matches the node's current flag (defaults
         # to image, but a flow loaded with the toggle on would land
         # straight on meta).
         self._on_mode_changed()
+
+    @override
+    def on_show_meta_changed(self) -> None:
+        # Swap the stacked page when the auto-injected info toggle
+        # flips. The :class:`NodeItem` driving this preview owns the
+        # node's single show-meta callback and forwards the signal
+        # here.
+        self._mode_changed.emit()
 
     @override
     def resizeEvent(self, event) -> None:  # type: ignore[override]
@@ -186,7 +211,7 @@ class DisplayPreview(_PreviewWidgetBase):
 
     # ── Worker thread ──────────────────────────────────────────────────────────
 
-    def _emit_from_worker(self, in_data: IoData) -> None:
+    def _emit_from_worker(self, node: NodeBase) -> None:
         """Called from whichever thread runs the Display node's process.
 
         Updates both pages of the stack so the toggle is instant. The
@@ -199,8 +224,11 @@ class DisplayPreview(_PreviewWidgetBase):
         from the node here, on the worker thread, so the snapshot
         stays consistent with the payload being sent.
         """
-        node = self._node
         assert isinstance(node, Display)
+        last = node.last_inputs
+        in_data = last[0] if last else None
+        if in_data is None:
+            return
         status = _format_status(
             node.current_fps, node.frames_processed, in_data.payload,
         )
@@ -414,7 +442,11 @@ class MetaInspectorPreview(_PreviewWidgetBase):
         self._text_ready.connect(self._on_text_ready)
         node.set_frame_callback(self._emit_from_worker)
 
-    def _emit_from_worker(self, data: IoData) -> None:
+    def _emit_from_worker(self, node: NodeBase) -> None:
+        last = node.last_inputs
+        data = last[0] if last else None
+        if data is None:
+            return
         self._text_ready.emit(format_meta(data))
 
     @Slot(str)
@@ -493,6 +525,104 @@ class PlayGatePreview(_PreviewWidgetBase):
         node.request_emit()
 
 
+# ── Generic meta preview ──────────────────────────────────────────────────────
+
+
+class GenericMetaPreview(_PreviewWidgetBase):
+    """Inline meta preview for any non-source node that doesn't ship
+    its own preview widget.
+
+    Visible only while the node's auto-injected info toggle is on; in
+    that mode it renders one section per input port, formatted like
+    the standalone :class:`MetaInspector` (see :func:`format_meta`).
+    When the toggle is off, :meth:`is_active` returns ``False`` and
+    ``NodeItem`` collapses the preview area so a non-source node
+    looks unchanged whenever the user isn't asking for meta.
+
+    The text snapshot is held by the widget and re-emitted whenever
+    the toggle flips back on, so the user sees the most recent frame's
+    meta even if the flow finished while the toggle was off.
+    """
+
+    _text_ready = Signal(str)
+
+    _PREVIEW_MIN_W: int = 220
+    _PREVIEW_MIN_H: int = 90
+    _EMPTY_PLACEHOLDER: str = "(no frame yet)"
+
+    def __init__(self, node: NodeBase) -> None:
+        super().__init__(node)
+        self._label = QLabel()
+        self._label.setAlignment(
+            Qt.AlignmentFlag.AlignTop | Qt.AlignmentFlag.AlignLeft,
+        )
+        self._label.setSizePolicy(
+            QSizePolicy.Policy.Expanding, QSizePolicy.Policy.MinimumExpanding,
+        )
+        self._label.setStyleSheet(
+            "QLabel { background: #111; color: #d6d6d6; padding: 4px;"
+            "         font-family: 'Consolas','Menlo',monospace;"
+            "         font-size: 11px; }"
+        )
+        self._label.setWordWrap(True)
+        self._label.setText(self._EMPTY_PLACEHOLDER)
+
+        self._scroll = QScrollArea()
+        self._scroll.setWidget(self._label)
+        self._scroll.setWidgetResizable(True)
+        self._scroll.setFrameShape(QFrame.Shape.Box)
+        self._scroll.setMinimumSize(self._PREVIEW_MIN_W, self._PREVIEW_MIN_H)
+        self._scroll.setSizePolicy(
+            QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding,
+        )
+        self._scroll.setStyleSheet(
+            "QScrollArea { background: #111; border: 1px solid #333; }"
+        )
+
+        self.setSizePolicy(
+            QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding,
+        )
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.addWidget(self._scroll)
+
+        self._text_ready.connect(self._on_text_ready)
+        node.set_frame_callback(self._emit_from_worker)
+        # Hidden until the toggle flips on; ``NodeItem`` calls
+        # ``setVisible(True)`` via its layout pass when ``is_active``
+        # turns True.
+        self.setVisible(node.show_meta)
+
+    @override
+    def is_active(self) -> bool:
+        return self._node.show_meta
+
+    @override
+    def on_show_meta_changed(self) -> None:
+        # ``NodeItem`` re-runs its layout pass right after this returns
+        # so the preview swaps in / out without a one-frame lag.
+        self.setVisible(self._node.show_meta)
+
+    def _emit_from_worker(self, node: NodeBase) -> None:
+        # Always render — even when the toggle is currently off — so
+        # flipping it back on shows the most recent frame's meta
+        # without waiting for the next dispatch.
+        sections: list[str] = []
+        last = node.last_inputs
+        for i, port in enumerate(node.inputs):
+            data = last[i] if i < len(last) else None
+            if data is None:
+                continue
+            sections.append(f"── {port.name} ──\n{format_meta(data)}")
+        text = "\n\n".join(sections) if sections else self._EMPTY_PLACEHOLDER
+        self._text_ready.emit(text)
+
+    @Slot(str)
+    def _on_text_ready(self, text: str) -> None:
+        self._label.setText(text)
+        self._label.update()
+
+
 # ── Registry ───────────────────────────────────────────────────────────────────
 
 _PREVIEW_WIDGET_CLASSES: dict[type[NodeBase], type[_PreviewWidgetBase]] = {
@@ -506,11 +636,18 @@ def build_preview_widget(node: NodeBase) -> _PreviewWidgetBase | None:
     """Return an inline preview for *node*, or ``None`` if the node
     doesn't have one registered.
 
-    :class:`~ui.node_item.NodeItem` calls this after building the
-    param widgets; a non-``None`` result is embedded in the node body
-    below the params.
+    Falls back to :class:`GenericMetaPreview` for any node that
+    advertises ``HAS_INFO_TOGGLE`` (every non-source node by default,
+    minus the few that opt out): the auto-injected info toggle would
+    have nothing to drive without a preview, so the framework
+    provides a meta-dump preview that lives dormant until the user
+    flips the toggle on. :class:`~ui.node_item.NodeItem` calls this
+    after building the param widgets; a non-``None`` result is
+    embedded in the node body below the params.
     """
     cls = _PREVIEW_WIDGET_CLASSES.get(type(node))
+    if cls is None and node.HAS_INFO_TOGGLE:
+        cls = GenericMetaPreview
     if cls is None:
         return None
     try:

--- a/src/ui/preview_widgets.py
+++ b/src/ui/preview_widgets.py
@@ -14,13 +14,12 @@ from PySide6.QtWidgets import (
     QPushButton,
     QScrollArea,
     QSizePolicy,
-    QStackedWidget,
     QVBoxLayout,
     QWidget,
 )
 
 from core import notifications
-from core.io_data import IoData, IoDataType
+from core.io_data import IoDataType
 from core.node_base import NodeBase
 from nodes.debug.meta_inspector import MetaInspector, format_meta
 from nodes.debug.play_gate import PlayGate
@@ -46,42 +45,20 @@ class _PreviewWidgetBase(QWidget):
         super().__init__()
         self._node = node
 
-    def is_active(self) -> bool:
-        """Return ``True`` when the preview wants to occupy body
-        space, ``False`` to collapse to zero height. ``NodeItem`` polls
-        this on every layout pass so a preview that's only relevant
-        when the node's info toggle is on (see
-        :class:`GenericMetaPreview`) doesn't take up vertical room
-        the rest of the time. Default: always active — most previews
-        are unconditional."""
-        return True
-
-    def on_show_meta_changed(self) -> None:
-        """Hook invoked when the owning node's :attr:`show_meta` flag
-        flips. Default: no-op. Override to swap which page of a stacked
-        widget is current (e.g. :class:`DisplayPreview` flips between
-        image and meta) or to refresh content the toggle should now
-        surface (e.g. :class:`GenericMetaPreview` re-emits the latest
-        meta when becoming visible)."""
-
 
 class DisplayPreview(_PreviewWidgetBase):
     """Inline preview for :class:`~nodes.filters.display.Display`.
 
-    Two modes, switched by the node's "show metadata" header toggle:
+    Every frame the Display sees is rendered as a scaled pixmap (or
+    formatted text for SCALAR / MATRIX payloads), with a status line
+    beneath listing FPS, running frame number, and payload shape.
+    Frames arrive on the worker thread via the node's
+    ``frame_callback``; queued :class:`Signal`-s hop them to the UI
+    thread before any QLabel updates.
 
-    - **Image mode (default).** Every frame the Display sees is
-      rendered as a scaled pixmap (or formatted text for SCALAR /
-      MATRIX payloads), with a status line beneath listing FPS,
-      running frame number, and payload shape.
-    - **Meta mode.** A scrollable text dump of the IoMeta + payload
-      summary — the same rendering the standalone
-      :class:`MetaInspector` provides.
-
-    Both pages stay in sync with each frame so toggling the header
-    swap is instant. Frames arrive on the worker thread via the
-    node's ``frame_callback``; queued :class:`Signal`-s hop them to
-    the UI thread before any QLabel updates.
+    Meta-text rendering lives in the overlaid :class:`MetaOverlay`
+    that ``NodeItem`` raises whenever the info toggle is on — this
+    preview only ever shows the image (or scalar / matrix text).
     """
 
     #: Worker thread emits a ready QImage and the status string for
@@ -91,21 +68,14 @@ class DisplayPreview(_PreviewWidgetBase):
     #: Worker thread emits formatted text and the status string for
     #: SCALAR / MATRIX payloads.
     _text_ready = Signal(str, str)
-    #: Worker thread emits the formatted meta dump for the meta page.
-    _meta_ready = Signal(str)
-    #: UI thread emits when the node's ``show_meta`` flag flips so
-    #: the stacked widget can swap pages without polling.
-    _mode_changed = Signal()
 
     _PREVIEW_MIN_W: int = 180
     _PREVIEW_MIN_H: int = 100
 
     _STATUS_PLACEHOLDER: str = "—"
-    _META_PLACEHOLDER: str = "(run the flow to see meta)"
 
     def __init__(self, node: Display) -> None:
         super().__init__(node)
-        # ── Image page ──────────────────────────────────────────────
         self._label = QLabel()
         self._label.setAlignment(Qt.AlignmentFlag.AlignCenter)
         self._label.setMinimumSize(self._PREVIEW_MIN_W, self._PREVIEW_MIN_H)
@@ -135,52 +105,15 @@ class DisplayPreview(_PreviewWidgetBase):
             "         font-size: 11px; padding: 2px 6px; }"
         )
 
-        self._image_page = QWidget()
-        image_layout = QVBoxLayout(self._image_page)
-        image_layout.setContentsMargins(0, 0, 0, 0)
-        image_layout.setSpacing(0)
-        image_layout.addWidget(self._label, 1)
-        image_layout.addWidget(self._status, 0)
-
-        # ── Meta page ───────────────────────────────────────────────
-        self._meta_label = QLabel()
-        self._meta_label.setAlignment(
-            Qt.AlignmentFlag.AlignTop | Qt.AlignmentFlag.AlignLeft,
-        )
-        self._meta_label.setSizePolicy(
-            QSizePolicy.Policy.Expanding, QSizePolicy.Policy.MinimumExpanding,
-        )
-        self._meta_label.setStyleSheet(
-            "QLabel { background: #111; color: #d6d6d6; padding: 4px;"
-            "         font-family: 'Consolas','Menlo',monospace;"
-            "         font-size: 11px; }"
-        )
-        # Word-wrap so a long source_path doesn't blow out the body
-        # width and force the user to resize the node.
-        self._meta_label.setWordWrap(True)
-        self._meta_label.setText(self._META_PLACEHOLDER)
-
-        self._meta_scroll = QScrollArea()
-        self._meta_scroll.setWidget(self._meta_label)
-        self._meta_scroll.setWidgetResizable(True)
-        self._meta_scroll.setFrameShape(QFrame.Shape.Box)
-        self._meta_scroll.setMinimumSize(self._PREVIEW_MIN_W, self._PREVIEW_MIN_H)
-        self._meta_scroll.setStyleSheet(
-            "QScrollArea { background: #111; border: 1px solid #333; }"
-        )
-
-        # ── Stack ───────────────────────────────────────────────────
-        self._stack = QStackedWidget()
-        self._stack.addWidget(self._image_page)
-        self._stack.addWidget(self._meta_scroll)
-
         # Mirror Expanding on the enclosing widget so its parent layout
         # honours vertical stretch rather than collapsing to sizeHint.
         self.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding)
 
         layout = QVBoxLayout(self)
         layout.setContentsMargins(0, 0, 0, 0)
-        layout.addWidget(self._stack)
+        layout.setSpacing(0)
+        layout.addWidget(self._label, 1)
+        layout.addWidget(self._status, 0)
 
         # Original-resolution frame; we always scale from this to avoid
         # losing quality on successive resizes.
@@ -188,21 +121,7 @@ class DisplayPreview(_PreviewWidgetBase):
 
         self._frame_ready.connect(self._on_frame_ready)
         self._text_ready.connect(self._on_text_ready)
-        self._meta_ready.connect(self._on_meta_ready)
-        self._mode_changed.connect(self._on_mode_changed)
         node.set_frame_callback(self._emit_from_worker)
-        # Show whichever page matches the node's current flag (defaults
-        # to image, but a flow loaded with the toggle on would land
-        # straight on meta).
-        self._on_mode_changed()
-
-    @override
-    def on_show_meta_changed(self) -> None:
-        # Swap the stacked page when the auto-injected info toggle
-        # flips. The :class:`NodeItem` driving this preview owns the
-        # node's single show-meta callback and forwards the signal
-        # here.
-        self._mode_changed.emit()
 
     @override
     def resizeEvent(self, event) -> None:  # type: ignore[override]
@@ -214,15 +133,14 @@ class DisplayPreview(_PreviewWidgetBase):
     def _emit_from_worker(self, node: NodeBase) -> None:
         """Called from whichever thread runs the Display node's process.
 
-        Updates both pages of the stack so the toggle is instant. The
-        meta-text emit is unconditional; image-mode dispatches on
-        payload kind: image payloads convert to a self-owning QImage
-        (so the underlying numpy buffer can be freed without tearing
-        the pixmap) and hop across threads via ``_frame_ready``;
-        SCALAR / MATRIX payloads format to a string and hop via
-        ``_text_ready``. The current FPS and frame count are read
-        from the node here, on the worker thread, so the snapshot
-        stays consistent with the payload being sent.
+        Image-mode dispatches on payload kind: image payloads convert
+        to a self-owning QImage (so the underlying numpy buffer can
+        be freed without tearing the pixmap) and hop across threads
+        via ``_frame_ready``; SCALAR / MATRIX payloads format to a
+        string and hop via ``_text_ready``. The current FPS and
+        frame count are read from the node here, on the worker
+        thread, so the snapshot stays consistent with the payload
+        being sent.
         """
         assert isinstance(node, Display)
         last = node.last_inputs
@@ -232,10 +150,6 @@ class DisplayPreview(_PreviewWidgetBase):
         status = _format_status(
             node.current_fps, node.frames_processed, in_data.payload,
         )
-
-        # Keep the meta page in lockstep with the image page so
-        # toggling the header switches instantly to the right text.
-        self._meta_ready.emit(format_meta(in_data))
 
         if in_data.type is IoDataType.SCALAR:
             self._text_ready.emit(format_scalar(in_data.payload), status)
@@ -275,22 +189,6 @@ class DisplayPreview(_PreviewWidgetBase):
         self._label.setPixmap(QPixmap())
         self._label.setText(text)
         self._status.setText(status)
-
-    @Slot(str)
-    def _on_meta_ready(self, text: str) -> None:
-        self._meta_label.setText(text)
-        # Same belt-and-braces nudge as the standalone MetaInspector
-        # widget — same-thread emits during click handlers can leave
-        # the proxy widget without a fresh paint until the next
-        # event-loop turn.
-        self._meta_label.update()
-
-    @Slot()
-    def _on_mode_changed(self) -> None:
-        node = self._node
-        assert isinstance(node, Display)
-        target = self._meta_scroll if node.show_meta else self._image_page
-        self._stack.setCurrentWidget(target)
 
     def _render_scaled(self) -> None:
         if self._source_image is None:
@@ -525,33 +423,36 @@ class PlayGatePreview(_PreviewWidgetBase):
         node.request_emit()
 
 
-# ── Generic meta preview ──────────────────────────────────────────────────────
+# ── Meta overlay (info-toggle target) ─────────────────────────────────────────
 
 
-class GenericMetaPreview(_PreviewWidgetBase):
-    """Inline meta preview for any non-source node that doesn't ship
-    its own preview widget.
+class MetaOverlay(QWidget):
+    """Scrollable text dump that fills the body area below a node's
+    header whenever the auto-injected info toggle is on.
 
-    Visible only while the node's auto-injected info toggle is on; in
-    that mode it renders one section per input port, formatted like
-    the standalone :class:`MetaInspector` (see :func:`format_meta`).
-    When the toggle is off, :meth:`is_active` returns ``False`` and
-    ``NodeItem`` collapses the preview area so a non-source node
-    looks unchanged whenever the user isn't asking for meta.
+    Always present on every non-source node, never contributes to the
+    node's natural width / height — :class:`ui.node_item.NodeItem`
+    sizes it to whatever the body already is and toggles its
+    visibility (plus the visibility of the body's ports / inline
+    widgets / regular preview) on the show-meta flip. When visible
+    it covers the section below the header completely; the user
+    accepts losing port labels in exchange for a roomy meta view at
+    the node's existing dimensions.
 
-    The text snapshot is held by the widget and re-emitted whenever
-    the toggle flips back on, so the user sees the most recent frame's
-    meta even if the flow finished while the toggle was off.
+    Renders one section per input port (with ``format_meta``); empty
+    inputs are skipped. The text is re-emitted on every frame so
+    flipping the toggle back on shows the most recent meta without
+    waiting for the next dispatch.
     """
 
     _text_ready = Signal(str)
 
-    _PREVIEW_MIN_W: int = 220
-    _PREVIEW_MIN_H: int = 90
     _EMPTY_PLACEHOLDER: str = "(no frame yet)"
 
     def __init__(self, node: NodeBase) -> None:
-        super().__init__(node)
+        super().__init__()
+        self._node = node
+
         self._label = QLabel()
         self._label.setAlignment(
             Qt.AlignmentFlag.AlignTop | Qt.AlignmentFlag.AlignLeft,
@@ -571,7 +472,6 @@ class GenericMetaPreview(_PreviewWidgetBase):
         self._scroll.setWidget(self._label)
         self._scroll.setWidgetResizable(True)
         self._scroll.setFrameShape(QFrame.Shape.Box)
-        self._scroll.setMinimumSize(self._PREVIEW_MIN_W, self._PREVIEW_MIN_H)
         self._scroll.setSizePolicy(
             QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding,
         )
@@ -587,26 +487,15 @@ class GenericMetaPreview(_PreviewWidgetBase):
         layout.addWidget(self._scroll)
 
         self._text_ready.connect(self._on_text_ready)
-        node.set_frame_callback(self._emit_from_worker)
-        # Hidden until the toggle flips on; ``NodeItem`` calls
-        # ``setVisible(True)`` via its layout pass when ``is_active``
-        # turns True.
+        # The owning node's :meth:`set_frame_callback` is single-slot,
+        # so the overlay subscribes through a dedicated meta-tap on
+        # ``NodeBase`` (see :meth:`add_meta_listener`) instead of
+        # competing with whichever preview widget needs the primary
+        # frame callback for image rendering.
+        node.add_meta_listener(self._emit_from_worker)
         self.setVisible(node.show_meta)
 
-    @override
-    def is_active(self) -> bool:
-        return self._node.show_meta
-
-    @override
-    def on_show_meta_changed(self) -> None:
-        # ``NodeItem`` re-runs its layout pass right after this returns
-        # so the preview swaps in / out without a one-frame lag.
-        self.setVisible(self._node.show_meta)
-
     def _emit_from_worker(self, node: NodeBase) -> None:
-        # Always render — even when the toggle is currently off — so
-        # flipping it back on shows the most recent frame's meta
-        # without waiting for the next dispatch.
         sections: list[str] = []
         last = node.last_inputs
         for i, port in enumerate(node.inputs):
@@ -636,18 +525,14 @@ def build_preview_widget(node: NodeBase) -> _PreviewWidgetBase | None:
     """Return an inline preview for *node*, or ``None`` if the node
     doesn't have one registered.
 
-    Falls back to :class:`GenericMetaPreview` for any node that
-    advertises ``HAS_INFO_TOGGLE`` (every non-source node by default,
-    minus the few that opt out): the auto-injected info toggle would
-    have nothing to drive without a preview, so the framework
-    provides a meta-dump preview that lives dormant until the user
-    flips the toggle on. :class:`~ui.node_item.NodeItem` calls this
-    after building the param widgets; a non-``None`` result is
-    embedded in the node body below the params.
+    :class:`~ui.node_item.NodeItem` calls this after building the
+    param widgets; a non-``None`` result is embedded in the node body
+    below the params. The meta-info overlay (:class:`MetaOverlay`)
+    is built independently and raised on top of this preview when
+    the info toggle is on, so a node with a registered preview keeps
+    it for the image / button / etc. and only swaps to meta on demand.
     """
     cls = _PREVIEW_WIDGET_CLASSES.get(type(node))
-    if cls is None and node.HAS_INFO_TOGGLE:
-        cls = GenericMetaPreview
     if cls is None:
         return None
     try:
@@ -656,5 +541,22 @@ def build_preview_widget(node: NodeBase) -> _PreviewWidgetBase | None:
         logger.exception(
             "Failed to build %s preview widget for %s",
             cls.__name__, type(node).__name__,
+        )
+        return None
+
+
+def build_meta_overlay(node: NodeBase) -> MetaOverlay | None:
+    """Return the meta overlay for *node* — ``None`` for nodes whose
+    class opts out of the info toggle (sources, MetaInspector). The
+    overlay is always built (not just when the toggle is on) so the
+    incoming frame stream stays subscribed and the user sees current
+    meta the instant the toggle flips."""
+    if not node.HAS_INFO_TOGGLE:
+        return None
+    try:
+        return MetaOverlay(node)
+    except Exception:
+        logger.exception(
+            "Failed to build MetaOverlay for %s", type(node).__name__,
         )
         return None

--- a/src/ui/theme.py
+++ b/src/ui/theme.py
@@ -192,6 +192,58 @@ def _reexport(theme: Theme) -> None:
 _reexport(_active_theme)
 
 
+# ── Static hints for the dynamically populated re-exports ──────────────────────
+#
+# ``_reexport`` writes the active theme's fields into ``globals()`` at
+# import time, which is invisible to static checkers — they only see
+# ``ui.theme`` lacking every name a downstream module imports
+# (``from ui.theme import NODE_BODY_COLOR`` etc.). Bare module-level
+# annotations are a PEP 526 no-op at runtime (they don't create or
+# shadow a value, so the dynamic write above stays authoritative)
+# while making the symbols visible to mypy / Pylance.
+SOURCE_HEADER_COLOR:        QColor
+FILTER_HEADER_COLOR:        QColor
+SINK_HEADER_COLOR:          QColor
+NODE_SKIPPED_HEADER_COLOR:  QColor
+NODE_BODY_COLOR:            QColor
+NODE_HEADER_DIVIDER_COLOR:  QColor
+NODE_BORDER_COLOR:          QColor
+NODE_BORDER_SELECTED:       QColor
+NODE_TITLE_TEXT_COLOR:      QColor
+NODE_PARAM_LABEL_COLOR:     QColor
+HEADER_AS_STRIP:            bool
+BORDER_FROM_CATEGORY:       bool
+NODE_GLOW_COLOR:            QColor
+NODE_GLOW_SELECTED_COLOR:   QColor
+NODE_GLOW_STROKES:          tuple[tuple[float, int], ...]
+LINK_GLOW_STROKES:          tuple[tuple[float, int], ...]
+LINK_STROKE_WIDTH:          float
+PORT_INPUT_COLOR:           QColor
+PORT_OUTPUT_COLOR:          QColor
+PORT_HOVER_COLOR:           QColor
+PORT_TYPE_COLORS:           Mapping[IoDataType, QColor]
+PORT_TYPE_DEFAULT_COLOR:    QColor
+PORT_DIRECTION_GLYPH_COLOR: QColor
+LINK_COLOR:                 QColor
+LINK_SELECTED_COLOR:        QColor
+LINK_PENDING_COLOR:         QColor
+CANVAS_BACKGROUND_COLOR:    QColor
+CANVAS_GRID_COLOR:          QColor
+STATUS_OK_COLOR:            QColor
+STATUS_FAIL_COLOR:          QColor
+STATUS_MUTED_COLOR:         QColor
+STATUS_WARN_COLOR:          QColor
+PALETTE_WINDOW:             QColor
+PALETTE_WINDOW_TEXT:        QColor
+PALETTE_BASE:               QColor
+PALETTE_ALT_BASE:           QColor
+PALETTE_TEXT:               QColor
+PALETTE_BUTTON:             QColor
+PALETTE_BUTTON_TEXT:        QColor
+PALETTE_HIGHLIGHT:          QColor
+PALETTE_HIGHLIGHTED_TEXT:   QColor
+
+
 def _resolve_qss(theme: Theme) -> str:
     """Substitute asset-path placeholders in the theme's QSS template
     with absolute paths to the bundled SVGs.

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -64,7 +64,7 @@ def test_display_invokes_frame_callback_per_frame() -> None:
     up, _ = _wire(node)
 
     received: list[IoData] = []
-    node.set_frame_callback(received.append)
+    node.set_frame_callback(lambda n: received.append(n.last_inputs[0]))
 
     node.before_run()
     for v in (10, 50, 130):
@@ -80,7 +80,7 @@ def test_display_can_clear_frame_callback() -> None:
     up, _ = _wire(node)
 
     received: list[IoData] = []
-    node.set_frame_callback(received.append)
+    node.set_frame_callback(lambda n: received.append(n.last_inputs[0]))
     node.set_frame_callback(None)
 
     node.before_run()
@@ -175,7 +175,7 @@ def test_display_does_not_mutate_image_payload() -> None:
     up, captured = _wire(node)
 
     received: list[IoData] = []
-    node.set_frame_callback(received.append)
+    node.set_frame_callback(lambda n: received.append(n.last_inputs[0]))
 
     node.before_run()
     big = lambda v: np.full((128, 256, 3), v, dtype=np.uint8)
@@ -257,7 +257,7 @@ def test_display_invokes_callback_with_scalar_iodata() -> None:
     up.connect(node.inputs[0])
 
     received: list[IoData] = []
-    node.set_frame_callback(received.append)
+    node.set_frame_callback(lambda n: received.append(n.last_inputs[0]))
 
     node.before_run()
     up.send(IoData.from_scalar(42))
@@ -297,7 +297,7 @@ def test_display_skips_overlay_for_scalar_payload() -> None:
     up.connect(node.inputs[0])
 
     received: list[IoData] = []
-    node.set_frame_callback(received.append)
+    node.set_frame_callback(lambda n: received.append(n.last_inputs[0]))
 
     node.before_run()
     for v in (10, 20, 30):

--- a/tests/test_meta_inspector.py
+++ b/tests/test_meta_inspector.py
@@ -40,7 +40,7 @@ def test_callback_receives_each_frame_with_meta() -> None:
     node.before_run()
 
     seen: list[IoData] = []
-    node.set_frame_callback(lambda d: seen.append(d))
+    node.set_frame_callback(lambda n: seen.append(n.last_inputs[0]))
 
     meta = IoMeta(source_path=Path("ship.jpg"))
     feeder.send(IoData.from_scalar(0, meta=meta))


### PR DESCRIPTION
## Summary

Generalizes the "info" toggle from the Display node into a framework feature available on every non-source node. Clicking the toggle raises a scrollable metadata overlay showing the latest input frame's IoMeta (payload kind, shape, meta keys) without changing the node's outer dimensions — the overlay fills the existing body area and port labels/widgets hide underneath.

## Key Changes

- **Moved toggle infrastructure to NodeBase**: `show_meta` flag, `set_show_meta_callback()`, per-frame input snapshot (`last_inputs`), generic `set_frame_callback()`, and multi-cast `add_meta_listener()` now live in the base class so every non-source node inherits the plumbing without duplication.

- **Auto-injected info toggle**: `NodeBase.header_items()` now injects an "info" Toggle for every node where `HAS_INFO_TOGGLE = True` (default for all non-sources). SourceNodeBase and MetaInspector override to `False` to opt out.

- **New MetaOverlay widget**: Replaces Display's dual-page stacked widget with a dedicated overlay class that renders one section per input port. Built once per node, positioned over the body, visibility driven by `show_meta` flag. Sits at higher Z-order so it cleanly covers body content when raised.

- **Frame callback refactored**: Changed signature from `callback(IoData)` to `callback(NodeBase)` so widgets read `node.last_inputs` directly. Snapshot captured before `process_impl()` runs so preview widgets see exactly the data the node operated on. Fires after successful `process_impl()` completion.

- **Decoupled preview and meta rendering**: Display keeps its image preview between toggle flips; MetaOverlay simply rises on top. Prevents redundant re-rendering and lets nodes with primary previews (Display's image, PlayGate's button) coexist with the meta overlay.

- **NodeItem layout updates**: Meta overlay positioned to cover entire body section below header. `_apply_show_meta()` hides input port sockets, param widgets, and regular preview when meta is on (output sockets stay visible for wiring). Port labels skipped entirely during paint when `show_meta` is active.

- **Cleaned up Display and MetaInspector**: Removed hand-rolled `show_meta` state, callbacks, and frame tracking — now inherited from NodeBase. Both nodes shed ~40 lines of duplicate plumbing.

## Implementation Details

- Input snapshot (`_last_inputs`) captured in `process()` before port-driven attribute population, ensuring preview widgets see raw inputs regardless of how the node consumes them.
- Meta listeners registered separately from the single-slot frame callback so a node's primary preview and the meta overlay don't compete for the callback slot.
- Toggle state persists across runs; `_last_inputs` cleared on `before_run()` so stale meta doesn't render before the first new frame arrives.
- Overlay never contributes to node sizing — it fills whatever the body already is, so toggling never grows or shrinks the node.

https://claude.ai/code/session_01GiKdKgko5wZ2j87ENb5mCM