### PR TITLE
Add HSV watermark with point symmetry flow

### DIFF
--- a/flow/hsv_watermark_pointsym.flowjs
+++ b/flow/hsv_watermark_pointsym.flowjs
@@ -1,0 +1,157 @@
+{
+  "version": 1,
+  "app_version": "0.4.0.0",
+  "name": "hsv_watermark_pointsym",
+  "nodes": [
+    {
+      "id": 0,
+      "module": "nodes.sources.image_source",
+      "class": "ImageSource",
+      "position": [-2000, -1500],
+      "port_defaults": {
+        "file_path": "ship.jpg"
+      }
+    },
+    {
+      "id": 1,
+      "module": "nodes.sources.image_source",
+      "class": "ImageSource",
+      "position": [-2000, -1380],
+      "port_defaults": {
+        "file_path": "logo.png"
+      }
+    },
+    {
+      "id": 2,
+      "module": "nodes.filters.rgba_split",
+      "class": "RgbaSplit",
+      "position": [-1740, -1380],
+      "port_defaults": {}
+    },
+    {
+      "id": 3,
+      "module": "nodes.filters.flip",
+      "class": "Flip",
+      "position": [-1480, -1300],
+      "port_defaults": {
+        "mode": -1
+      }
+    },
+    {
+      "id": 4,
+      "module": "nodes.filters.overlay",
+      "class": "Overlay",
+      "position": [-1220, -1380],
+      "port_defaults": {
+        "angle": 0.0,
+        "scale": 1.0,
+        "xpos": 330,
+        "ypos": 326,
+        "alpha": 0.5
+      }
+    },
+    {
+      "id": 5,
+      "module": "nodes.filters.hsv_split",
+      "class": "HsvSplit",
+      "position": [-1740, -1500],
+      "port_defaults": {}
+    },
+    {
+      "id": 6,
+      "module": "nodes.filters.overlay",
+      "class": "Overlay",
+      "position": [-940, -1620],
+      "port_defaults": {
+        "angle": 0.0,
+        "scale": 0.4,
+        "xpos": 960,
+        "ypos": 538,
+        "alpha": 0.4
+      }
+    },
+    {
+      "id": 7,
+      "module": "nodes.filters.overlay",
+      "class": "Overlay",
+      "position": [-940, -1480],
+      "port_defaults": {
+        "angle": 0.0,
+        "scale": 0.4,
+        "xpos": 960,
+        "ypos": 538,
+        "alpha": 0.4
+      }
+    },
+    {
+      "id": 8,
+      "module": "nodes.filters.overlay",
+      "class": "Overlay",
+      "position": [-940, -1340],
+      "port_defaults": {
+        "angle": 0.0,
+        "scale": 0.4,
+        "xpos": 960,
+        "ypos": 538,
+        "alpha": 0.4
+      }
+    },
+    {
+      "id": 9,
+      "module": "nodes.filters.hsv_join",
+      "class": "HsvJoin",
+      "position": [-660, -1500],
+      "port_defaults": {}
+    },
+    {
+      "id": 10,
+      "module": "nodes.filters.display",
+      "class": "Display",
+      "position": [-400, -1560],
+      "port_defaults": {},
+      "size": [702, 570]
+    }
+  ],
+  "connections": [
+    {"src_node": 1, "src_output": 0, "dst_node": 2, "dst_input": 0},
+    {"src_node": 2, "src_output": 3, "dst_node": 3, "dst_input": 0},
+    {"src_node": 2, "src_output": 3, "dst_node": 4, "dst_input": 0},
+    {"src_node": 3, "src_output": 0, "dst_node": 4, "dst_input": 1},
+
+    {"src_node": 0, "src_output": 0, "dst_node": 5, "dst_input": 0},
+
+    {"src_node": 5, "src_output": 0, "dst_node": 6, "dst_input": 0},
+    {"src_node": 5, "src_output": 1, "dst_node": 7, "dst_input": 0},
+    {"src_node": 5, "src_output": 2, "dst_node": 8, "dst_input": 0},
+
+    {"src_node": 4, "src_output": 0, "dst_node": 6, "dst_input": 1},
+    {"src_node": 4, "src_output": 0, "dst_node": 7, "dst_input": 1},
+    {"src_node": 4, "src_output": 0, "dst_node": 8, "dst_input": 1},
+
+    {"src_node": 6, "src_output": 0, "dst_node": 9, "dst_input": 0},
+    {"src_node": 7, "src_output": 0, "dst_node": 9, "dst_input": 1},
+    {"src_node": 8, "src_output": 0, "dst_node": 9, "dst_input": 2},
+
+    {"src_node": 9, "src_output": 0, "dst_node": 10, "dst_input": 0}
+  ],
+  "backdrops": [
+    {
+      "position": [-2030, -1550],
+      "size": [320, 280],
+      "title": "Sources",
+      "color": [70, 60, 40, 140]
+    },
+    {
+      "position": [-1770, -1430],
+      "size": [620, 230],
+      "title": "Symmetrise watermark (A + flip180(A)) / 2",
+      "color": [40, 60, 70, 140]
+    },
+    {
+      "position": [-970, -1670],
+      "size": [320, 480],
+      "title": "Stamp on H / S / V",
+      "color": [60, 40, 60, 140]
+    }
+  ]
+}

--- a/flow/hsv_watermark_pointsym.flowjs
+++ b/flow/hsv_watermark_pointsym.flowjs
@@ -7,7 +7,10 @@
       "id": 0,
       "module": "nodes.sources.image_source",
       "class": "ImageSource",
-      "position": [-2000, -1500],
+      "position": [
+        -2100.4811124605794,
+        -1420.7087820038976
+      ],
       "port_defaults": {
         "file_path": "ship.jpg"
       }
@@ -16,7 +19,10 @@
       "id": 1,
       "module": "nodes.sources.image_source",
       "class": "ImageSource",
-      "position": [-2000, -1380],
+      "position": [
+        -2100.4811124605794,
+        -1296.7087820038976
+      ],
       "port_defaults": {
         "file_path": "logo.png"
       }
@@ -25,14 +31,20 @@
       "id": 2,
       "module": "nodes.filters.rgba_split",
       "class": "RgbaSplit",
-      "position": [-1740, -1380],
+      "position": [
+        -1750.2531747408755,
+        -1304.1265069175217
+      ],
       "port_defaults": {}
     },
     {
       "id": 3,
       "module": "nodes.filters.flip",
       "class": "Flip",
-      "position": [-1480, -1300],
+      "position": [
+        -1480.0,
+        -1300.0
+      ],
       "port_defaults": {
         "mode": -1
       }
@@ -41,7 +53,10 @@
       "id": 4,
       "module": "nodes.filters.overlay",
       "class": "Overlay",
-      "position": [-1220, -1380],
+      "position": [
+        -1220.0,
+        -1380.0
+      ],
       "port_defaults": {
         "angle": 0.0,
         "scale": 1.0,
@@ -54,14 +69,20 @@
       "id": 5,
       "module": "nodes.filters.hsv_split",
       "class": "HsvSplit",
-      "position": [-1740, -1500],
+      "position": [
+        -1746.1519048445252,
+        -1572.4557681688527
+      ],
       "port_defaults": {}
     },
     {
       "id": 6,
       "module": "nodes.filters.overlay",
       "class": "Overlay",
-      "position": [-940, -1620],
+      "position": [
+        -932.7270270270269,
+        -1750.9135135135136
+      ],
       "port_defaults": {
         "angle": 0.0,
         "scale": 0.4,
@@ -74,7 +95,10 @@
       "id": 7,
       "module": "nodes.filters.overlay",
       "class": "Overlay",
-      "position": [-940, -1480],
+      "position": [
+        -932.7270270270269,
+        -1458.9135135135136
+      ],
       "port_defaults": {
         "angle": 0.0,
         "scale": 0.4,
@@ -87,7 +111,10 @@
       "id": 8,
       "module": "nodes.filters.overlay",
       "class": "Overlay",
-      "position": [-940, -1340],
+      "position": [
+        -932.7270270270269,
+        -1166.9135135135136
+      ],
       "port_defaults": {
         "angle": 0.0,
         "scale": 0.4,
@@ -100,58 +127,170 @@
       "id": 9,
       "module": "nodes.filters.hsv_join",
       "class": "HsvJoin",
-      "position": [-660, -1500],
+      "position": [
+        -643.6358108108109,
+        -1465.4533783783786
+      ],
       "port_defaults": {}
     },
     {
       "id": 10,
       "module": "nodes.filters.display",
       "class": "Display",
-      "position": [-400, -1560],
+      "position": [
+        -400.0,
+        -1560.0
+      ],
       "port_defaults": {},
-      "size": [702, 570]
+      "size": [
+        702.0,
+        570.0
+      ]
     }
   ],
   "connections": [
-    {"src_node": 1, "src_output": 0, "dst_node": 2, "dst_input": 0},
-    {"src_node": 2, "src_output": 3, "dst_node": 3, "dst_input": 0},
-    {"src_node": 2, "src_output": 3, "dst_node": 4, "dst_input": 0},
-    {"src_node": 3, "src_output": 0, "dst_node": 4, "dst_input": 1},
-
-    {"src_node": 0, "src_output": 0, "dst_node": 5, "dst_input": 0},
-
-    {"src_node": 5, "src_output": 0, "dst_node": 6, "dst_input": 0},
-    {"src_node": 5, "src_output": 1, "dst_node": 7, "dst_input": 0},
-    {"src_node": 5, "src_output": 2, "dst_node": 8, "dst_input": 0},
-
-    {"src_node": 4, "src_output": 0, "dst_node": 6, "dst_input": 1},
-    {"src_node": 4, "src_output": 0, "dst_node": 7, "dst_input": 1},
-    {"src_node": 4, "src_output": 0, "dst_node": 8, "dst_input": 1},
-
-    {"src_node": 6, "src_output": 0, "dst_node": 9, "dst_input": 0},
-    {"src_node": 7, "src_output": 0, "dst_node": 9, "dst_input": 1},
-    {"src_node": 8, "src_output": 0, "dst_node": 9, "dst_input": 2},
-
-    {"src_node": 9, "src_output": 0, "dst_node": 10, "dst_input": 0}
+    {
+      "src_node": 1,
+      "src_output": 0,
+      "dst_node": 2,
+      "dst_input": 0
+    },
+    {
+      "src_node": 2,
+      "src_output": 3,
+      "dst_node": 3,
+      "dst_input": 0
+    },
+    {
+      "src_node": 2,
+      "src_output": 3,
+      "dst_node": 4,
+      "dst_input": 0
+    },
+    {
+      "src_node": 3,
+      "src_output": 0,
+      "dst_node": 4,
+      "dst_input": 1
+    },
+    {
+      "src_node": 0,
+      "src_output": 0,
+      "dst_node": 5,
+      "dst_input": 0
+    },
+    {
+      "src_node": 5,
+      "src_output": 0,
+      "dst_node": 6,
+      "dst_input": 0
+    },
+    {
+      "src_node": 5,
+      "src_output": 1,
+      "dst_node": 7,
+      "dst_input": 0
+    },
+    {
+      "src_node": 5,
+      "src_output": 2,
+      "dst_node": 8,
+      "dst_input": 0
+    },
+    {
+      "src_node": 4,
+      "src_output": 0,
+      "dst_node": 6,
+      "dst_input": 1
+    },
+    {
+      "src_node": 4,
+      "src_output": 0,
+      "dst_node": 7,
+      "dst_input": 1
+    },
+    {
+      "src_node": 4,
+      "src_output": 0,
+      "dst_node": 8,
+      "dst_input": 1
+    },
+    {
+      "src_node": 6,
+      "src_output": 0,
+      "dst_node": 9,
+      "dst_input": 0
+    },
+    {
+      "src_node": 7,
+      "src_output": 0,
+      "dst_node": 9,
+      "dst_input": 1
+    },
+    {
+      "src_node": 8,
+      "src_output": 0,
+      "dst_node": 9,
+      "dst_input": 2
+    },
+    {
+      "src_node": 9,
+      "src_output": 0,
+      "dst_node": 10,
+      "dst_input": 0
+    }
   ],
   "backdrops": [
     {
-      "position": [-2030, -1550],
-      "size": [320, 280],
+      "position": [
+        -2122.278572667879,
+        -1456.3543373666712
+      ],
+      "size": [
+        278.30375605377344,
+        284.78481487907516
+      ],
       "title": "Sources",
-      "color": [70, 60, 40, 140]
+      "color": [
+        70,
+        60,
+        40,
+        140
+      ]
     },
     {
-      "position": [-1770, -1430],
-      "size": [620, 230],
+      "position": [
+        -1792.5569844299257,
+        -1596.784975784907
+      ],
+      "size": [
+        751.2406366832054,
+        502.7344481072864
+      ],
       "title": "Symmetrise watermark (A + flip180(A)) / 2",
-      "color": [40, 60, 70, 140]
+      "color": [
+        40,
+        60,
+        70,
+        140
+      ]
     },
     {
-      "position": [-970, -1670],
-      "size": [320, 480],
+      "position": [
+        -970.0,
+        -1788.1858108108108
+      ],
+      "size": [
+        221.48581540560144,
+        925.2955726210164
+      ],
       "title": "Stamp on H / S / V",
-      "color": [60, 40, 60, 140]
+      "color": [
+        60,
+        40,
+        60,
+        140
+      ]
     }
   ]
 }

--- a/flow/hsv_watermark_pointsym_2.flowjs
+++ b/flow/hsv_watermark_pointsym_2.flowjs
@@ -1,0 +1,296 @@
+{
+  "version": 1,
+  "app_version": "0.4.0.0",
+  "name": "hsv_watermark_pointsym_2",
+  "nodes": [
+    {
+      "id": 0,
+      "module": "nodes.sources.image_source",
+      "class": "ImageSource",
+      "position": [
+        -2100.4811124605794,
+        -1420.7087820038976
+      ],
+      "port_defaults": {
+        "file_path": "ship.jpg"
+      }
+    },
+    {
+      "id": 1,
+      "module": "nodes.sources.image_source",
+      "class": "ImageSource",
+      "position": [
+        -2100.4811124605794,
+        -1296.7087820038976
+      ],
+      "port_defaults": {
+        "file_path": "logo.png"
+      }
+    },
+    {
+      "id": 2,
+      "module": "nodes.filters.rgba_split",
+      "class": "RgbaSplit",
+      "position": [
+        -1750.2531747408755,
+        -1304.1265069175217
+      ],
+      "port_defaults": {}
+    },
+    {
+      "id": 3,
+      "module": "nodes.filters.flip",
+      "class": "Flip",
+      "position": [
+        -1480.0,
+        -1300.0
+      ],
+      "port_defaults": {
+        "mode": -1
+      }
+    },
+    {
+      "id": 4,
+      "module": "nodes.filters.overlay",
+      "class": "Overlay",
+      "position": [
+        -1220.0,
+        -1380.0
+      ],
+      "port_defaults": {
+        "angle": 0.0,
+        "scale": 1.0,
+        "xpos": 330,
+        "ypos": 326,
+        "alpha": 0.5
+      }
+    },
+    {
+      "id": 5,
+      "module": "nodes.filters.hsv_split",
+      "class": "HsvSplit",
+      "position": [
+        -1746.1519048445252,
+        -1572.4557681688527
+      ],
+      "port_defaults": {}
+    },
+    {
+      "id": 6,
+      "module": "nodes.filters.overlay",
+      "class": "Overlay",
+      "position": [
+        -932.7270270270269,
+        -1750.9135135135136
+      ],
+      "port_defaults": {
+        "angle": 0.0,
+        "scale": 0.4,
+        "xpos": 960,
+        "ypos": 538,
+        "alpha": 0.4
+      }
+    },
+    {
+      "id": 7,
+      "module": "nodes.filters.overlay",
+      "class": "Overlay",
+      "position": [
+        -932.7270270270269,
+        -1458.9135135135136
+      ],
+      "port_defaults": {
+        "angle": 0.0,
+        "scale": 0.4,
+        "xpos": 960,
+        "ypos": 538,
+        "alpha": 0.4
+      }
+    },
+    {
+      "id": 8,
+      "module": "nodes.filters.overlay",
+      "class": "Overlay",
+      "position": [
+        -932.7270270270269,
+        -1166.9135135135136
+      ],
+      "port_defaults": {
+        "angle": 0.0,
+        "scale": 0.4,
+        "xpos": 960,
+        "ypos": 538,
+        "alpha": 0.4
+      }
+    },
+    {
+      "id": 9,
+      "module": "nodes.filters.hsv_join",
+      "class": "HsvJoin",
+      "position": [
+        -643.6358108108109,
+        -1465.4533783783786
+      ],
+      "port_defaults": {}
+    },
+    {
+      "id": 10,
+      "module": "nodes.filters.display",
+      "class": "Display",
+      "position": [
+        -400.0,
+        -1560.0
+      ],
+      "port_defaults": {},
+      "size": [
+        702.0,
+        570.0
+      ]
+    }
+  ],
+  "connections": [
+    {
+      "src_node": 1,
+      "src_output": 0,
+      "dst_node": 2,
+      "dst_input": 0
+    },
+    {
+      "src_node": 2,
+      "src_output": 3,
+      "dst_node": 3,
+      "dst_input": 0
+    },
+    {
+      "src_node": 2,
+      "src_output": 3,
+      "dst_node": 4,
+      "dst_input": 0
+    },
+    {
+      "src_node": 3,
+      "src_output": 0,
+      "dst_node": 4,
+      "dst_input": 1
+    },
+    {
+      "src_node": 0,
+      "src_output": 0,
+      "dst_node": 5,
+      "dst_input": 0
+    },
+    {
+      "src_node": 5,
+      "src_output": 0,
+      "dst_node": 6,
+      "dst_input": 0
+    },
+    {
+      "src_node": 5,
+      "src_output": 1,
+      "dst_node": 7,
+      "dst_input": 0
+    },
+    {
+      "src_node": 5,
+      "src_output": 2,
+      "dst_node": 8,
+      "dst_input": 0
+    },
+    {
+      "src_node": 4,
+      "src_output": 0,
+      "dst_node": 6,
+      "dst_input": 1
+    },
+    {
+      "src_node": 4,
+      "src_output": 0,
+      "dst_node": 7,
+      "dst_input": 1
+    },
+    {
+      "src_node": 4,
+      "src_output": 0,
+      "dst_node": 8,
+      "dst_input": 1
+    },
+    {
+      "src_node": 6,
+      "src_output": 0,
+      "dst_node": 9,
+      "dst_input": 0
+    },
+    {
+      "src_node": 7,
+      "src_output": 0,
+      "dst_node": 9,
+      "dst_input": 1
+    },
+    {
+      "src_node": 8,
+      "src_output": 0,
+      "dst_node": 9,
+      "dst_input": 2
+    },
+    {
+      "src_node": 9,
+      "src_output": 0,
+      "dst_node": 10,
+      "dst_input": 0
+    }
+  ],
+  "backdrops": [
+    {
+      "position": [
+        -2122.278572667879,
+        -1456.3543373666712
+      ],
+      "size": [
+        278.30375605377344,
+        284.78481487907516
+      ],
+      "title": "Sources",
+      "color": [
+        70,
+        60,
+        40,
+        140
+      ]
+    },
+    {
+      "position": [
+        -1792.5569844299257,
+        -1596.784975784907
+      ],
+      "size": [
+        751.2406366832054,
+        502.7344481072864
+      ],
+      "title": "Symmetrise watermark (A + flip180(A)) / 2",
+      "color": [
+        40,
+        60,
+        70,
+        140
+      ]
+    },
+    {
+      "position": [
+        -970.0,
+        -1788.1858108108108
+      ],
+      "size": [
+        221.48581540560144,
+        925.2955726210164
+      ],
+      "title": "Stamp on H / S / V",
+      "color": [
+        60,
+        40,
+        60,
+        140
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
This PR adds a new image processing flow that demonstrates watermarking an image using HSV color space decomposition with point-symmetric watermark application.

## Key Changes
- Added `hsv_watermark_pointsym.flowjs`: A new flow configuration that implements a watermarking technique by:
  - Loading a base image (ship.jpg) and a logo (logo.png)
  - Creating a point-symmetric watermark by flipping the logo 180 degrees and blending it with the original
  - Decomposing the base image into HSV channels
  - Overlaying the symmetrized watermark onto each H, S, and V channel independently with 40% opacity
  - Recomposing the HSV channels back into a final image
  - Displaying the result

## Implementation Details
- The flow uses 11 nodes organized into 3 logical sections (marked by backdrops):
  - **Sources**: Image and logo loading
  - **Symmetrise watermark**: Creates point-symmetric watermark using flip and overlay operations
  - **Stamp on H/S/V**: Applies the watermark to each HSV channel separately
- The watermark is positioned at (960, 538) with 40% scale and 40% alpha on each channel
- The symmetrized watermark itself uses 50% alpha blending

https://claude.ai/code/session_01Jox9eJDho3CJjz9C6WWKo6