### PR TITLE
Remove scheduled nightly workflow trigger

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -6,8 +6,6 @@ name: nightly
 # see the latest build under the same URL. The job is skipped automatically
 # when there have been no commits to `main` in the last 24 hours.
 on:
-  schedule:
-    - cron: '17 3 * * *'   # 03:17 UTC daily
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary
Removed the scheduled cron trigger from the nightly workflow, keeping only the manual `workflow_dispatch` trigger.

## Changes
- Removed the `schedule` section with the daily cron job (`17 3 * * *` at 03:17 UTC) from the nightly workflow configuration

## Details
The nightly workflow will no longer run automatically on a daily schedule. It can still be triggered manually via `workflow_dispatch` when needed. This change may be intended to reduce unnecessary CI runs or shift to a more on-demand approach for nightly builds.

https://claude.ai/code/session_011DWSLuuxYGdXz4rBp8F2zY