### PR TITLE
Drop removed assets/_title.png from PyInstaller datas

### DIFF
--- a/stjornhorn.spec
+++ b/stjornhorn.spec
@@ -72,7 +72,6 @@ a = Analysis(
         ('assets/icons',         'assets/icons'),
         ('assets/fonts',         'assets/fonts'),
         ('assets/title.png',     'assets'),
-        ('assets/_title.png',    'assets'),
         ('assets/app_icon.ico',  'assets'),
         ('assets/app_icon.png',  'assets'),
         ('doc/welcome.html',     'doc'),


### PR DESCRIPTION
## Summary

`assets/_title.png` was removed from the working tree but `stjornhorn.spec` still listed it under `datas`. PyInstaller fails with a missing-source error before it can produce a bundle. Nothing in `src/` references the file (only `assets/title.png`, via `SPLASH_IMAGE_PATH` in `src/constants.py`), so the spec line is just dropped.

No version bump — this only touches build config.

## Test plan

- [ ] `pyinstaller stjornhorn.spec --noconfirm` completes without the missing-source error.
- [ ] Resulting bundle still launches and the splash image renders (loaded from `assets/title.png`).


---
_Generated by [Claude Code](https://claude.ai/code/session_011DWSLuuxYGdXz4rBp8F2zY)_